### PR TITLE
[Notes] Note type endpoint

### DIFF
--- a/config/pimcore/config.yaml
+++ b/config/pimcore/config.yaml
@@ -51,6 +51,11 @@ pimcore_studio_backend:
                   group: system
                 - key: size
                   group: system
+    notes:
+        types:
+            asset: ['content', 'seo', 'warning', 'notice']
+            document: ['content', 'seo', 'warning', 'notice']
+            data-object: ['content', 'seo', 'warning', 'notice']
 
 mercure:
     hubs:

--- a/doc/10_Extending_Studio/07_Notes.md
+++ b/doc/10_Extending_Studio/07_Notes.md
@@ -1,0 +1,17 @@
+# Extending Notes
+
+Notes to log changes or events on elements independently of the versioning. You can get more general information about notes [here](https://pimcore.com/docs/platform/Pimcore/Tools_and_Features/Notes_and_Events/)
+
+There are currently 4 predefined types of notes for each element type (asset, document, data object):
+- content
+- seo
+- warning
+- notice
+
+You can extend or adapt these types in the `config.yaml` file, for example:
+
+```yaml
+pimcore_studio_backend:
+    types:
+        asset: ['content', 'seo', 'warning', 'notice', 'customType']
+```

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\InvalidHostException;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset\DownloadLimits;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset\MimeTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset\ResizeModes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -53,6 +54,7 @@ class Configuration implements ConfigurationInterface
         $this->addAssetDownloadLimits($rootNode);
         $this->addCsvSettings($rootNode);
         $this->addGridConfiguration($rootNode);
+        $this->addNoteTypes($rootNode);
 
         return $treeBuilder;
     }
@@ -229,5 +231,35 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+    }
+
+    private function addNoteTypes(ArrayNodeDefinition $node): void
+    {
+        $defaultOptions = ['content', 'seo', 'warning', 'notice'];
+
+        $node->children()
+        ->arrayNode('notes')
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('types')
+                    ->info('List all note types for asset, document, and data-object.')
+                    ->normalizeKeys(false)
+                    ->children()
+                        ->arrayNode(ElementTypes::TYPE_ASSET)
+                            ->prototype('scalar')->end()
+                            ->defaultValue($defaultOptions)
+                        ->end()
+                        ->arrayNode(ElementTypes::TYPE_DOCUMENT)
+                            ->prototype('scalar')->end()
+                            ->defaultValue($defaultOptions)
+                        ->end()
+                        ->arrayNode(ElementTypes::TYPE_DATA_OBJECT)
+                            ->prototype('scalar')->end()
+                            ->defaultValue($defaultOptions)
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
     }
 }

--- a/src/DependencyInjection/PimcoreStudioBackendExtension.php
+++ b/src/DependencyInjection/PimcoreStudioBackendExtension.php
@@ -26,6 +26,7 @@ use Pimcore\Bundle\StudioBackendBundle\EventSubscriber\CorsSubscriber;
 use Pimcore\Bundle\StudioBackendBundle\Exception\InvalidPathException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ConfigurationServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\HubServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Note\Service\NoteServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Service\OpenApiServiceInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -88,6 +89,9 @@ class PimcoreStudioBackendExtension extends Extension implements PrependExtensio
 
         $definition = $container->getDefinition(ConfigurationServiceInterface::class);
         $definition->setArgument('$predefinedColumns', $config['grid']['asset']['predefined_columns']);
+
+        $definition = $container->getDefinition(NoteServiceInterface::class);
+        $definition->setArgument('$noteTypes', $config['notes']['types']);
 
     }
 

--- a/src/Note/Attribute/Response/Content/NoteTypesJson.php
+++ b/src/Note/Attribute/Response/Content/NoteTypesJson.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Note\Attribute\Response\Content;
+
+use OpenApi\Attributes\Items;
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Property;
+use Pimcore\Bundle\StudioBackendBundle\Note\Schema\NoteType;
+
+/**
+ * @internal
+ */
+final class NoteTypesJson extends JsonContent
+{
+    public function __construct()
+    {
+        parent::__construct(
+            required: ['items'],
+            properties: [
+                new Property(
+                    'items',
+                    type: 'array',
+                    items: new Items(ref: NoteType::class)
+                ),
+            ],
+            type: 'object',
+        );
+    }
+}

--- a/src/Note/Controller/Element/TypeController.php
+++ b/src/Note/Controller/Element/TypeController.php
@@ -18,19 +18,10 @@ namespace Pimcore\Bundle\StudioBackendBundle\Note\Controller\Element;
 
 use OpenApi\Attributes\Get;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidFilterException;
