### PR TITLE
Disable roave/security due to a twig security issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
   },
   "require-dev": {
     "pimcore/admin-ui-classic-bundle": "^v1.3",
-    "roave/security-advisories": "dev-latest",
     "codeception/codeception": "^5.0.10",
     "codeception/phpunit-wrapper": "^9",
     "codeception/module-asserts": "^2",


### PR DESCRIPTION
## Additional info
Disabling security check due to https://github.com/pimcore/pimcore/issues/17582

Enabling it again when issue is resolved