### PR TITLE
[Asset versions] Check if asset version download endpoint should deliver thumbnail or original asset

### DIFF
--- a/src/Asset/Service/DocumentService.php
+++ b/src/Asset/Service/DocumentService.php
@@ -60,6 +60,10 @@ final readonly class DocumentService implements DocumentServiceInterface
             return $this->getStreamFromDocument($asset);
         }
 
+        if (!str_ends_with($asset->getKey(), '.pdf')) {
+            throw new EnvironmentException('Invalid document name: ' . $asset->getKey());
+        }
+
         if ($this->isScanningEnabled()) {
             $this->validatePdfScanStatus($asset);
             if ($asset->getScanStatus() === null) {

--- a/src/Asset/Service/DocumentService.php
+++ b/src/Asset/Service/DocumentService.php
@@ -60,10 +60,6 @@ final readonly class DocumentService implements DocumentServiceInterface
             return $this->getStreamFromDocument($asset);
         }
 
-        if (!str_ends_with($asset->getKey(), '.pdf')) {
-            throw new EnvironmentException('Invalid document name: ' . $asset->getKey());
-        }
-
         if ($this->isScanningEnabled()) {
             $this->validatePdfScanStatus($asset);
             if ($asset->getScanStatus() === null) {

--- a/src/Version/Controller/Asset/PdfStreamController.php
+++ b/src/Version/Controller/Asset/PdfStreamController.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Version\Controller\Asset;
+
+use OpenApi\Attributes\Get;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Attributes\Response\Content\AssetMediaType;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Attributes\Response\Header\ContentDisposition;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\AccessDeniedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementProcessingNotCompletedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementStreamResourceNotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UnprocessableContentException;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Parameters\Path\IdParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constants\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constants\HttpResponseHeaders;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constants\UserPermissions;
+use Pimcore\Bundle\StudioBackendBundle\Version\Service\VersionBinaryServiceInterface;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class PdfStreamController extends AbstractApiController
+{
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly SecurityServiceInterface $securityService,
+        private readonly VersionBinaryServiceInterface $versionBinaryService,
+    ) {
+        parent::__construct($serializer);
+    }
+
+    /**
+     * @throws AccessDeniedException
+     * @throws ElementProcessingNotCompletedException
+     * @throws ElementStreamResourceNotFoundException
+     * @throws EnvironmentException
+     * @throws InvalidElementTypeException
+     * @throws NotFoundException
+     * @throws UnprocessableContentException
+     */
+    #[Route('/versions/{id}/pdf/stream', name: 'pimcore_studio_api_stream_pdf_version', methods: ['GET'])]
+    #[IsGranted(UserPermissions::ASSETS->value)]
+    #[Get(
+        path: self::API_PATH . '/versions/{id}/pdf/stream',
+        operationId: 'streamPdfVersionById',
+        description: 'Get PDF version stream based on the version ID',
+        summary: 'Get PDF version stream by ID',
+        tags: [Tags::Versions->name]
+    )]
+    #[IdParameter(type: 'version')]
+    #[SuccessResponse(
+        description: 'PDF version stream',
+        content: new AssetMediaType('application/pdf'),
+        headers: [new ContentDisposition(HttpResponseHeaders::INLINE_TYPE->value)]
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::NOT_FOUND,
+    ])]
+    public function streamPdfVersionById(int $id): StreamedResponse
+    {
+        return $this->versionBinaryService->streamPdfPreview($id, $this->securityService->getCurrentUser());
+    }
+}

--- a/src/Version/Service/VersionBinaryService.php
+++ b/src/Version/Service/VersionBinaryService.php
@@ -17,10 +17,16 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Version\Service;
 
 use Pimcore\Bundle\StaticResolverBundle\Models\Asset\Image\Thumbnail\ConfigResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\DocumentServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\AccessDeniedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementProcessingNotCompletedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementStreamResourceNotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UnprocessableContentException;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constants\Asset\FormatTypes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constants\Asset\MimeTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constants\HttpResponseHeaders;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\ElementProviderTrait;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\StreamedResponseTrait;
@@ -38,9 +44,10 @@ final readonly class VersionBinaryService implements VersionBinaryServiceInterfa
     use StreamedResponseTrait;
 
     public function __construct(
-        private VersionDetailServiceInterface $versionDetailService,
+        private DocumentServiceInterface $documentService,
         private ConfigResolverInterface $configResolver,
-        private VersionRepositoryInterface $repository
+        private VersionDetailServiceInterface $versionDetailService,
+        private VersionRepositoryInterface $repository,
     ) {
     }
 
