### PR TITLE
[Grid] Configuration ID as Query Parameter.

### DIFF
--- a/src/Asset/Controller/Grid/Configuration/GetConfigurationController.php
+++ b/src/Asset/Controller/Grid/Configuration/GetConfigurationController.php
@@ -20,18 +20,21 @@ use OpenApi\Attributes\Get;
 use OpenApi\Attributes\Items;
 use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Property;
+use Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter\GridConfigurationIdParameter;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ConfigurationServiceInterface;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Parameters\Path\IdParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Parameters\Path\IdParameter As IdParameterPath;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Parameters\Query\IdParameter as IdParameterQuery;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Response\DefaultResponses;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Response\SuccessResponse;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constants\HttpResponseCodes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constants\UserPermissions;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -52,21 +55,21 @@ final class GetConfigurationController extends AbstractApiController
      * @throws NotFoundException|SearchException
      */
     #[Route(
-        '/assets/grid/configuration/{folderId}/{configurationId}',
+        '/assets/grid/configuration/{folderId}',
         name: 'pimcore_studio_api_get_asset_grid_configuration',
         methods: ['GET'],
     )]
     #[IsGranted(UserPermissions::ASSETS->value)]
     #[Get(
-        path: self::API_PATH . '/assets/grid/configuration/{folderId}/{configurationId}',
+        path: self::API_PATH . '/assets/grid/configuration/{folderId}',
         operationId: 'getAssetGridConfiguration',
         description: 'Get asset saved grid configuration for a specific folder if a configuration-id is set otherwise
         get the default configuration will be returned.',
         summary: 'Get asset grid configuration for a specific folder',
         tags: [Tags::Grid->name]
     )]
-    #[IdParameter(name: 'folderId')]
-    #[IdParameter(name: 'configurationId', required: false)]
+    #[IdParameterPath(name: 'folderId')]
+    #[IdParameterQuery(description: 'Configuration ID', namePrefix: 'configuration', required: false)]
     #[SuccessResponse(
         description: 'Grid configuration',
         content: new JsonContent(
@@ -82,7 +85,10 @@ final class GetConfigurationController extends AbstractApiController
         HttpResponseCodes::UNAUTHORIZED,
         HttpResponseCodes::NOT_FOUND,
     ])]
-    public function getAssetGridConfiguration(int $folderId, ?int $configurationId = null): JsonResponse
+    public function getAssetGridConfiguration(
+        int $folderId,
+        #[MapQueryString] GridConfigurationIdParameter $configurationId = new GridConfigurationIdParameter()
+    ): JsonResponse
     {
         /**
          * @todo: implement usage of $folderId and $configurationId

--- a/src/Asset/Controller/Grid/Configuration/GetConfigurationController.php
+++ b/src/Asset/Controller/Grid/Configuration/GetConfigurationController.php
@@ -26,7 +26,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ConfigurationServiceInterface;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Parameters\Path\IdParameter As IdParameterPath;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Parameters\Path\IdParameter as IdParameterPath;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Parameters\Query\IdParameter as IdParameterQuery;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Response\DefaultResponses;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attributes\Response\SuccessResponse;
@@ -88,8 +88,7 @@ final class GetConfigurationController extends AbstractApiController
     public function getAssetGridConfiguration(
         int $folderId,
         #[MapQueryString] GridConfigurationIdParameter $configurationId = new GridConfigurationIdParameter()
-    ): JsonResponse
-    {
+    ): JsonResponse {
         /**
          * @todo: implement usage of $folderId and $configurationId
          * If a configurationId is set, return the saved configuration for the folder.

--- a/src/Asset/MappedParameter/GridConfigurationIdParameter.php
+++ b/src/Asset/MappedParameter/GridConfigurationIdParameter.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter;
+
+/**
+ * @internal
+ */
+final readonly class GridConfigurationIdParameter
+{
+    public function __construct(
+        private ?int $configurationId = null
+    ) {
+    }
+
+    public function getConfigurationId(): ?int
+    {
+        return $this->configurationId;
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
The FE Client can not work with optional path parameter. So this PR changes the Configuration ID to an Query Parameter. 

## Additional info
