### PR TITLE
[Data Objects]: Extend Patcher to use field adapters for editable data

### DIFF
--- a/src/Asset/Controller/PatchController.php
+++ b/src/Asset/Controller/PatchController.php
@@ -76,8 +76,10 @@ final class PatchController extends AbstractApiController
         content: new IdJson('ID of created jobRun', 'jobRunId')
     )]
     #[DefaultResponses([
-        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::BAD_REQUEST,
+        HttpResponseCodes::INTERNAL_SERVER_ERROR,
         HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::UNAUTHORIZED,
     ])]
     public function assetPatchById(#[MapRequestPayload] PatchAssetParameter $patchAssetParameter): Response
     {

--- a/src/Asset/Controller/PatchFolderController.php
+++ b/src/Asset/Controller/PatchFolderController.php
@@ -72,8 +72,10 @@ final class PatchFolderController extends AbstractApiController
         content: new IdJson('ID of created jobRun', 'jobRunId')
     )]
     #[DefaultResponses([
-        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::BAD_REQUEST,
+        HttpResponseCodes::INTERNAL_SERVER_ERROR,
         HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::UNAUTHORIZED,
     ])]
     public function assetPatchFolderById(#[MapRequestPayload] PatchFolderParameter $patchFolderParameter): Response
     {

--- a/src/Asset/Controller/UpdateController.php
+++ b/src/Asset/Controller/UpdateController.php
@@ -22,6 +22,8 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Attribute\Response\Content\OneOfAss
 use Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter\UpdateAssetParameter;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementSavingFailedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
@@ -49,6 +51,9 @@ final class UpdateController extends AbstractApiController
         parent::__construct($serializer);
     }
 
+    /**
+     * @throws ElementSavingFailedException|NotFoundException
+     */
     #[Route('/assets/{id}', name: 'pimcore_studio_api_update_asset', methods: ['PUT'])]
     #[IsGranted(UserPermissions::ASSETS->value)]
     #[Put(
@@ -65,8 +70,9 @@ final class UpdateController extends AbstractApiController
         content: new OneOfAssetJson()
     )]
     #[DefaultResponses([
-        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::INTERNAL_SERVER_ERROR,
         HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::UNAUTHORIZED,
     ])]
     public function assetUpdateById(int $id, #[MapRequestPayload] UpdateAssetParameter $updateAsset): JsonResponse
     {

--- a/src/DataObject/Attribute/Request/PatchDataObjectRequestBody.php
+++ b/src/DataObject/Attribute/Request/PatchDataObjectRequestBody.php
@@ -23,6 +23,7 @@ use OpenApi\Attributes\Property;
 use OpenApi\Attributes\RequestBody;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateBooleanProperty;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateIntegerProperty;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateObjectProperty;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateStringProperty;
 
 /**
@@ -57,6 +58,7 @@ final class PatchDataObjectRequestBody extends RequestBody
                                 new UpdateStringProperty('childrenSortBy'),
                                 new UpdateStringProperty('childrenSortOrder'),
                                 new UpdateBooleanProperty('published'),
+                                new UpdateObjectProperty('editableData'),
                             ],
                             type: 'object',
                         ),

--- a/src/DataObject/Controller/PatchController.php
+++ b/src/DataObject/Controller/PatchController.php
@@ -76,8 +76,10 @@ final class PatchController extends AbstractApiController
         content: new IdJson('ID of created jobRun', 'jobRunId')
     )]
     #[DefaultResponses([
-        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::BAD_REQUEST,
+        HttpResponseCodes::INTERNAL_SERVER_ERROR,
         HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::UNAUTHORIZED,
     ])]
     public function dataObjectPatchById(#[MapRequestPayload] DataParameter $parameter): Response
     {

--- a/src/DataObject/Controller/UpdateController.php
+++ b/src/DataObject/Controller/UpdateController.php
@@ -22,6 +22,8 @@ use Pimcore\Bundle\StudioBackendBundle\DataObject\Attribute\Request\UpdateDataOb
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Attribute\Response\Content\OneOfDataObjectsJson;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\MappedParameter\DataParameter;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataObjectServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementSavingFailedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
@@ -49,6 +51,9 @@ final class UpdateController extends AbstractApiController
         parent::__construct($serializer);
     }
 
+    /**
+     * @throws ElementSavingFailedException|NotFoundException
+     */
     #[Route('/data-objects/{id}', name: 'pimcore_studio_api_update_data_object', methods: ['PUT'])]
     #[IsGranted(UserPermissions::DATA_OBJECTS->value)]
     #[Put(
@@ -65,8 +70,9 @@ final class UpdateController extends AbstractApiController
         content: new OneOfDataObjectsJson()
     )]
     #[DefaultResponses([
