### PR TITLE
[Grid] Add PQLQuery Filter

### DIFF
--- a/config/data_index_filters.yaml
+++ b/config/data_index_filters.yaml
@@ -35,6 +35,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\TagFilter:
     tags: [ 'pimcore.studio_backend.open_search.filter' ]
 
+  Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\PqlFilter:
+    tags: [ 'pimcore.studio_backend.open_search.filter' ]
+
   # DataObject
   Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\DataObject\ClassNameFilter:
       tags: [ 'pimcore.studio_backend.open_search.data_object.filter' ]

--- a/doc/03_Grid.md
+++ b/doc/03_Grid.md
@@ -24,23 +24,25 @@ Here you can define `page`, `pageSize` and `includeDescendants`.
 
 ### ColumnFilter
 It is also possible to filter the data by a column. This is done by adding a `columnFilter` to the `filter` property.
-A `columnFilter` has a reference to the column and the value you want to filter by.
+A `columnFilter` has a reference to the column and the value you want to filter by. Some filters do not require a 
+specific column, like the `system.tag` filter. This filters will be applied to the general search query.
 
 Available filters are:
 
-|       Type        |     filterValue     |           Options           |
-|:-----------------:|:-------------------:|:---------------------------:|
-|  metadata.select  |       string        |                             |
-|   metadata.date   | object of timestamp |    `from`, `to`, or `on`    |
-|  metadata.input   |       string        |                             |
-| metadata.checkbox |       boolean       |                             |
-| metadata.textarea |       string        |                             |
-|  metadata.object  |       integer       |      ID of the object       |
-| metadata.document |       integer       |     ID fo the document      |
-|  metadata.asset   |       integer       |       ID fo the asset       |
-|   system.string   |       string        | Wildcard search can be used |
-|  system.datetime  |       integer       |    `from`, `to`, or `on`    |
-|    system.tag     |       object        | `considerChildTags`, `tags` |
+|       Type        |     filterValue     |           Options           | `key` required |
+|:-----------------:|:-------------------:|:---------------------------:|:--------------:|
+|  metadata.select  |       string        |                             |      true      |
+|   metadata.date   | object of timestamp |    `from`, `to`, or `on`    |      true      |
+|  metadata.input   |       string        |                             |      true      |
+| metadata.checkbox |       boolean       |                             |      true      |
+| metadata.textarea |       string        |                             |      true      |
+|  metadata.object  |       integer       |      ID of the object       |      true      |
+| metadata.document |       integer       |     ID fo the document      |      true      |
+|  metadata.asset   |       integer       |       ID fo the asset       |      true      |
+|   system.string   |       string        | Wildcard search can be used |      true      |
+|  system.datetime  |       integer       |    `from`, `to`, or `on`    |      true      |
+|    system.tag     |       object        | `considerChildTags`, `tags` |     false      |
+|    system.pql     |       string        |          PQL Query          |     false      |
 
 
 

--- a/src/DataIndex/Adapter/AssetSearchAdapter.php
+++ b/src/DataIndex/Adapter/AssetSearchAdapter.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Adapter;
 
+use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\AssetSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
@@ -26,6 +27,7 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Asset;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\AssetSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Hydrator\HydratorServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
 use function sprintf;
@@ -41,7 +43,7 @@ final readonly class AssetSearchAdapter implements AssetSearchAdapterInterface
     }
 
     /**
-     * @throws SearchException
+     * @throws SearchException|InvalidArgumentException
      */
     public function searchAssets(QueryInterface $assetQuery): AssetSearchResult
     {
@@ -49,6 +51,8 @@ final readonly class AssetSearchAdapter implements AssetSearchAdapterInterface
             $searchResult = $this->searchService->search($assetQuery->getSearch());
         } catch (AssetSearchException) {
             throw new SearchException('assets');
+        } catch (Exception $e) {
+            throw new InvalidArgumentException($e->getMessage());
         }
 
         $result = [];

