### PR TITLE
#253 [Grid] Differentiate between ColumnConfiguration and ColumnData

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ Swagger-ui is available at `/studio/api/docs` and the OpenApi Specification is a
 ## Documentation Overview
 
 - [Installation](./doc/01_Installation.md)
+
+- [Grid](./doc/03_Grid.md)

--- a/doc/03_Grid.md
+++ b/doc/03_Grid.md
@@ -3,11 +3,11 @@
 On the request level we have three main components for the grid: `Column`, `ColumnConfiguration` and `ColumnData`.
 
 ## Column
-A column is a single column in the grid. It has a name, type adn a local. It is used to get the data for the column.
+A column is a single column in the grid. It has a name, type and a locale. It is used to get the data for the column.
 in addition, it has a configuration which can be used to configure the column, like the direction of the sorting
 
 ## ColumnConfiguration
-A column configuration is how the column should behave, for example if it should be sortable or editable. 
+A column configuration represents how the column should behave, for example if it should be sort-able or editable. 
 
 ## ColumnData
 A column data is the actual data for a column. It has a reference to the column and the actual data.

--- a/doc/03_Grid.md
+++ b/doc/03_Grid.md
@@ -1,0 +1,13 @@
+# Grid
+
+On the request level we have three main components for the grid: `Column`, `ColumnConfiguration` and `ColumnData`.
+
+## Column
+A column is a single column in the grid. It has a name, type adn a local. It is used to get the data for the column.
+in addition, it has a configuration which can be used to configure the column, like the direction of the sorting
+
+## ColumnConfiguration
+A column configuration is how the column should behave, for example if it should be sortable or editable. 
+
+## ColumnData
+A column data is the actual data for a column. It has a reference to the column and the actual data.

