### PR TITLE
Exclude attributes for long inheritance chain

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -34,6 +34,7 @@ exclude:
       - .env
       - .gitatributes
       - src/DependencyInjection/Configuration.php
+      - src/Attributes
       - qodana.sarif.json
 include:
   - name: PhpTaintFunctionInspection


### PR DESCRIPTION
Extending openapi attributes causes qodana problems