-        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::INTERNAL_SERVER_ERROR,
         HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::UNAUTHORIZED,
     ])]
     public function dataObjectUpdateById(int $id, #[MapRequestPayload] DataParameter $parameter): JsonResponse
     {

--- a/src/Patcher/Service/PatchService.php
+++ b/src/Patcher/Service/PatchService.php
@@ -32,6 +32,8 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Config;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Jobs;
+use Pimcore\Bundle\StudioBackendBundle\Updater\Service\UpdateServiceInterface;
+use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Element\ElementDescriptor;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\UserInterface;
@@ -43,10 +45,11 @@ use function count;
 final readonly class PatchService implements PatchServiceInterface
 {
     public function __construct(
-        private SynchronousProcessingServiceInterface $synchronousProcessingService,
-        private JobExecutionAgentInterface $jobExecutionAgent,
+        private AdapterLoaderInterface $adapterLoader,
         private ElementServiceInterface $elementService,
-        private AdapterLoaderInterface $adapterLoader
+        private JobExecutionAgentInterface $jobExecutionAgent,
+        private SynchronousProcessingServiceInterface $synchronousProcessingService,
+        private UpdateServiceInterface $updateService,
     ) {
     }
 
@@ -112,6 +115,15 @@ final readonly class PatchService implements PatchServiceInterface
         UserInterface $user,
     ): void {
         try {
+            if (isset($elementPatchData[UpdateServiceInterface::EDITABLE_DATA_KEY]) && $element instanceof Concrete) {
+                $this->updateService->updateEditableData(
+                    $element,
+                    $elementPatchData[UpdateServiceInterface::EDITABLE_DATA_KEY]
+                );
+
+                unset($elementPatchData[UpdateServiceInterface::EDITABLE_DATA_KEY]);
+            }
+
             $adapters = $this->adapterLoader->loadAdapters($elementType);
             foreach ($adapters as $adapter) {
                 $adapter->patch($element, $elementPatchData);

--- a/src/Updater/Service/UpdateService.php
+++ b/src/Updater/Service/UpdateService.php
@@ -36,8 +36,6 @@ final readonly class UpdateService implements UpdateServiceInterface
     use ElementProviderTrait;
     use ValidateFieldTypeTrait;
 
-    private const EDITABLE_DATA_KEY = 'editableData';
-
     public function __construct(
         private AdapterLoaderInterface $adapterLoader,
         private DataAdapterServiceInterface $dataAdapterService,
@@ -74,7 +72,7 @@ final readonly class UpdateService implements UpdateServiceInterface
     /**
      * @throws ElementSavingFailedException
      */
-    private function updateEditableData(Concrete $element, array $editableData): void
+    public function updateEditableData(Concrete $element, array $editableData): void
     {
         try {
             $class = $element->getClass();

--- a/src/Updater/Service/UpdateServiceInterface.php
+++ b/src/Updater/Service/UpdateServiceInterface.php
@@ -18,14 +18,22 @@ namespace Pimcore\Bundle\StudioBackendBundle\Updater\Service;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementSavingFailedException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Model\DataObject\Concrete;
 
 /**
  * @internal
  */
 interface UpdateServiceInterface
 {
+    public const EDITABLE_DATA_KEY = 'editableData';
+
     /**
      * @throws ElementSavingFailedException|NotFoundException
      */
     public function update(string $elementType, int $id, array $data): void;
+
+    /**
+     * @throws ElementSavingFailedException
+     */
+    public function updateEditableData(Concrete $element, array $editableData): void;
 }


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-ui-bundle/issues/300

## Additional info
- extend Patcher to update editable data - can be used for inline editing and detail editor