### PR TITLE
[Task][Asset] Add thumbnail clear

### DIFF
--- a/src/Asset/Controller/Image/ImageClearController.php
+++ b/src/Asset/Controller/Image/ImageClearController.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Thumbnail\Controller;
+
+use OpenApi\Attributes\Delete;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Thumbnail\Service\ThumbnailServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\PaginatedResponseTrait;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class ImageClearController extends AbstractApiController
+{
+    use PaginatedResponseTrait;
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly AssetServiceInterface $assetService
+    ) {
+        parent::__construct($serializer);
+    }
+
+    /**
+     * @throws UserNotFoundException
+     */
+    #[Route('/assets/{id}/image/thumbnail/clear', name: 'pimcore_studio_api_clear_image_thumbnail', methods: ['DELETE'])]
+    #[IsGranted(UserPermissions::ASSETS->value)]
+    #[IsGranted(UserPermissions::THUMBNAILS->value)]
+    #[Delete(
+        path: self::PREFIX . '/assets/{id}/image/thumbnail/clear',
+        operationId: 'asset_image_clear_thumbnail',
+        description: 'asset_image_clear_thumbnail_description',
+        summary: 'asset_image_clear_thumbnail_summary',
+        tags: [Tags::AssetThumbnails->value]
+    )]
+    #[IdParameter(type: ElementTypes::TYPE_ASSET)]
+    #[SuccessResponse]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::INTERNAL_SERVER_ERROR
+    ])]
+    public function clearImageThumbnails(int $id): Response
+    {
+        $this->assetService->clearThumbnails($id);
+
+        return new Response();
+    }
+}

--- a/src/Asset/Controller/Image/ImageClearController.php
+++ b/src/Asset/Controller/Image/ImageClearController.php
@@ -24,7 +24,6 @@ use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParame
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
-use Pimcore\Bundle\StudioBackendBundle\Thumbnail\Service\ThumbnailServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
@@ -66,7 +65,7 @@ final class ImageClearController extends AbstractApiController
     #[DefaultResponses([
         HttpResponseCodes::UNAUTHORIZED,
         HttpResponseCodes::NOT_FOUND,
-        HttpResponseCodes::INTERNAL_SERVER_ERROR
+        HttpResponseCodes::INTERNAL_SERVER_ERROR,
     ])]
     public function clearImageThumbnails(int $id): Response
     {

--- a/src/Asset/Controller/Image/ThumbnailImageClearController.php
+++ b/src/Asset/Controller/Image/ThumbnailImageClearController.php
@@ -50,7 +50,11 @@ final class ThumbnailImageClearController extends AbstractApiController
     /**
      * @throws UserNotFoundException
      */
-    #[Route('/assets/{id}/image/thumbnail/clear', name: 'pimcore_studio_api_clear_image_thumbnail', methods: ['DELETE'])]
+    #[Route(
+        path: '/assets/{id}/image/thumbnail/clear',
+        name: 'pimcore_studio_api_clear_image_thumbnail',
+        methods: ['DELETE']
+    )]
     #[IsGranted(UserPermissions::ASSETS->value)]
     #[Delete(
         path: self::PREFIX . '/assets/{id}/image/thumbnail/clear',

--- a/src/Asset/Controller/Image/ThumbnailImageClearController.php
+++ b/src/Asset/Controller/Image/ThumbnailImageClearController.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Bundle\StudioBackendBundle\Thumbnail\Controller;
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Controller\Image;
 
 use OpenApi\Attributes\Delete;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface;
@@ -36,7 +36,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 /**
  * @internal
  */
