### PR TITLE
Added path prefix `assign` to routes in `AssignController`

### DIFF
--- a/src/Tag/Controller/Element/AssignController.php
+++ b/src/Tag/Controller/Element/AssignController.php
@@ -48,10 +48,10 @@ final class AssignController extends AbstractApiController
     /**
      * @throws ElementSavingFailedException|NotFoundException
      */
-    #[Route('/tags/{elementType}/{id}/{tagId}', name: 'pimcore_studio_api_assign_element_tag', methods: ['POST'])]
+    #[Route('/tags/assign/{elementType}/{id}/{tagId}', name: 'pimcore_studio_api_assign_element_tag', methods: ['POST'])]
     #[IsGranted(UserPermissions::TAGS_ASSIGNMENT->value)]
     #[Post(
-        path: self::API_PATH . '/tags/{elementType}/{id}/{tagId}',
+        path: self::API_PATH . '/tags/assign/{elementType}/{id}/{tagId}',
         operationId: 'assignTagForElement',
         summary: 'Assign tag for element',
         tags: [Tags::TagsForElement->value]

--- a/src/Tag/Controller/Element/AssignController.php
+++ b/src/Tag/Controller/Element/AssignController.php
@@ -48,7 +48,11 @@ final class AssignController extends AbstractApiController
     /**
      * @throws ElementSavingFailedException|NotFoundException
      */
-    #[Route('/tags/assign/{elementType}/{id}/{tagId}', name: 'pimcore_studio_api_assign_element_tag', methods: ['POST'])]
+    #[Route(
+        '/tags/assign/{elementType}/{id}/{tagId}',
+        name: 'pimcore_studio_api_assign_element_tag',
+        methods: ['POST'])
+    ]
     #[IsGranted(UserPermissions::TAGS_ASSIGNMENT->value)]
     #[Post(
         path: self::API_PATH . '/tags/assign/{elementType}/{id}/{tagId}',


### PR DESCRIPTION
To fix the collision of route paths I added the a prefix (`assign`) to the path.


![image](https://github.com/user-attachments/assets/c82de661-f725-4901-9f30-4fe0652c2b3e)

