### PR TITLE
Make schemas public that use additional attributes

### DIFF
--- a/src/Asset/Schema/Asset.php
+++ b/src/Asset/Schema/Asset.php
@@ -23,9 +23,6 @@ use Pimcore\Bundle\StudioBackendBundle\Response\Element;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'Asset',
     required: [

--- a/src/Asset/Schema/CustomSettings.php
+++ b/src/Asset/Schema/CustomSettings.php
@@ -23,9 +23,6 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\CustomSettings\FixedCustomSe
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'CustomSettings',
     type: 'object'

--- a/src/Note/Schema/Note.php
+++ b/src/Note/Schema/Note.php
@@ -23,9 +23,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'Note',
     required: ['id', 'type', 'cId', 'cType', 'cPath', 'date', 'title', 'description', 'locked', 'data'],

--- a/src/Property/Schema/ElementProperty.php
+++ b/src/Property/Schema/ElementProperty.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'DataProperty',
     required: ['key', 'data', 'type', 'inheritable', 'inherited'],

--- a/src/Property/Schema/PredefinedProperty.php
+++ b/src/Property/Schema/PredefinedProperty.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'PredefinedProperty',
     required: ['id', 'name', 'key', 'type', 'ctype', 'inheritable', 'creationDate', 'modificationDate'],

--- a/src/Response/Element.php
+++ b/src/Response/Element.php
@@ -20,6 +20,9 @@ use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Permissions;
 
+/**
+ * @internal
+ */
 #[Schema(
     title: 'Element',
     required: [

--- a/src/Schedule/Schema/Schedule.php
+++ b/src/Schedule/Schema/Schedule.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'Schedule',
     required: ['id', 'ctype', 'date', 'active', 'userId'],

--- a/src/Thumbnail/Schema/Thumbnail.php
+++ b/src/Thumbnail/Schema/Thumbnail.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'Thumbnail',
     required: ['id', 'text'],

--- a/src/User/Schema/User.php
+++ b/src/User/Schema/User.php
@@ -22,9 +22,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'User',
     description: 'Contains all information about a user',

--- a/src/User/Schema/UserPermission.php
+++ b/src/User/Schema/UserPermission.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'User Permission',
     description: 'A permission for a user or role',

--- a/src/User/Schema/UserRole.php
+++ b/src/User/Schema/UserRole.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'User Role',
     description: 'A user role which is a combination of permissions and settings.',

--- a/src/User/Schema/UserTreeNode.php
+++ b/src/User/Schema/UserTreeNode.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'User Tree Node',
     description: 'One node in the user tree',

--- a/src/Version/Schema/AssetVersion.php
+++ b/src/Version/Schema/AssetVersion.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'AssetVersion',
     required: ['fileName'],

--- a/src/Version/Schema/DataObjectVersion.php
+++ b/src/Version/Schema/DataObjectVersion.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'DataObjectVersion',
     required: ['modificationDate', 'path', 'published'],

--- a/src/Version/Schema/DocumentVersion.php
+++ b/src/Version/Schema/DocumentVersion.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'DocumentVersion',
     required: ['modificationDate', 'path', 'published'],

--- a/src/Version/Schema/ImageVersion.php
+++ b/src/Version/Schema/ImageVersion.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'ImageVersion',
     required: ['fileName', 'creationDate', 'fileSize', 'mimeType'],

--- a/src/Version/Schema/Version.php
+++ b/src/Version/Schema/Version.php
@@ -21,9 +21,6 @@ use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
-/**
- * @internal
- */
 #[Schema(
     title: 'Version',
     required: ['id', 'cid', 'ctype', 'note', 'date', 'public', 'published', 'versionCount', 'autosave', 'user'],


### PR DESCRIPTION
## Changes in this pull request
Resolves #163 

## Additional info
Schemas that use the additional attributes need to be considered as public.

Using them in an event e.g. where you have an additional method with an input parameter of that schema, it will be shown as internal.