-final class ImageClearController extends AbstractApiController
+final class ThumbnailImageClearController extends AbstractApiController
 {
     use PaginatedResponseTrait;
 
@@ -52,13 +52,12 @@ final class ImageClearController extends AbstractApiController
      */
     #[Route('/assets/{id}/image/thumbnail/clear', name: 'pimcore_studio_api_clear_image_thumbnail', methods: ['DELETE'])]
     #[IsGranted(UserPermissions::ASSETS->value)]
-    #[IsGranted(UserPermissions::THUMBNAILS->value)]
     #[Delete(
         path: self::PREFIX . '/assets/{id}/image/thumbnail/clear',
         operationId: 'asset_image_clear_thumbnail',
         description: 'asset_image_clear_thumbnail_description',
         summary: 'asset_image_clear_thumbnail_summary',
-        tags: [Tags::AssetThumbnails->value]
+        tags: [Tags::Assets->value]
     )]
     #[IdParameter(type: ElementTypes::TYPE_ASSET)]
     #[SuccessResponse]

--- a/src/Asset/Service/AssetService.php
+++ b/src/Asset/Service/AssetService.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Asset\Service;
 
+use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\Asset\AssetServiceResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Event\PreResponse\AssetEvent;
@@ -33,6 +34,8 @@ use Pimcore\Bundle\StudioBackendBundle\DataIndex\OpenSearchFilterInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\AssetQueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Request\ElementParameters;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\AccessDeniedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidFilterServiceTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidFilterTypeException;
@@ -249,6 +252,28 @@ final readonly class AssetService implements AssetServiceInterface
             } else {
                 return $filename;
             }
+        }
+    }
+
+    /**
+     * @throws DatabaseException|ForbiddenException
+     */
+    public function clearThumbnails(int $id): void
+    {
+        $asset = $this->getAsset($id);
+
+        if (!$asset->getPermissions()->isPublish()) {
+            throw new ForbiddenException('Not allowed to clear thumbnails for this asset');
+        }
+
+        $asset = $this->serviceResolver->getElementById('asset', $id);
+
+        $asset->clearThumbnails(true); // force clear
+
+        try {
+            $asset->save();
+        } catch (Exception $e) {
+            throw new DatabaseException($e->getMessage());
         }
     }
 

--- a/src/Asset/Service/AssetServiceInterface.php
+++ b/src/Asset/Service/AssetServiceInterface.php
@@ -26,6 +26,8 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Text;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Unknown;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Video;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Request\ElementParameters;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidFilterServiceTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidFilterTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
@@ -103,4 +105,9 @@ interface AssetServiceInterface
     ): AssetModel;
 
     public function getUniqueAssetName(string $targetPath, string $filename): string;
+
+    /**
+     * @throws DatabaseException|ForbiddenException
+     */
+    public function clearThumbnails(int $id): void;
 }

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -100,8 +100,13 @@ asset_get_tree_description: |
   You can use different query parameters to filter the assets and it is possible to exclude folders from the result completely
 asset_get_tree_success_response: Paginated assets with total count as header param as JSON
 asset_get_tree_summary: Get all asset data for the tree
-asset_image_download_by_format_description: |
-  Download the image asset based on the provided <strong>{id}</strong> and <strong>{format}</strong>. <br> The <strong>{id}</strong> must be an ID of existing asset image
+asset_image_create_thumbnail_description: |
+  Create a new image thumbnail based on the provided <strong>{id}</strong> and configuration parameters. <br> 
+  The <strong>{id}</strong> must be an ID of existing asset image
+asset_image_clear_thumbnail_summary: Clear image thumbnail by ID
+asset_image_clear_thumbnail_description: |
+    Clear the image thumbnail based on the provided <strong>{id}</strong>. <br> 
+    The <strong>{id}</strong> must be an ID of existing asset image
 asset_image_download_by_format_success_response: Image asset binary file based on format
 asset_image_download_by_format_summary: Download image asset by ID and format
 asset_image_download_by_thumbnail_description: |


### PR DESCRIPTION
## Changes in this pull request
Resolves #611 

## Additional info
Adding endpoint to clear thumbnails

Maybe move it to the thumbnail service, but not 100% sure since we again would need to import e.g. the assetservice and the serviceresolver