--- a/src/Asset/Attributes/Request/CsvExportRequestBody.php
+++ b/src/Asset/Attributes/Request/CsvExportRequestBody.php
@@ -22,7 +22,7 @@ use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\RequestBody;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Util\Constants\Csv;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Configuration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
 
 /**
  * @internal
@@ -36,7 +36,11 @@ final class CsvExportRequestBody extends RequestBody
             content: new JsonContent(
                 properties: [
                     new Property(property: 'assets', type: 'array', items: new Items(type: 'integer'), example: [83]),
-                    new Property(property: 'gridConfig', ref: Configuration::class),
+                    new Property(
+                        property: 'gridConfig',
+                        type: 'array',
+                        items: new Items(ref: Column::class)
+                    ),
                     new Property(property: 'settings', properties: [
                         new Property(property: Csv::SETTINGS_DELIMITER->value, type: 'string', example: ';'),
                         new Property(

--- a/src/Asset/Controller/Grid/Configuration/GetController.php
+++ b/src/Asset/Controller/Grid/Configuration/GetController.php
@@ -24,8 +24,6 @@ use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Configuration;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\GridServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Response\DefaultResponses;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Response\SuccessResponse;
@@ -66,10 +64,10 @@ final class GetController extends AbstractApiController
         content: new JsonContent(
             properties: [
                 new Property(
-                property: 'columns',
-                type: 'array',
-                items: new Items(ref: ColumnConfiguration::class),
-            )],
+                    property: 'columns',
+                    type: 'array',
+                    items: new Items(ref: ColumnConfiguration::class),
+                )],
         )
     )]
     #[DefaultResponses([

--- a/src/Asset/Controller/Grid/Configuration/GetController.php
+++ b/src/Asset/Controller/Grid/Configuration/GetController.php
@@ -17,10 +17,14 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Asset\Controller\Grid\Configuration;
 
 use OpenApi\Attributes\Get;
+use OpenApi\Attributes\Items;
 use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Property;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Configuration;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\GridServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Response\DefaultResponses;
@@ -60,7 +64,12 @@ final class GetController extends AbstractApiController
     #[SuccessResponse(
         description: 'Grid configuration',
         content: new JsonContent(
-            ref: Configuration::class
+            properties: [
+                new Property(
+                property: 'columns',
+                type: 'array',
+                items: new Items(ref: ColumnConfiguration::class),
+            )],
         )
     )]
     #[DefaultResponses([

--- a/src/Asset/Controller/Grid/GetController.php
+++ b/src/Asset/Controller/Grid/GetController.php
@@ -69,6 +69,7 @@ final class GetController extends AbstractApiController
     #[DefaultResponses([
         HttpResponseCodes::UNAUTHORIZED,
         HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::BAD_REQUEST,
     ])]
     public function getAssetGrid(#[MapRequestPayload] GridParameter $gridParameter): JsonResponse
     {

--- a/src/Asset/ExecutionEngine/AutomationAction/Messenger/Handler/CsvCreationHandler.php
+++ b/src/Asset/ExecutionEngine/AutomationAction/Messenger/Handler/CsvCreationHandler.php
@@ -98,11 +98,11 @@ final class CsvCreationHandler extends AbstractHandler
         }
 
         $settings = $this->extractConfigFieldFromJobStepConfig($message, 'settings');
-        $configuration = $this->gridService->getConfigurationFromArray(
+        $columnCollection = $this->gridService->getConfigurationFromArray(
             $this->extractConfigFieldFromJobStepConfig($message, 'configuration')
         );
 
-        $csv = $this->csvService->getCsvFile($jobRun->getId(), $configuration, $settings);
+        $csv = $this->csvService->getCsvFile($jobRun->getId(), $columnCollection, $settings);
 
         if (!$csv) {
             $this->abort($this->getAbortData(
@@ -125,7 +125,7 @@ final class CsvCreationHandler extends AbstractHandler
         }
 
         $assetData = $this->gridService->getGridValuesForElement(
-            $configuration,
+            $columnCollection,
             $asset,
             ElementTypes::TYPE_ASSET
         );

--- a/src/Asset/Service/ExecutionEngine/CsvService.php
+++ b/src/Asset/Service/ExecutionEngine/CsvService.php
@@ -80,14 +80,14 @@ final class CsvService implements CsvServiceInterface
         return $this->getTempFilePath($jobRun->getId(), self::CSV_FILE_PATH);
     }
 
-    public function getCsvFile(int $id, ColumnCollection $configuration, array $settings): string
+    public function getCsvFile(int $id, ColumnCollection $columnCollection, array $settings): string
     {
         $storage = $this->storageResolver->get(StorageDirectories::TEMP->value);
         $file = $this->getTempFileName($id, self::CSV_FILE_NAME);
 
         try {
             if (!$storage->fileExists($file)) {
-                $headers = $this->getHeaders($configuration, $settings);
+                $headers = $this->getHeaders($columnCollection, $settings);
                 $storage->write(
                     $file,
                     implode($settings[Csv::SETTINGS_DELIMITER->value] ?? ',', $headers). Csv::NEW_LINE->value
@@ -125,7 +125,7 @@ final class CsvService implements CsvServiceInterface
         return '"' . $value . '"';
     }
 
-    private function getHeaders(ColumnCollection $configuration, array $settings): array
+    private function getHeaders(ColumnCollection $columnCollection, array $settings): array
     {
         $header = $settings[Csv::SETTINGS_HEADER->value] ?? Csv::SETTINGS_HEADER_NO_HEADER->value;
         if ($header === Csv::SETTINGS_HEADER_NO_HEADER->value) {
@@ -133,7 +133,7 @@ final class CsvService implements CsvServiceInterface
         }
 
         return $this->gridService->getColumnKeys(
-            $configuration,
+            $columnCollection,
             $header === Csv::SETTINGS_HEADER_NAME->value
         );
     }

--- a/src/Asset/Service/ExecutionEngine/CsvService.php
+++ b/src/Asset/Service/ExecutionEngine/CsvService.php
@@ -29,8 +29,8 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Util\Constants\Csv;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Config;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Jobs;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Configuration;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\GridServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Collection\ColumnCollection;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constants\StorageDirectories;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\TempFilePathTrait;
@@ -80,7 +80,7 @@ final class CsvService implements CsvServiceInterface
         return $this->getTempFilePath($jobRun->getId(), self::CSV_FILE_PATH);
     }
 
-    public function getCsvFile(int $id, Configuration $configuration, array $settings): string
+    public function getCsvFile(int $id, ColumnCollection $configuration, array $settings): string
     {
         $storage = $this->storageResolver->get(StorageDirectories::TEMP->value);
         $file = $this->getTempFileName($id, self::CSV_FILE_NAME);
@@ -125,7 +125,7 @@ final class CsvService implements CsvServiceInterface
         return '"' . $value . '"';
     }
 
-    private function getHeaders(Configuration $configuration, array $settings): array
+    private function getHeaders(ColumnCollection $configuration, array $settings): array
     {
         $header = $settings[Csv::SETTINGS_HEADER->value] ?? Csv::SETTINGS_HEADER_NO_HEADER->value;
         if ($header === Csv::SETTINGS_HEADER_NO_HEADER->value) {

--- a/src/Asset/Service/ExecutionEngine/CsvServiceInterface.php
+++ b/src/Asset/Service/ExecutionEngine/CsvServiceInterface.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Asset\Service\ExecutionEngine;
 
 use Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter\ExportAssetParameter;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Configuration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Collection\ColumnCollection;
 
 /**
  * @internal
@@ -28,7 +28,7 @@ interface CsvServiceInterface
 
     public const CSV_FILE_PATH = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/' . self::CSV_FILE_NAME;
 
-    public function getCsvFile(int $id, Configuration $configuration, array $settings): string;
+    public function getCsvFile(int $id, ColumnCollection $configuration, array $settings): string;
 
     public function addData(string $filePath, string $delimiter, array $data): void;
 

--- a/src/Asset/Service/ExecutionEngine/CsvServiceInterface.php
+++ b/src/Asset/Service/ExecutionEngine/CsvServiceInterface.php
@@ -28,7 +28,7 @@ interface CsvServiceInterface
 
     public const CSV_FILE_PATH = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/' . self::CSV_FILE_NAME;
 
-    public function getCsvFile(int $id, ColumnCollection $configuration, array $settings): string;
+    public function getCsvFile(int $id, ColumnCollection $columnCollection, array $settings): string;
 
     public function addData(string $filePath, string $delimiter, array $data): void;
 

--- a/src/Grid/Attributes/Request/GridRequestBody.php
+++ b/src/Grid/Attributes/Request/GridRequestBody.php
@@ -42,7 +42,7 @@ final class GridRequestBody extends RequestBody
                         property: 'columns',
                         type: 'array',
                         items: new Items(ref: Column::class)
-                    ),
+                    )
                 ],
                 type: 'object',
             ),

--- a/src/Grid/Attributes/Request/GridRequestBody.php
+++ b/src/Grid/Attributes/Request/GridRequestBody.php
@@ -42,7 +42,7 @@ final class GridRequestBody extends RequestBody
                         property: 'columns',
                         type: 'array',
                         items: new Items(ref: Column::class)
-                    )
+                    ),
                 ],
                 type: 'object',
             ),

--- a/src/Grid/Attributes/Request/GridRequestBody.php
+++ b/src/Grid/Attributes/Request/GridRequestBody.php
@@ -35,19 +35,13 @@ final class GridRequestBody extends RequestBody
         parent::__construct(
             required: true,
             content: new JsonContent(
-                required: ['folderId', 'gridConfig'],
+                required: ['folderId', 'columns'],
                 properties: [
                     new SingleInteger(propertyName: 'folderId'),
                     new Property(
-                        property: 'gridConfig',
-                        properties: [
-                            new Property(
-                                property: 'columns',
-                                type: 'array',
-                                items: new Items(ref: Column::class)
-                            ),
-                        ],
-                        type: 'object'
+                        property: 'columns',
+                        type: 'array',
+                        items: new Items(ref: Column::class)
                     ),
                 ],
                 type: 'object',

--- a/src/Grid/Column/Collector/MetaDataCollector.php
+++ b/src/Grid/Column/Collector/MetaDataCollector.php
@@ -19,7 +19,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Collector;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnCollectorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnDefinitionInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\FrontendType;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\MetaData\Repository\MetaDataRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constants\ElementTypes;
 use function array_key_exists;
@@ -42,9 +42,9 @@ final readonly class MetaDataCollector implements ColumnCollectorInterface
     /**
      * @param ColumnDefinitionInterface[] $availableColumnDefinitions
      *
-     * @return Column[]
+     * @return ColumnConfiguration[]
      */
