### PR TITLE
[DataObject]: Fix data object layout endpoint when layout value in panel is null

### DIFF
--- a/src/DataObject/Service/LayoutService.php
+++ b/src/DataObject/Service/LayoutService.php
@@ -90,7 +90,7 @@ final readonly class LayoutService implements LayoutServiceInterface
             $panel->getDatatype(),
             $panel->fieldtype,
             $panel->getType(),
-            $panel->getLayout(),
+            $panel->layout,
             $panel->getRegion(),
             $panel->getTitle(),
             $panel->getWidth(),


### PR DESCRIPTION
Unfortunately the getter in the Pimcore core has a bug. It's return type is not nullable allthough the value can get null. I therefore access the property directly for now:

![image](https://github.com/user-attachments/assets/aea4da2a-58f3-43b3-9ba2-94b13dd93137)

https://github.com/pimcore/pimcore/blob/11.x/models/DataObject/ClassDefinition/Layout/Panel.php#L38
