### PR TITLE
[Assets][Image] Add endpoint to return image preview based on studio config

### DIFF
--- a/src/Asset/Controller/Image/PreviewStreamController.php
+++ b/src/Asset/Controller/Image/PreviewStreamController.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Controller\Image;
+
+use OpenApi\Attributes\Get;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Attribute\Response\Content\AssetMediaType;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Attribute\Response\Header\ContentDisposition;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\BinaryServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\AccessDeniedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseHeaders;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class PreviewStreamController extends AbstractApiController
+{
+    public function __construct(
+        private readonly AssetServiceInterface $assetService,
+        private readonly BinaryServiceInterface $binaryService,
+        private readonly SecurityServiceInterface $securityService,
+        SerializerInterface $serializer
+    ) {
+        parent::__construct($serializer);
+    }
+
+    /**
+     * @throws AccessDeniedException
+     * @throws NotFoundException
+     * @throws InvalidElementTypeException
+     * @throws InvalidThumbnailException
+     * @throws UserNotFoundException
+     */
+    #[Route(
+        '/assets/{id}/image/stream/preview',
+        name: 'pimcore_studio_api_stream_image_preview',
+        methods: ['GET']
+    )]
+    #[IsGranted(UserPermissions::ASSETS->value)]
+    #[Get(
+        path: self::PREFIX . '/assets/{id}/image/stream/preview',
+        operationId: 'asset_image_stream_preview',
+        description: 'asset_image_stream_preview_description',
+        summary: 'asset_image_stream_preview_summary',
+        tags: [Tags::Assets->name]
+    )]
+    #[IdParameter(type: 'image')]
+    #[SuccessResponse(
+        description: 'asset_image_stream_preview_success_response',
+        content: [new AssetMediaType('image/*')],
+        headers: [new ContentDisposition(HttpResponseHeaders::INLINE_TYPE->value)]
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::NOT_FOUND,
+    ])]
+    public function streamImagePreview(int $id): StreamedResponse
+    {
+        $asset = $this->assetService->getAssetElement(
+            $this->securityService->getCurrentUser(),
+            $id
+        );
+
+        return $this->binaryService->streamPreviewImageThumbnail($asset);
+    }
+}

--- a/src/Asset/Service/BinaryService.php
+++ b/src/Asset/Service/BinaryService.php
@@ -28,6 +28,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseHeaders;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\StreamedResponseTrait;
 use Pimcore\Messenger\AssetPreviewImageMessage;
 use Pimcore\Model\Asset;
+use Pimcore\Model\Asset\Image;
 use Pimcore\Model\Asset\Video;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -61,6 +62,21 @@ final readonly class BinaryService implements BinaryServiceInterface
         }
 
         return $this->getVideoByThumbnail($video, $thumbnailName, HttpResponseHeaders::ATTACHMENT_TYPE->value);