-use Pimcore\Bundle\StudioBackendBundle\Note\Attribute\Parameter\Query\NoteSortByParameter;
-use Pimcore\Bundle\StudioBackendBundle\Note\MappedParameter\NoteElementParameters;
-use Pimcore\Bundle\StudioBackendBundle\Note\MappedParameter\NoteParameters;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Note\Schema\Note;
 use Pimcore\Bundle\StudioBackendBundle\Note\Service\NoteServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\ElementTypeParameter;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParameter;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\FieldFilterParameter;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\FilterParameter;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\PageParameter;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\PageSizeParameter;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\SortOrderParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\GenericCollection;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\CollectionJson;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
@@ -38,9 +29,7 @@ use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessRespons
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
-use Pimcore\Bundle\StudioBackendBundle\Util\Trait\PaginatedResponseTrait;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -48,10 +37,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 /**
  * @internal
  */
-final class CollectionController extends AbstractApiController
+final class TypeController extends AbstractApiController
 {
-    use PaginatedResponseTrait;
-
     public function __construct(
         SerializerInterface $serializer,
         private readonly NoteServiceInterface $noteService
@@ -60,49 +47,29 @@ final class CollectionController extends AbstractApiController
     }
 
     /**
-     * @throws InvalidFilterException
+     * @throws NotFoundException
      */
-    #[Route(
-        '/notes/{elementType}/{id}',
-        name: 'pimcore_studio_api_get_element_notes',
-        requirements: ['id' => '\d+'],
-        methods: ['GET'])
-    ]
+    #[Route('/notes/type/{elementType}', name: 'pimcore_studio_api_get_element_note_types', methods: ['GET'])]
     #[IsGranted(UserPermissions::ELEMENT_TYPE_PERMISSION->value)]
     #[IsGranted(UserPermissions::NOTES_EVENTS->value)]
     #[Get(
-        path: self::API_PATH . '/notes/{elementType}/{id}',
-        operationId: 'note_element_get_collection',
-        description: 'note_element_get_collection_description',
-        summary: 'note_element_get_collection_summary',
+        path: self::API_PATH . '/notes/type/{elementType}',
+        operationId: 'note_element_get_type_collection',
+        description: 'note_element_get_type_collection_description',
+        summary: 'note_element_get_type_collection_summary',
         tags: [Tags::Notes->name]
     )]
     #[ElementTypeParameter]
-    #[IdParameter(type: 'element')]
-    #[PageParameter]
-    #[PageSizeParameter(50)]
-    #[NoteSortByParameter]
-    #[SortOrderParameter]
-    #[FilterParameter('notes')]
-    #[FieldFilterParameter]
     #[SuccessResponse(
-        description: 'note_element_get_collection_success_response',
+        description: 'note_element_get_type_collection_success_response',
         content: new CollectionJson(new GenericCollection(Note::class))
     )]
     #[DefaultResponses([
         HttpResponseCodes::UNAUTHORIZED,
     ])]
-    public function getNotes(
-        string $elementType,
-        int $id,
-        #[MapQueryString] NoteParameters $parameters = new NoteParameters()
+    public function getNoteTypes(
+        string $elementType
     ): JsonResponse {
-        $collection = $this->noteService->listNotes(new NoteElementParameters($elementType, $id), $parameters);
-
-        return $this->getPaginatedCollection(
-            $this->serializer,
-            $collection->getItems(),
-            $collection->getTotalItems()
-        );
+        return $this->jsonResponse($this->noteService->getNoteTypes($elementType));
     }
 }

--- a/src/Note/Controller/Element/TypeController.php
+++ b/src/Note/Controller/Element/TypeController.php
@@ -19,11 +19,9 @@ namespace Pimcore\Bundle\StudioBackendBundle\Note\Controller\Element;
 use OpenApi\Attributes\Get;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
-use Pimcore\Bundle\StudioBackendBundle\Note\Schema\Note;
+use Pimcore\Bundle\StudioBackendBundle\Note\Attribute\Response\Content\NoteTypesJson;
 use Pimcore\Bundle\StudioBackendBundle\Note\Service\NoteServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\ElementTypeParameter;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\GenericCollection;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\CollectionJson;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
@@ -62,7 +60,7 @@ final class TypeController extends AbstractApiController
     #[ElementTypeParameter]
     #[SuccessResponse(
         description: 'note_element_get_type_collection_success_response',
-        content: new CollectionJson(new GenericCollection(Note::class))
+        content: new NoteTypesJson()
     )]
     #[DefaultResponses([
         HttpResponseCodes::UNAUTHORIZED,
