### PR TITLE
Added check if `dataUri` exists

### DIFF
--- a/src/Asset/Updater/Adapter/DataUriAdapter.php
+++ b/src/Asset/Updater/Adapter/DataUriAdapter.php
@@ -32,7 +32,7 @@ final readonly class DataUriAdapter implements UpdateAdapterInterface
 
     public function update(ElementInterface $element, array $data): void
     {
-        if (!$element instanceof Asset) {
+        if (!$element instanceof Asset || !array_key_exists($this->getIndexKey(), $data)) {
             return;
         }
 

--- a/src/Asset/Updater/Adapter/DataUriAdapter.php
+++ b/src/Asset/Updater/Adapter/DataUriAdapter.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Element\ElementInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use function array_key_exists;
 
 /**
  * @internal


### PR DESCRIPTION
## Changes in this pull request
Added check if `dataUri` is present

## Additional info
An error is thrown if you try to update an asset because `dataUri` is missing in the update body. 
Since it's not required (afaik), I would add a check if it's there. 

WDYT?