--- a/src/DataIndex/Adapter/AssetSearchAdapterInterface.php
+++ b/src/DataIndex/Adapter/AssetSearchAdapterInterface.php
@@ -20,13 +20,14 @@ use Pimcore\Bundle\GenericDataIndexBundle\Exception\AssetSearchException;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Asset;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\AssetSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
 
 interface AssetSearchAdapterInterface
 {
     /**
-     * @throws SearchException
+     * @throws SearchException|InvalidArgumentException
      */
     public function searchAssets(QueryInterface $assetQuery): AssetSearchResult;
 

--- a/src/DataIndex/AssetSearchService.php
+++ b/src/DataIndex/AssetSearchService.php
@@ -29,6 +29,7 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Video;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Adapter\AssetSearchAdapterInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Provider\AssetQueryProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
 use function count;
@@ -42,7 +43,7 @@ final readonly class AssetSearchService implements AssetSearchServiceInterface
     }
 
     /**
-     * @throws SearchException
+     * @throws SearchException|InvalidArgumentException
      */
     public function searchAssets(QueryInterface $assetQuery): AssetSearchResult
     {

--- a/src/DataIndex/AssetSearchServiceInterface.php
+++ b/src/DataIndex/AssetSearchServiceInterface.php
@@ -27,13 +27,14 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Text;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Unknown;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Video;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
 
 interface AssetSearchServiceInterface
 {
     /**
-     * @throws SearchException
+     * @throws SearchException|InvalidArgumentException
      */
     public function searchAssets(QueryInterface $assetQuery): AssetSearchResult;
 

--- a/src/DataIndex/Filter/PqlFilter.php
+++ b/src/DataIndex/Filter/PqlFilter.php
@@ -20,12 +20,11 @@ use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\SimpleColumnFiltersParameterInterface;
-use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\TagFilterParameterInterface;
 
 /**
  * @internal
  */
-final class TagFilter implements FilterInterface
+final class PqlFilter implements FilterInterface
 {
     public function apply(mixed $parameters, QueryInterface $query): QueryInterface
     {
@@ -33,18 +32,18 @@ final class TagFilter implements FilterInterface
             return $query;
         }
 
-        $filter = $parameters->getSimpleColumnFilterByType(ColumnType::SYSTEM_TAG->value);
+        $filter = $parameters->getSimpleColumnFilterByType(ColumnType::SYSTEM_PQL_QUERY->value);
 
         if (!$filter) {
             return $query;
         }
 
-        $filterValue = $filter->getFilterValue();
-
-        if (!isset($filterValue['tags'], $filterValue['considerChildTags'])) {
-            throw new InvalidArgumentException('Invalid tag filter');
+        if (!is_string($filter->getFilterValue())) {
+            throw new InvalidArgumentException('Invalid PQL filter. Filter value must be a string.');
         }
 
-        return $query->filterTags($filterValue['tags'], $filterValue['considerChildTags']);
+        $filterValue = $filter->getFilterValue();
+
+        return $query->filterByPql($filterValue);
     }
 }

--- a/src/DataIndex/Filter/PqlFilter.php
+++ b/src/DataIndex/Filter/PqlFilter.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\SimpleColumnFiltersParameterInterface;
+use function is_string;
 
 /**
  * @internal

--- a/src/DataIndex/Filter/TagFilter.php
+++ b/src/DataIndex/Filter/TagFilter.php
@@ -20,7 +20,6 @@ use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\SimpleColumnFiltersParameterInterface;
-use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\TagFilterParameterInterface;
 
 /**
  * @internal

--- a/src/DataIndex/Grid/GridSearch.php
+++ b/src/DataIndex/Grid/GridSearch.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\AssetSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\AssetSearchServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\OpenSearchFilterInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
 use Pimcore\Bundle\StudioBackendBundle\Filter\Service\FilterServiceProviderInterface;
@@ -39,7 +40,7 @@ final readonly class GridSearch implements GridSearchInterface
     }
 
     /**
-     * @throws NotFoundException|SearchException
+     * @throws NotFoundException|SearchException|InvalidArgumentException
      */
     public function searchAssets(GridParameter $gridParameter): AssetSearchResult
     {

--- a/src/DataIndex/Query/AssetQuery.php
+++ b/src/DataIndex/Query/AssetQuery.php
@@ -27,6 +27,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\Path
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\TagFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\FullTextSearch\ElementKeySearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\FullTextSearch\WildcardSearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\QueryLanguage\PqlFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\OrderByField;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
 
@@ -150,9 +151,16 @@ final class AssetQuery implements QueryInterface
     /**
      * @param array<int> $tags
      */
-    public function filterTags(array $tags, bool $considerChildTags): QueryInterface
+    public function filterTags(array $tags, bool $considerChildTags): self
     {
         $this->search->addModifier(new TagFilter($tags, $considerChildTags));
+
+        return $this;
+    }
+
+    public function filterByPql(string $pqlQuery): self
+    {
+        $this->search->addModifier(new PqlFilter($pqlQuery));
 
         return $this;
     }

--- a/src/DataIndex/Query/DataObjectQuery.php
+++ b/src/DataIndex/Query/DataObjectQuery.php
@@ -25,6 +25,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\Pare
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\PathFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Tree\TagFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\FullTextSearch\ElementKeySearch;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\QueryLanguage\PqlFilter;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByIndexField;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
@@ -129,9 +130,16 @@ final class DataObjectQuery implements QueryInterface
     /**
      * @param array<int> $tags
      */
-    public function filterTags(array $tags, bool $considerChildTags): QueryInterface
+    public function filterTags(array $tags, bool $considerChildTags): self
     {
         $this->search->addModifier(new TagFilter($tags, $considerChildTags));
+
+        return $this;
+    }
+
+    public function filterByPql(string $pqlQuery): self
+    {
+        $this->search->addModifier(new PqlFilter($pqlQuery));
 
         return $this;
     }

--- a/src/DataIndex/Query/QueryInterface.php
+++ b/src/DataIndex/Query/QueryInterface.php
@@ -42,4 +42,6 @@ interface QueryInterface
      * @param array<int> $tags
      */
     public function filterTags(array $tags, bool $considerChildTags): self;
+
+    public function filterByPql(string $pqlQuery): self;
 }

--- a/src/Grid/Column/ColumnType.php
+++ b/src/Grid/Column/ColumnType.php
@@ -26,6 +26,7 @@ enum ColumnType: string
     case SYSTEM_INTEGER = 'system.integer';
     case SYSTEM_DATETIME = 'system.datetime';
     case SYSTEM_TAG = 'system.tag';
+    case SYSTEM_PQL_QUERY = 'system.pql';
     case METADATA_SELECT = 'metadata.select';
     case METADATA_INPUT = 'metadata.input';
     case METADATA_DATE = 'metadata.date';

--- a/src/MappedParameter/Filter/ColumnFilter.php
+++ b/src/MappedParameter/Filter/ColumnFilter.php
@@ -19,27 +19,18 @@ namespace Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter;
 /**
  * @internal
  */
-final readonly class ColumnFilter
+final readonly class ColumnFilter extends SimpleColumnFilter
 {
     public function __construct(
         private string $key,
         private string $type,
         private mixed $filterValue,
     ) {
+        parent::__construct($this->type, $this->filterValue);
     }
 
     public function getKey(): string
     {
         return $this->key;
-    }
-
-    public function getType(): string
-    {
-        return $this->type;
-    }
-
-    public function getFilterValue(): mixed
-    {
-        return $this->filterValue;
     }
 }

--- a/src/MappedParameter/Filter/SimpleColumnFilter.php
+++ b/src/MappedParameter/Filter/SimpleColumnFilter.php
@@ -19,24 +19,21 @@ namespace Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter;
 /**
  * @internal
  */
-final readonly class TagFilterParameter
+readonly class SimpleColumnFilter
 {
     public function __construct(
-        private array $tags,
-        private bool $considerChildTags
+        private string $type,
+        private mixed $filterValue,
     ) {
     }
 
-    /**
-     * @return array<int>
-     */
-    public function getTags(): array
+    public function getType(): string
     {
-        return $this->tags;
+        return $this->type;
     }
 
-    public function considerChildTags(): bool
+    public function getFilterValue(): mixed
     {
-        return $this->considerChildTags;
+        return $this->filterValue;
     }
 }

--- a/src/MappedParameter/Filter/SimpleColumnFiltersParameterInterface.php
+++ b/src/MappedParameter/Filter/SimpleColumnFiltersParameterInterface.php
@@ -19,7 +19,10 @@ namespace Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter;
 /**
  * @internal
  */
-interface TagFilterParameterInterface
+interface SimpleColumnFiltersParameterInterface
 {
-    public function getTagFilter(): ?TagFilterParameter;
+    /**
+     * A column filter that does not require a key
+     */
+    public function getSimpleColumnFilterByType(string $type): ?SimpleColumnFilter;
 }


### PR DESCRIPTION
## Changes in this pull request
Resolves #394 

## Additional info
Some minor Refactoring. Now it is possible to have a filter without a key, like `tag`, and `pql`. Those will be applied to the query and not to a column itself. For this we now have the `SimpleColumnFiltersParameterInterface`