@@ -92,5 +99,30 @@ final readonly class VersionBinaryService implements VersionBinaryServiceInterfa
             [],
             $thumbnail->getFileSize()
         );
+    }
+
+    /**
+     * @throws AccessDeniedException
+     * @throws ElementProcessingNotCompletedException
+     * @throws ElementStreamResourceNotFoundException
+     * @throws EnvironmentException
+     * @throws InvalidElementTypeException
+     * @throws NotFoundException
+     * @throws UnprocessableContentException
+     */
+    public function streamPdfPreview(
+        int $id,
+        UserInterface $user
+    ): StreamedResponse {
+        $version = $this->repository->getVersionById($id);
+        $document = $this->repository->getElementFromVersion($version, $user);
+
+        if (!$document instanceof Asset\Document ||
+            $document->getMimeType() !== MimeTypes::PDF
+        ) {
+            throw new InvalidElementTypeException($document->getType());
+        }
+
+        return $this->documentService->getPreviewStream($document);
     }
 }

--- a/src/Version/Service/VersionBinaryService.php
+++ b/src/Version/Service/VersionBinaryService.php
@@ -32,6 +32,8 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Traits\ElementProviderTrait;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\StreamedResponseTrait;
 use Pimcore\Bundle\StudioBackendBundle\Version\Repository\VersionRepositoryInterface;
 use Pimcore\Model\Asset;
+use Pimcore\Model\Asset\Document;
+use Pimcore\Model\Asset\Image;
 use Pimcore\Model\UserInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -81,7 +83,7 @@ final readonly class VersionBinaryService implements VersionBinaryServiceInterfa
     ): StreamedResponse {
         $version = $this->repository->getVersionById($id);
         $image = $this->repository->getElementFromVersion($version, $user);
-        if (!$image instanceof Asset\Image) {
+        if (!$image instanceof Image) {
             throw new InvalidElementTypeException($image->getType());
         }
 
@@ -117,7 +119,7 @@ final readonly class VersionBinaryService implements VersionBinaryServiceInterfa
         $version = $this->repository->getVersionById($id);
         $document = $this->repository->getElementFromVersion($version, $user);
 
-        if (!$document instanceof Asset\Document ||
+        if (!$document instanceof Document ||
             $document->getMimeType() !== MimeTypes::PDF
         ) {
             throw new InvalidElementTypeException($document->getType());

--- a/src/Version/Service/VersionBinaryServiceInterface.php
+++ b/src/Version/Service/VersionBinaryServiceInterface.php
@@ -17,8 +17,12 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Version\Service;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\AccessDeniedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementProcessingNotCompletedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementStreamResourceNotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UnprocessableContentException;
 use Pimcore\Model\UserInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -39,6 +43,20 @@ interface VersionBinaryServiceInterface
      * @throws AccessDeniedException|NotFoundException|InvalidElementTypeException
      */
     public function streamThumbnailImage(
+        int $id,
+        UserInterface $user
+    ): StreamedResponse;
+
+    /**
+     * @throws AccessDeniedException
+     * @throws ElementProcessingNotCompletedException
+     * @throws ElementStreamResourceNotFoundException
+     * @throws EnvironmentException
+     * @throws InvalidElementTypeException
+     * @throws NotFoundException
+     * @throws UnprocessableContentException
+     */
+    public function streamPdfPreview(
         int $id,
         UserInterface $user
     ): StreamedResponse;

--- a/src/Workflow/Schema/WorkflowStatus.php
+++ b/src/Workflow/Schema/WorkflowStatus.php
@@ -54,6 +54,12 @@ final readonly class WorkflowStatus
             example: 'Edit Images'
         )]
         private string $label,
+        #[Property(
+            description: 'visibleInDetail',
+            type: 'boolean',
+            example: true
+        )]
+        private bool $visibleInDetail,
     ) {
 
     }
@@ -76,5 +82,10 @@ final readonly class WorkflowStatus
     public function getLabel(): string
     {
         return $this->label;
+    }
+
+    public function isVisibleInDetail(): bool
+    {
+        return $this->visibleInDetail;
     }
 }

--- a/src/Workflow/Service/WorkflowDetailsService.php
+++ b/src/Workflow/Service/WorkflowDetailsService.php
@@ -131,6 +131,7 @@ final readonly class WorkflowDetailsService implements WorkflowDetailsServiceInt
                 $status->getColorInverted(),
                 $status->getPlace(),
                 $status->getLabel(),
+                $status->isVisibleInHeader(),
             );
         }
 


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-backend-bundle/issues/170

## Additional info
- add new endpoint to stream original PDF from the version (no thumbnail is used here)
- the rest can use download of original files (no change required)