@@ -70,6 +68,7 @@ final class TypeController extends AbstractApiController
     public function getNoteTypes(
         string $elementType
     ): JsonResponse {
-        return $this->jsonResponse($this->noteService->getNoteTypes($elementType));
+
+        return $this->jsonResponse($this->noteService->listNoteTypes($elementType));
     }
 }

--- a/src/Note/Event/NoteTypeEvent.php
+++ b/src/Note/Event/NoteTypeEvent.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Note\Event;
+
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+use Pimcore\Bundle\StudioBackendBundle\Note\Schema\NoteType;
+
+final class NoteTypeEvent extends AbstractPreResponseEvent
+{
+    public const EVENT_NAME = 'pre_response.note.type';
+
+    public function __construct(
+        private readonly NoteType $noteType
+    ) {
+        parent::__construct($noteType);
+    }
+
+    /**
+     * Use this to get additional infos out of the response object
+     */
+    public function getNote(): NoteType
+    {
+        return $this->noteType;
+    }
+}

--- a/src/Note/Schema/NoteType.php
+++ b/src/Note/Schema/NoteType.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Note\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+#[Schema(
+    title: 'NoteType',
+    required: ['id'],
+    type: 'object'
+)]
+final class NoteType implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(description: 'id', type: 'string', example: 'info')]
+        private readonly string $id,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Note/Schema/NoteTypeCollection.php
+++ b/src/Note/Schema/NoteTypeCollection.php
@@ -14,24 +14,34 @@ declare(strict_types=1);
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Bundle\StudioBackendBundle\Note\Attribute\Response\Property;
+namespace Pimcore\Bundle\StudioBackendBundle\Note\Schema;
 
 use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
-use Pimcore\Bundle\StudioBackendBundle\Note\Schema\Note;
+use OpenApi\Attributes\Schema;
 
 /**
  * @internal
  */
-final class NoteCollection extends Property
+#[Schema(
+    title: 'NoteTypeCollection',
+    required: ['items'],
+    type: 'object'
+)]
+final readonly class NoteTypeCollection
 {
-    public function __construct()
-    {
-        parent::__construct(
-            'items',
-            title: 'items',
+    public function __construct(
+        #[Property(
+            description: 'items',
             type: 'array',
-            items: new Items(ref: Note::class)
-        );
+            items: new Items(ref: NoteType::class)
+        )]
+        private array $items
+    ) {
+    }
+
+    public function getItems(): array
+    {
+        return $this->items;
     }
 }

--- a/src/Note/Service/NoteServiceInterface.php
+++ b/src/Note/Service/NoteServiceInterface.php
@@ -25,6 +25,7 @@ use Pimcore\Bundle\StudioBackendBundle\Note\MappedParameter\NoteParameters;
 use Pimcore\Bundle\StudioBackendBundle\Note\Response\Collection;
 use Pimcore\Bundle\StudioBackendBundle\Note\Schema\CreateNote;
 use Pimcore\Bundle\StudioBackendBundle\Note\Schema\Note;
+use Pimcore\Bundle\StudioBackendBundle\Note\Schema\NoteTypeCollection;
 
 /**
  * @internal
@@ -49,5 +50,5 @@ interface NoteServiceInterface
     /**
      * @throws NotFoundException
      */
-    public function getNoteTypes(string $elementType): array;
+    public function listNoteTypes(string $elementType): NoteTypeCollection;
 }

--- a/src/Note/Service/NoteServiceInterface.php
+++ b/src/Note/Service/NoteServiceInterface.php
@@ -45,4 +45,9 @@ interface NoteServiceInterface
      * @throws NotFoundException
      */
     public function deleteNote(int $id): void;
+
+    /**
+     * @throws NotFoundException
+     */
+    public function getNoteTypes(string $elementType): array;
 }

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -268,6 +268,9 @@ note_element_get_collection_description: |
   You can use different query parameters to filter the notes
 note_element_get_collection_success_response: Paginated notes with total count
 note_element_get_collection_summary: Get paginated notes for an element by id
+note_element_get_type_collection_description: Get note types collection by <strong>{elementType}</strong>
+note_element_get_type_collection_success_response: Note types collection
+note_element_get_type_collection_summary: Get note types
 note_get_collection_description: |
   Get paginated notes. <br>
   You can use different query parameters to filter the notes


### PR DESCRIPTION
## Changes in this pull request
Part of #384 

## Additional info
Add new endpoint to list note types based on the element type

As currently the configuration is located in the classic admin UI, we need to somehow merge these options at least until we stop supporting classic UI bundle