### PR TITLE
Problem when requesting 2 version preview image streams from the same asset ID in parallel

### DIFF
--- a/src/Version/Service/VersionBinaryService.php
+++ b/src/Version/Service/VersionBinaryService.php
@@ -87,14 +87,17 @@ final readonly class VersionBinaryService implements VersionBinaryServiceInterfa
         if (!$image instanceof Image) {
             throw new InvalidElementTypeException($image->getType());
         }
-        $thumbnail = $this->getImageThumbnail($image);
-
-        return $this->getStreamedResponse(
+        $originalName = $image->getFilename();
+        $thumbnail = $this->getImageThumbnail($image, $originalName);
+        $response = $this->getStreamedResponse(
             $thumbnail,
             HttpResponseHeaders::INLINE_TYPE->value,
             [],
             $thumbnail->getFileSize()
         );
+        $image->setFilename($originalName);
+
+        return $response;
     }
 
     /**
@@ -122,9 +125,9 @@ final readonly class VersionBinaryService implements VersionBinaryServiceInterfa
         return $this->documentService->getPreviewStream($document);
     }
 
-    private function getImageThumbnail(Image $image): ThumbnailInterface
+    private function getImageThumbnail(Image $image, string $originalName): ThumbnailInterface
     {
-        $image->setFilename(uniqid('', true));
+        $image->setFilename(uniqid('', true) . '_'. $originalName);
         $config = $this->configResolver->getPreviewConfig();
         $thumbnail = $image->getThumbnail($config);
 

--- a/src/Version/Service/VersionBinaryService.php
+++ b/src/Version/Service/VersionBinaryService.php
@@ -122,7 +122,8 @@ final readonly class VersionBinaryService implements VersionBinaryServiceInterfa
         return $this->documentService->getPreviewStream($document);
     }
 
-    private function getImageThumbnail(Image $image): ThumbnailInterface {
+    private function getImageThumbnail(Image $image): ThumbnailInterface
+    {
         $image->setFilename(uniqid('', true));
         $config = $this->configResolver->getPreviewConfig();
         $thumbnail = $image->getThumbnail($config);

--- a/src/Version/Service/VersionBinaryService.php
+++ b/src/Version/Service/VersionBinaryService.php
@@ -127,7 +127,7 @@ final readonly class VersionBinaryService implements VersionBinaryServiceInterfa
 
     private function getImageThumbnail(Image $image, string $originalName): ThumbnailInterface
     {
-        $image->setFilename(uniqid('', true) . '_'. $originalName);
+        $image->setFilename(uniqid('', true) . '_' . $originalName);
         $config = $this->configResolver->getPreviewConfig();
         $thumbnail = $image->getThumbnail($config);
 

--- a/src/Version/Service/VersionBinaryService.php
+++ b/src/Version/Service/VersionBinaryService.php
@@ -34,6 +34,7 @@ use Pimcore\Bundle\StudioBackendBundle\Version\Repository\VersionRepositoryInter
 use Pimcore\Model\Asset;
 use Pimcore\Model\Asset\Document;
 use Pimcore\Model\Asset\Image;
+use Pimcore\Model\Asset\Image\ThumbnailInterface;
 use Pimcore\Model\UserInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -86,14 +87,7 @@ final readonly class VersionBinaryService implements VersionBinaryServiceInterfa
         if (!$image instanceof Image) {
             throw new InvalidElementTypeException($image->getType());
         }
-
-        $config = $this->configResolver->getPreviewConfig();
-        $thumbnail = $image->getThumbnail($config);
-
-        $autoFormatConfigs = $config->getAutoFormatThumbnailConfigs();
-        if ($autoFormatConfigs && $config->getFormat() === strtoupper(FormatTypes::SOURCE)) {
-            $thumbnail = $image->getThumbnail(current($autoFormatConfigs));
-        }
+        $thumbnail = $this->getImageThumbnail($image);
 
         return $this->getStreamedResponse(
             $thumbnail,
@@ -126,5 +120,18 @@ final readonly class VersionBinaryService implements VersionBinaryServiceInterfa
         }
 
         return $this->documentService->getPreviewStream($document);
+    }
+
+    private function getImageThumbnail(Image $image): ThumbnailInterface {
+        $image->setFilename(uniqid('', true));
+        $config = $this->configResolver->getPreviewConfig();
+        $thumbnail = $image->getThumbnail($config);
+
+        $autoFormatConfigs = $config->getAutoFormatThumbnailConfigs();
+        if ($autoFormatConfigs && $config->getFormat() === strtoupper(FormatTypes::SOURCE)) {
+            $thumbnail = $image->getThumbnail(current($autoFormatConfigs));
+        }
+
+        return $thumbnail;
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Resolves #393 
