### PR TITLE
[Grid] [Resolver] Asset Documnet and DataObject Resolver for Metadata should not throw a NotFoundException

### DIFF
--- a/src/DataIndex/Adapter/DocumentSearchAdapter.php
+++ b/src/DataIndex/Adapter/DocumentSearchAdapter.php
@@ -56,7 +56,7 @@ final readonly class DocumentSearchAdapter implements DocumentSearchAdapterInter
         }
 
         if (!$document) {
-            throw new NotFoundException('Asset', $id);
+            throw new NotFoundException('Document', $id);
         }
 
         return $this->hydratorService->hydrate($document);

--- a/src/Grid/Column/Resolver/Metadata/AssetResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/AssetResolver.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\Metadata;
 
 use Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
@@ -47,9 +48,13 @@ final class AssetResolver implements ColumnResolverInterface
             return $this->getColumnData($column, null);
         }
 
-        $relatedAsset = $this->assetService->getAsset(
-            reset($asset['asset'])
-        );
+        try {
+            $relatedAsset = $this->assetService->getAsset(
+                reset($asset['asset'])
+            );   
+        } catch (NotFoundException) {
+            return $this->getColumnData($column, null);
+        }
 
         return $this->getColumnData(
             $column,

--- a/src/Grid/Column/Resolver/Metadata/AssetResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/AssetResolver.php
@@ -51,7 +51,7 @@ final class AssetResolver implements ColumnResolverInterface
         try {
             $relatedAsset = $this->assetService->getAsset(
                 reset($asset['asset'])
-            );   
+            );
         } catch (NotFoundException) {
             return $this->getColumnData($column, null);
         }

--- a/src/Grid/Column/Resolver/Metadata/DataObjectResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/DataObjectResolver.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\Metadata;
 
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataObjectServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
@@ -47,9 +48,14 @@ final class DataObjectResolver implements ColumnResolverInterface
             return $this->getColumnData($column, null);
         }
 
-        $relatedObject = $this->dataObjectService->getDataObject(
-            reset($object['object'])
-        );
+        try {
+            $relatedObject = $this->dataObjectService->getDataObject(
+                reset($object['object'])
+            );
+        } catch (NotFoundException) {
+            return $this->getColumnData($column, null);
+        }
+
 
         return $this->getColumnData(
             $column,

--- a/src/Grid/Column/Resolver/Metadata/DataObjectResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/DataObjectResolver.php
@@ -56,7 +56,6 @@ final class DataObjectResolver implements ColumnResolverInterface
             return $this->getColumnData($column, null);
         }
 
-
         return $this->getColumnData(
             $column,
             $relatedObject->getFullPath()

--- a/src/Grid/Column/Resolver/Metadata/DocumentResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/DocumentResolver.php
@@ -49,7 +49,7 @@ final class DocumentResolver implements ColumnResolverInterface
         }
 
         try {
-            $documentIndex = $this->documentService->getDocument(
+            $relatedDocument = $this->documentService->getDocument(
                 reset($document['document'])
             );
         } catch (NotFoundException) {
@@ -58,7 +58,7 @@ final class DocumentResolver implements ColumnResolverInterface
 
         return $this->getColumnData(
             $column,
-            $documentIndex->getFullPath()
+            $relatedDocument->getFullPath()
         );
     }
 

--- a/src/Grid/Column/Resolver/Metadata/DocumentResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/DocumentResolver.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\Metadata;
 
 use Pimcore\Bundle\StudioBackendBundle\Document\Service\DocumentServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
@@ -47,9 +48,13 @@ final class DocumentResolver implements ColumnResolverInterface
             return $this->getColumnData($column, null);
         }
 
-        $documentIndex = $this->documentService->getDocument(
-            reset($document['document'])
-        );
+        try {
+            $documentIndex = $this->documentService->getDocument(
+                reset($document['document'])
+            );
+        } catch (NotFoundException) {
+            return $this->getColumnData($column, null);
+        }
 
         return $this->getColumnData(
             $column,


### PR DESCRIPTION
## Changes in this pull request
Resolves #517 

## Additional info
