### PR TITLE
[Task] Update controller responses to jobrunid instead of id

### DIFF
--- a/src/Asset/Controller/CloneController.php
+++ b/src/Asset/Controller/CloneController.php
@@ -74,7 +74,7 @@ final class CloneController extends AbstractApiController
     )]
     #[CreatedResponse(
         description: 'asset_clone_created_response',
-        content: new IdJson('ID of created jobRun')
+        content: new IdJson('ID of created jobRun', 'jobRunId')
     )]
     #[IdParameter(type: ElementTypes::TYPE_ASSET)]
     #[IdParameter(type: ElementTypes::TYPE_ASSET, name: 'parentId')]
@@ -93,7 +93,7 @@ final class CloneController extends AbstractApiController
         if ($jobRunId) {
             $status = HttpResponseCodes::CREATED->value;
 
-            return $this->jsonResponse(['id' => $jobRunId], $status);
+            return $this->jsonResponse(['jobRunId' => $jobRunId], $status);
         }
 
         return new Response($data, $status);

--- a/src/Asset/Controller/PatchController.php
+++ b/src/Asset/Controller/PatchController.php
@@ -73,7 +73,7 @@ final class PatchController extends AbstractApiController
     )]
     #[CreatedResponse(
         description: 'asset_patch_by_id_created_response',
-        content: new IdJson('ID of created jobRun')
+        content: new IdJson('ID of created jobRun', 'jobRunId')
     )]
     #[DefaultResponses([
         HttpResponseCodes::UNAUTHORIZED,
@@ -92,7 +92,7 @@ final class PatchController extends AbstractApiController
         if ($jobRunId) {
             $status = HttpResponseCodes::CREATED->value;
 
-            return $this->jsonResponse(['id' => $jobRunId], $status);
+            return $this->jsonResponse(['jobRunId' => $jobRunId], $status);
         }
 
         return new Response($data, $status);

--- a/src/Asset/Controller/Upload/ZipController.php
+++ b/src/Asset/Controller/Upload/ZipController.php
@@ -75,7 +75,7 @@ final class ZipController extends AbstractApiController
     )]
     #[CreatedResponse(
         description: 'asset_upload_zip_created_response',
-        content: new IdJson('ID of created jobRun')
+        content: new IdJson('ID of created jobRun', 'jobRunId')
     )]
     #[IdParameter(type: ElementTypes::TYPE_ASSET, name: 'parentId')]
     #[AddAssetRequestBody(
@@ -105,7 +105,7 @@ final class ZipController extends AbstractApiController
 
         return $this->jsonResponse(
             [
-                'id' => $this->zipService->uploadZipAssets(
+                'jobRunId' => $this->zipService->uploadZipAssets(
                     $this->securityService->getCurrentUser(),
                     $file,
                     $parentId


### PR DESCRIPTION
## Changes in this pull request
Resolves #449 

## Additional info
Adapting response to jobRunId if jobRunId is returned