### PR TITLE
[CustomSettings]: Renamed meta data field

### DIFF
--- a/src/Asset/Hydrator/CustomSettingsHydrator.php
+++ b/src/Asset/Hydrator/CustomSettingsHydrator.php
@@ -24,9 +24,9 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\CustomSettings;
  */
 final class CustomSettingsHydrator implements CustomSettingsHydratorInterface
 {
-    private const METADATA_KEY = 'embeddedMetadata';
+    private const METADATA_KEY = 'embeddedMetaData';
 
-    private const METADATA_EXTRACTED_KEY = 'embeddedMetadataExtracted';
+    private const METADATA_EXTRACTED_KEY = 'embeddedMetaDataExtracted';
 
     private const FIXED_CUSTOM_SETTINGS_KEYS = [
         self::METADATA_KEY,

--- a/tests/Unit/Asset/Hydrator/CustomSettingsHydratorTest.php
+++ b/tests/Unit/Asset/Hydrator/CustomSettingsHydratorTest.php
@@ -47,11 +47,11 @@ final class CustomSettingsHydratorTest extends Unit
     public function testHydrate(): void
     {
         $assetCustomSettings = [
-            'embeddedMetadata' => [
+            'embeddedMetaData' => [
                 'FileSize' => '6.9 MB',
                 'FileType' => 'PNG',
             ],
-            'embeddedMetadataExtracted' => true,
+            'embeddedMetaDataExtracted' => true,
             'imageDimensionsCalculated' => true,
             'imageWidth' => 932,
             'imageHeight' => 327,


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-backend-bundle/issues/377

issue introduced by https://github.com/pimcore/studio-backend-bundle/pull/313
in the core, the custom settings inside of meta data are using MetaData 
