### PR TITLE
[Grid] [Asset] Save Configuration shared User and role can be empty.

### DIFF
--- a/src/Asset/MappedParameter/Grid/SaveConfigurationParameter.php
+++ b/src/Asset/MappedParameter/Grid/SaveConfigurationParameter.php
@@ -37,11 +37,9 @@ final readonly class SaveConfigurationParameter implements ConfigurationParamete
         #[NotBlank]
         private string $description,
         #[NotBlank]
-        private array $sharedUsers,
-        #[NotBlank]
-        private array $sharedRoles,
-        #[NotBlank]
         private array $columns,
+        private array $sharedUsers = [],
+        private array $sharedRoles = [],
         private ?Filter $filter = null,
         private bool $saveFilter = false,
         private bool $shareGlobal = false,


### PR DESCRIPTION
## Changes in this pull request
Resolves #465 

## Additional info