+    }
+
+    /**
+     * @throws InvalidElementTypeException|InvalidThumbnailException
+     */
+    public function streamPreviewImageThumbnail(Asset $image): StreamedResponse
+    {
+        if (!$image instanceof Image) {
+            throw new InvalidElementTypeException($image->getType());
+        }
+
+        return $this->getStreamedResponse(
+            $this->thumbnailService->getImagePreviewThumbnail($image),
+            HttpResponseHeaders::INLINE_TYPE->value
+        );
     }
 
     /**

--- a/src/Asset/Service/BinaryServiceInterface.php
+++ b/src/Asset/Service/BinaryServiceInterface.php
@@ -24,7 +24,6 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailConfigurationException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailException;
 use Pimcore\Model\Asset;
-use Pimcore\Model\Asset\Image;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**

--- a/src/Asset/Service/BinaryServiceInterface.php
+++ b/src/Asset/Service/BinaryServiceInterface.php
@@ -24,6 +24,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailConfigurationException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailException;
 use Pimcore\Model\Asset;
+use Pimcore\Model\Asset\Image;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -41,6 +42,11 @@ interface BinaryServiceInterface
         Asset $video,
         string $thumbnailName
     ): StreamedResponse;
+
+    /**
+     * @throws InvalidElementTypeException|InvalidThumbnailException
+     */
+    public function streamPreviewImageThumbnail(Asset $image): StreamedResponse;
 
     /**
      * @throws ElementProcessingNotCompletedException

--- a/src/Asset/Service/ThumbnailService.php
+++ b/src/Asset/Service/ThumbnailService.php
@@ -182,7 +182,7 @@ final readonly class ThumbnailService implements ThumbnailServiceInterface
             [
                 //ToDo: Replace with the path to the actual image once its present in Studio UI
                 'path' => '/bundles/pimcoreadmin/img/tree-preview-transparent-background.png',
-                'mode' => 'asTexture'
+                'mode' => 'asTexture',
             ]
         );
         $previewThumbnail->addItem(
@@ -190,7 +190,7 @@ final readonly class ThumbnailService implements ThumbnailServiceInterface
             [
                 'width' => 1920,
                 'height' => 1920,
-                'forceResize' => false
+                'forceResize' => false,
             ]
         );
 

--- a/src/Asset/Service/ThumbnailServiceInterface.php
+++ b/src/Asset/Service/ThumbnailServiceInterface.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailConfigurati
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ThumbnailResizingFailedException;
 use Pimcore\Model\Asset\Image;
+use Pimcore\Model\Asset\Image\Thumbnail\Config as ImageThumbnailConfig;
 use Pimcore\Model\Asset\Image\ThumbnailInterface;
 use Pimcore\Model\Asset\Video\Thumbnail\Config as VideoThumbnailConfig;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -44,6 +45,11 @@ interface ThumbnailServiceInterface
         Image $image,
         bool $deleteAfterSend = true
     ): BinaryFileResponse;
+
+    /**
+     * @throws InvalidThumbnailException
+     */
+    public function getImagePreviewThumbnail(Image $image): ThumbnailInterface;
 
     /**
      * @throws InvalidThumbnailException

--- a/src/Asset/Service/ThumbnailServiceInterface.php
+++ b/src/Asset/Service/ThumbnailServiceInterface.php
@@ -22,7 +22,6 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailConfigurati
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ThumbnailResizingFailedException;
 use Pimcore\Model\Asset\Image;
-use Pimcore\Model\Asset\Image\Thumbnail\Config as ImageThumbnailConfig;
 use Pimcore\Model\Asset\Image\ThumbnailInterface;
 use Pimcore\Model\Asset\Video\Thumbnail\Config as VideoThumbnailConfig;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;

--- a/src/Util/Constant/Asset/MimeTypes.php
+++ b/src/Util/Constant/Asset/MimeTypes.php
@@ -26,6 +26,7 @@ enum MimeTypes: string
     use EnumToValueArrayTrait;
 
     case JPEG = 'JPEG';
+    case PJPEG = 'PJPEG';
     case PNG = 'PNG';
     case PDF = 'application/pdf';
     case CSV = 'text/csv';

--- a/src/Util/Constant/Thumbnails.php
+++ b/src/Util/Constant/Thumbnails.php
@@ -22,5 +22,6 @@ namespace Pimcore\Bundle\StudioBackendBundle\Util\Constant;
 enum Thumbnails: string
 {
     case DEFAULT_THUMBNAIL_ID = 'pimcore-system-treepreview';
+    case DEFAULT_STUDIO_THUMBNAIL_ID = 'studio-preview';
     case DEFAULT_THUMBNAIL_TEXT = 'original';
 }

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -110,6 +110,11 @@ asset_image_download_custom_description: |
   The <strong>{id}</strong> must be an ID of existing asset image
 asset_image_download_custom_success_response: Custom image binary file
 asset_image_download_custom_summary: Download custom image by ID and configuration
+asset_image_stream_preview_description: |
+  Stream image asset preview based on the provided <strong>{id}</strong>. <br> 
+  The <strong>{id}</strong> must be an ID of existing asset image
+asset_image_stream_preview_success_response: Image preview stream
+asset_image_stream_preview_summary: Stream image asset preview by ID
 asset_patch_by_id_created_response: Successfully created jobRun for patching multiple assets
 asset_patch_by_id_description: |
   Patching assets based on the given ID and data. <br> Patching can be used for updating single or multiple fields. <br> If single element is being patched, operation is executed synchronously. Multiple elements are patched asynchronously.


### PR DESCRIPTION
## Changes in this pull request
Resolves #458 


### Additional info
Added a new endpoint to return image preview stream based on the pre-defined config