-    public function getColumnDefinitions(array $availableColumnDefinitions): array
+    public function getColumnConfigurations(array $availableColumnDefinitions): array
     {
         return array_merge(
             $this->getDefaultMetaData(),
@@ -54,14 +54,14 @@ final readonly class MetaDataCollector implements ColumnCollectorInterface
 
     /**
      *
-     * @return Column[]
+     * @return ColumnConfiguration[]
      */
     private function getDefaultMetaData(): array
     {
         $defaultMetadata = ['title', 'alt', 'copyright'];
         $columns = [];
         foreach ($defaultMetadata as $metadata) {
-            $columns[] = new Column(
+            $columns[] = new ColumnConfiguration(
                 key: $metadata,
                 group: 'default_metadata',
                 sortable: true,
@@ -80,7 +80,7 @@ final readonly class MetaDataCollector implements ColumnCollectorInterface
     /**
      * @param ColumnDefinitionInterface[] $availableColumnDefinitions
      *
-     * @return Column[]
+     * @return ColumnConfiguration[]
      */
     private function getPredefinedMetaData(array $availableColumnDefinitions): array
     {
@@ -93,7 +93,7 @@ final readonly class MetaDataCollector implements ColumnCollectorInterface
                 continue;
             }
 
-            $columns[] = new Column(
+            $columns[] = new ColumnConfiguration(
                 key: $item->getName(),
                 group: 'predefined_metadata',
                 sortable: $availableColumnDefinitions[$type]->isSortable(),

--- a/src/Grid/Column/Collector/SystemFieldCollector.php
+++ b/src/Grid/Column/Collector/SystemFieldCollector.php
@@ -18,7 +18,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Collector;
 
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnCollectorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnDefinitionInterface;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\SystemColumnServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constants\ElementTypes;
 use function array_key_exists;
@@ -41,9 +41,9 @@ final readonly class SystemFieldCollector implements ColumnCollectorInterface
     /**
      * @param ColumnDefinitionInterface[] $availableColumnDefinitions
      *
-     * @return Column[]
+     * @return ColumnConfiguration[]
      */
-    public function getColumnDefinitions(array $availableColumnDefinitions): array
+    public function getColumnConfigurations(array $availableColumnDefinitions): array
     {
         $systemColumns = $this->systemColumnService->getSystemColumnsForAssets();
         $columns = [];
@@ -53,7 +53,7 @@ final readonly class SystemFieldCollector implements ColumnCollectorInterface
                 continue;
             }
 
-            $column = new Column(
+            $column = new ColumnConfiguration(
                 key: $columnKey,
                 group: $this->getCollectorName(),
                 sortable: $availableColumnDefinitions[$type]->isSortable(),

--- a/src/Grid/Column/ColumnCollectorInterface.php
+++ b/src/Grid/Column/ColumnCollectorInterface.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column;
 
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
 
 interface ColumnCollectorInterface
 {
@@ -25,9 +25,9 @@ interface ColumnCollectorInterface
     /**
      * @param ColumnDefinitionInterface[] $availableColumnDefinitions
      *
-     * @return Column[]
+     * @return ColumnConfiguration[]
      */
-    public function getColumnDefinitions(array $availableColumnDefinitions): array;
+    public function getColumnConfigurations(array $availableColumnDefinitions): array;
 
     public function supportedElementTypes(): array;
 }

--- a/src/Grid/Event/GridColumnConfigurationEvent.php
+++ b/src/Grid/Event/GridColumnConfigurationEvent.php
@@ -17,14 +17,14 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Grid\Event;
 
 use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
 
-final class GridColumnDefinitionEvent extends AbstractPreResponseEvent
+final class GridColumnConfigurationEvent extends AbstractPreResponseEvent
 {
-    public const EVENT_NAME = 'pre_response.grid_column_definition';
+    public const EVENT_NAME = 'pre_response.grid_column_configuration';
 
     public function __construct(
-        private readonly Column $column
+        private readonly ColumnConfiguration $column
     ) {
         parent::__construct($column);
     }
@@ -32,7 +32,7 @@ final class GridColumnDefinitionEvent extends AbstractPreResponseEvent
     /**
      * Use this to get additional infos out of the response object
      */
-    public function getConfiguration(): Column
+    public function getConfiguration(): ColumnConfiguration
     {
         return $this->column;
     }

--- a/src/Grid/MappedParameter/GridParameter.php
+++ b/src/Grid/MappedParameter/GridParameter.php
@@ -23,7 +23,7 @@ final readonly class GridParameter
 {
     public function __construct(
         private int $folderId,
-        private array $gridConfig,
+        private array $columns,
     ) {
     }
 
@@ -32,8 +32,8 @@ final readonly class GridParameter
         return $this->folderId;
     }
 
-    public function getGridConfig(): array
+    public function getColumns(): array
     {
-        return $this->gridConfig;
+        return $this->columns;
     }
 }

--- a/src/Grid/Schema/Column.php
+++ b/src/Grid/Schema/Column.php
@@ -27,7 +27,7 @@ use OpenApi\Attributes\Schema;
  */
 #[Schema(
     title: 'Grid Column Request',
-    required: ['key', 'locale', 'type', 'config'],
+    required: ['key', 'type', 'config'],
     type: 'object'
 )]
 final readonly class Column
@@ -39,6 +39,8 @@ final readonly class Column
         private ?string $locale,
         #[Property(description: 'Type', type: 'string', example: 'system.integer')]
         private string $type,
+        #[Property(description: 'Group', type: 'string', example: 'system')]
+        private ?string $group,
         #[Property(description: 'Config', type: 'array', items: new Items(type: 'string'), example: ['key' => 'value'])]
         private array $config,
     ) {
@@ -57,6 +59,11 @@ final readonly class Column
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public function getGroup(): string
+    {
+        return $this->group;
     }
 
     public function getConfig(): array

--- a/src/Grid/Schema/Column.php
+++ b/src/Grid/Schema/Column.php
@@ -19,8 +19,6 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Schema;
 use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
-use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
-use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
 /**
  * Column contains all data + values that is needed for the grid
@@ -34,7 +32,6 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 )]
 final class Column
 {
-
     public function __construct(
         #[Property(description: 'Key', type: 'string', example: 'id')]
         private readonly string $key,
@@ -46,7 +43,6 @@ final class Column
         private readonly array $config,
     ) {
     }
-
 
     public function getKey(): string
     {

--- a/src/Grid/Schema/Column.php
+++ b/src/Grid/Schema/Column.php
@@ -21,7 +21,7 @@ use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
 
 /**
- * Column contains all data + values that is needed for the grid
+ * Contains all data that is needed to get all the data for the column.
  *
  * @internal
  */

--- a/src/Grid/Schema/Column.php
+++ b/src/Grid/Schema/Column.php
@@ -30,17 +30,17 @@ use OpenApi\Attributes\Schema;
     required: ['key', 'locale', 'type', 'config'],
     type: 'object'
 )]
-final class Column
+final readonly class Column
 {
     public function __construct(
         #[Property(description: 'Key', type: 'string', example: 'id')]
-        private readonly string $key,
+        private string $key,
         #[Property(description: 'Locale', type: 'string', example: 'en')]
-        private readonly ?string $locale,
-        #[Property(description: 'Type', type: 'string', example: 'integer')]
-        private readonly string $type,
+        private ?string $locale,
+        #[Property(description: 'Type', type: 'string', example: 'system.integer')]
+        private string $type,
         #[Property(description: 'Config', type: 'array', items: new Items(type: 'string'), example: ['key' => 'value'])]
-        private readonly array $config,
+        private array $config,
     ) {
     }
 
@@ -57,5 +57,10 @@ final class Column
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public function getConfig(): array
+    {
+        return $this->config;
     }
 }

--- a/src/Grid/Schema/ColumnConfiguration.php
+++ b/src/Grid/Schema/ColumnConfiguration.php
@@ -28,29 +28,64 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
  * @internal
  */
 #[Schema(
-    title: 'Grid Column Request',
-    required: ['key', 'locale', 'type', 'config'],
+    title: 'GridColumnDefinition',
+    required: ['key', 'group', 'sortable', 'editable', 'localizable', 'locale', 'type', 'config'],
     type: 'object'
 )]
-final class Column
+final class ColumnConfiguration implements AdditionalAttributesInterface
 {
+    use AdditionalAttributesTrait;
 
     public function __construct(
         #[Property(description: 'Key', type: 'string', example: 'id')]
         private readonly string $key,
+        #[Property(description: 'Group', type: 'string', example: 'system')]
+        private readonly string $group,
+        #[Property(description: 'Sortable', type: 'boolean', example: true)]
+        private readonly bool $sortable,
+        #[Property(description: 'Editable', type: 'boolean', example: false)]
+        private readonly bool $editable,
+        #[Property(description: 'Localizable', type: 'boolean', example: false)]
+        private readonly bool $localizable,
         #[Property(description: 'Locale', type: 'string', example: 'en')]
         private readonly ?string $locale,
         #[Property(description: 'Type', type: 'string', example: 'integer')]
         private readonly string $type,
+        #[Property(description: 'Frontend Type', type: 'string', example: 'integer')]
+        private readonly string $frontendType,
         #[Property(description: 'Config', type: 'array', items: new Items(type: 'string'), example: ['key' => 'value'])]
         private readonly array $config,
     ) {
     }
 
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
 
     public function getKey(): string
     {
         return $this->key;
+    }
+
+    public function getGroup(): string
+    {
+        return $this->group;
+    }
+
+    public function isSortable(): bool
+    {
+        return $this->sortable;
+    }
+
+    public function isEditable(): bool
+    {
+        return $this->editable;
+    }
+
+    public function isLocalizable(): bool
+    {
+        return $this->localizable;
     }
 
     public function getLocale(): ?string
@@ -61,5 +96,10 @@ final class Column
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public function getFrontendType(): string
+    {
+        return $this->frontendType;
     }
 }

--- a/src/Grid/Schema/ColumnConfiguration.php
+++ b/src/Grid/Schema/ColumnConfiguration.php
@@ -23,7 +23,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\AdditionalAttributesTrait;
 
 /**
- * Column contains all data + values that is needed for the grid
+ * Contains all data to configure a grid column
  *
  * @internal
  */

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -105,12 +105,12 @@ final class GridService implements GridServiceInterface
      * @throws InvalidArgumentException
      */
     public function getGridDataForElement(
-        ColumnCollection $configuration,
+        ColumnCollection $columnCollection,
         ElementInterface $element,
         string $elementType
     ): array {
         $data = [];
-        foreach ($configuration->getColumns() as $column) {
+        foreach ($columnCollection->getColumns() as $column) {
             // move this to the resolver
             if (!$this->supports($column, $elementType)) {
                 continue;
@@ -130,11 +130,11 @@ final class GridService implements GridServiceInterface
     }
 
     public function getGridValuesForElement(
-        ColumnCollection $configuration,
+        ColumnCollection $columnCollection,
         ElementInterface $element,
         string $elementType
     ): array {
-        $data = $this->getGridDataForElement($configuration, $element, $elementType);
+        $data = $this->getGridDataForElement($columnCollection, $element, $elementType);
 
         return array_map(
             static fn (ColumnData $columnData) => $columnData->getValue(),
@@ -205,13 +205,13 @@ final class GridService implements GridServiceInterface
         return new ColumnCollection($columns);
     }
 
-    public function getColumnKeys(ColumnCollection $configuration, bool $withGroup = false): array
+    public function getColumnKeys(ColumnCollection $columnCollection, bool $withGroup = false): array
     {
         return array_map(
             static function (Column $column) use ($withGroup) {
                 return $column->getKey() . ($withGroup ? '~' . $column->getGroup() : '');
             },
-            $configuration->getColumns()
+            $columnCollection->getColumns()
         );
     }
 

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -16,18 +16,20 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service;
 
+use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Grid\GridSearchInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnCollectorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnDefinitionInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Event\GridColumnConfigurationEvent;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Event\GridColumnDataEvent;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Event\GridColumnDefinitionEvent;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Configuration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Collection\ColumnCollection;
 use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constants\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Traits\ElementProviderTrait;
@@ -87,7 +89,7 @@ final class GridService implements GridServiceInterface
             $asset = $this->getElement($this->serviceResolver, $type, $item->getId());
 
             $data[] = $this->getGridDataForElement(
-                $this->getConfigurationFromArray($gridParameter->getGridConfig()),
+                $this->getConfigurationFromArray($gridParameter->getColumns()),
                 $asset,
                 $type
             );
@@ -103,9 +105,9 @@ final class GridService implements GridServiceInterface
      * @throws InvalidArgumentException
      */
     public function getGridDataForElement(
-        Configuration $configuration,
+        ColumnCollection $configuration,
         ElementInterface $element,
-        string $elementType
+        string           $elementType
     ): array {
         $data = [];
         foreach ($configuration->getColumns() as $column) {
@@ -128,9 +130,9 @@ final class GridService implements GridServiceInterface
     }
 
     public function getGridValuesForElement(
-        Configuration $configuration,
+        ColumnCollection $configuration,
         ElementInterface $element,
-        string $elementType
+        string           $elementType
     ): array {
         $data = $this->getGridDataForElement($configuration, $element, $elementType);
 
@@ -140,7 +142,10 @@ final class GridService implements GridServiceInterface
         );
     }
 
-    public function getAssetGridConfiguration(): Configuration
+    /**
+     * @return ColumnConfiguration[]
+     */
+    public function getAssetGridConfiguration(): array
     {
         $columns = [];
         foreach ($this->getColumnCollectors() as $collector) {
@@ -151,7 +156,7 @@ final class GridService implements GridServiceInterface
 
             $columns = array_merge(
                 $columns,
-                $collector->getColumnDefinitions(
+                $collector->getColumnConfigurations(
                     $this->getColumnDefinitions()
                 )
             );
@@ -159,46 +164,47 @@ final class GridService implements GridServiceInterface
 
         foreach ($columns as $column) {
             $this->eventDispatcher->dispatch(
-                new GridColumnDefinitionEvent($column),
-                GridColumnDefinitionEvent::EVENT_NAME
+                new GridColumnConfigurationEvent($column),
+                GridColumnConfigurationEvent::EVENT_NAME
             );
         }
 
-        return new Configuration($columns);
+        return $columns;
     }
 
-    public function getDocumentGridColumns(): Configuration
+    public function getDocumentGridColumns(): ColumnCollection
     {
-        return new Configuration([]);
+        return new ColumnCollection([]);
     }
 
-    public function getDataObjectGridColumns(ClassDefinition $classDefinition): Configuration
+    public function getDataObjectGridColumns(ClassDefinition $classDefinition): ColumnCollection
     {
-        return new Configuration([]);
+        return new ColumnCollection([]);
     }
 
-    public function getConfigurationFromArray(array $config): Configuration
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function getConfigurationFromArray(array $config): ColumnCollection
     {
         $columns = [];
-
-        foreach ($config['columns'] as $column) {
-            $columns[] = new Column(
-                key: $column['key'],
-                group: $column['group'],
-                sortable: $column['sortable'],
-                editable: $column['editable'],
-                localizable: $column['localizable'],
-                locale: $column['locale'],
-                type: $column['type'],
-                frontendType: $column['frontendType'],
-                config: $column['config']
-            );
+        foreach ($config as $column) {
+            try {
+                $columns[] = new Column(
+                    key: $column['key'],
+                    locale: $column['locale'],
+                    type: $column['type'],
+                    config: $column['config']
+                );
+            } catch (Exception $e) {
+                throw new InvalidArgumentException('Invalid column configuration');
+            }
         }
 
-        return new Configuration($columns);
+        return new ColumnCollection($columns);
     }
 
-    public function getColumnKeys(Configuration $configuration, bool $withGroup = false): array
+    public function getColumnKeys(ColumnCollection $configuration, bool $withGroup = false): array
     {
         return array_map(
             static function (Column $column) use ($withGroup) {
@@ -224,6 +230,9 @@ final class GridService implements GridServiceInterface
         return true;
     }
 
+    /**
+     * @return array<string, ColumnDefinitionInterface>
+     */
     private function getColumnDefinitions(): array
     {
         if ($this->columnDefinitions) {

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -107,7 +107,7 @@ final class GridService implements GridServiceInterface
     public function getGridDataForElement(
         ColumnCollection $configuration,
         ElementInterface $element,
-        string           $elementType
+        string $elementType
     ): array {
         $data = [];
         foreach ($configuration->getColumns() as $column) {
@@ -132,7 +132,7 @@ final class GridService implements GridServiceInterface
     public function getGridValuesForElement(
         ColumnCollection $configuration,
         ElementInterface $element,
-        string           $elementType
+        string $elementType
     ): array {
         $data = $this->getGridDataForElement($configuration, $element, $elementType);
 

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -192,8 +192,9 @@ final class GridService implements GridServiceInterface
             try {
                 $columns[] = new Column(
                     key: $column['key'],
-                    locale: $column['locale'],
+                    locale: $column['locale'] ?? null,
                     type: $column['type'],
+                    group: $column['group'] ?? null,
                     config: $column['config']
                 );
             } catch (Exception $e) {

--- a/src/Grid/Service/GridServiceInterface.php
+++ b/src/Grid/Service/GridServiceInterface.php
@@ -18,7 +18,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Configuration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Collection\ColumnCollection;
 use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\Element\ElementInterface;
@@ -28,30 +29,33 @@ use Pimcore\Model\Element\ElementInterface;
  */
 interface GridServiceInterface
 {
-    public function getAssetGridConfiguration(): Configuration;
+    /**
+     * @return ColumnConfiguration[]
+     */
+    public function getAssetGridConfiguration(): array;
 
-    public function getDocumentGridColumns(): Configuration;
+    public function getDocumentGridColumns(): ColumnCollection;
 
-    public function getDataObjectGridColumns(ClassDefinition $classDefinition): Configuration;
+    public function getDataObjectGridColumns(ClassDefinition $classDefinition): ColumnCollection;
 
     /**
      * @throws InvalidArgumentException
      */
     public function getGridDataForElement(
-        Configuration $configuration,
+        ColumnCollection $configuration,
         ElementInterface $element,
-        string $elementType
+        string           $elementType
     ): array;
 
     public function getGridValuesForElement(
-        Configuration $configuration,
+        ColumnCollection $configuration,
         ElementInterface $element,
-        string $elementType
+        string           $elementType
     ): array;
 
-    public function getConfigurationFromArray(array $config): Configuration;
+    public function getConfigurationFromArray(array $config): ColumnCollection;
 
     public function getAssetGrid(GridParameter $gridParameter): Collection;
 
-    public function getColumnKeys(Configuration $configuration, bool $withGroup = false): array;
+    public function getColumnKeys(ColumnCollection $configuration, bool $withGroup = false): array;
 }

--- a/src/Grid/Service/GridServiceInterface.php
+++ b/src/Grid/Service/GridServiceInterface.php
@@ -42,13 +42,13 @@ interface GridServiceInterface
      * @throws InvalidArgumentException
      */
     public function getGridDataForElement(
-        ColumnCollection $configuration,
+        ColumnCollection $columnCollection,
         ElementInterface $element,
         string $elementType
     ): array;
 
     public function getGridValuesForElement(
-        ColumnCollection $configuration,
+        ColumnCollection $columnCollection,
         ElementInterface $element,
         string $elementType
     ): array;
@@ -57,5 +57,5 @@ interface GridServiceInterface
 
     public function getAssetGrid(GridParameter $gridParameter): Collection;
 
-    public function getColumnKeys(ColumnCollection $configuration, bool $withGroup = false): array;
+    public function getColumnKeys(ColumnCollection $columnCollection, bool $withGroup = false): array;
 }

--- a/src/Grid/Service/GridServiceInterface.php
+++ b/src/Grid/Service/GridServiceInterface.php
@@ -44,13 +44,13 @@ interface GridServiceInterface
     public function getGridDataForElement(
         ColumnCollection $configuration,
         ElementInterface $element,
-        string           $elementType
+        string $elementType
     ): array;
 
     public function getGridValuesForElement(
         ColumnCollection $configuration,
         ElementInterface $element,
-        string           $elementType
+        string $elementType
     ): array;
 
     public function getConfigurationFromArray(array $config): ColumnCollection;

--- a/src/Grid/Util/Collection/ColumnCollection.php
+++ b/src/Grid/Util/Collection/ColumnCollection.php
@@ -14,30 +14,19 @@ declare(strict_types=1);
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Bundle\StudioBackendBundle\Grid\Schema;
+namespace Pimcore\Bundle\StudioBackendBundle\Grid\Util\Collection;
 
-use OpenApi\Attributes\Items;
-use OpenApi\Attributes\Property;
-use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
 
 /**
  * @internal
  */
-#[Schema(
-    title: 'GridConfiguration',
-    type: 'object'
-)]
-final readonly class Configuration
+final readonly class ColumnCollection
 {
     /**
      * @param array<int, Column> $columns
      */
     public function __construct(
-        #[Property(
-            property: 'columns',
-            type: 'array',
-            items: new Items(ref: Column::class)
-        )]
         private array $columns,
     ) {
     }


### PR DESCRIPTION
## Changes in this pull request
Resolves #253

## Additional info

On the request level we now have three main components for the grid: `Column`, `ColumnConfiguration` and `ColumnData`.
