### PR TITLE
[Bug] Fix sorting by filesize. 

### DIFF
--- a/src/Grid/Mapper/ColumnMapper.php
+++ b/src/Grid/Mapper/ColumnMapper.php
@@ -33,7 +33,7 @@ final readonly class ColumnMapper implements ColumnMapperInterface
         'filename' => 'string',
         'creationDate' => 'datetime',
         'modificationDate' => 'datetime',
-        'size' => 'fileSize',
+        'fileSize' => 'fileSize',
         'key' => 'string',
         'published' => 'boolean',
         'classname' => 'string',

--- a/src/Grid/Service/SystemColumnService.php
+++ b/src/Grid/Service/SystemColumnService.php
@@ -35,7 +35,7 @@ final readonly class SystemColumnService implements SystemColumnServiceInterface
         $systemColumns = Service::GRID_SYSTEM_COLUMNS;
         $columns = [];
         foreach ($systemColumns as $column) {
-            $column = $this->mapCustomColumKeys($column);
+            $column = $this->mapCustomColumnKeys($column);
 
             $columns[$column] = $this->columnMapper->getType($column);
         }
@@ -54,7 +54,7 @@ final readonly class SystemColumnService implements SystemColumnServiceInterface
         return $columns;
     }
 
-    private function mapCustomColumKeys(string $key): string
+    private function mapCustomColumnKeys(string $key): string
     {
         $keyMapping = [
             'size' => 'fileSize',

--- a/src/Grid/Service/SystemColumnService.php
+++ b/src/Grid/Service/SystemColumnService.php
@@ -35,6 +35,8 @@ final readonly class SystemColumnService implements SystemColumnServiceInterface
         $systemColumns = Service::GRID_SYSTEM_COLUMNS;
         $columns = [];
         foreach ($systemColumns as $column) {
+            $column = $this->mapCustomColumKeys($column);
+
             $columns[$column] = $this->columnMapper->getType($column);
         }
 
@@ -50,5 +52,14 @@ final readonly class SystemColumnService implements SystemColumnServiceInterface
         }
 
         return $columns;
+    }
+
+    private function mapCustomColumKeys(string $key): string
+    {
+        $keyMapping = [
+            'size' => 'fileSize',
+        ];
+
+        return $keyMapping[$key] ?? $key;
     }
 }

--- a/tests/Unit/Grid/Mapper/ColumnMapperTest.php
+++ b/tests/Unit/Grid/Mapper/ColumnMapperTest.php
@@ -79,7 +79,7 @@ final class ColumnMapperTest extends Unit
     public function testMapperForSize(): void
     {
         $mapper = new ColumnMapper();
-        $this->assertSame('fileSize', $mapper->getType('size'));
+        $this->assertSame('fileSize', $mapper->getType('fileSize'));
     }
 
     public function testMapperForKey(): void

--- a/tests/Unit/Grid/Service/SystemColumnServiceTest.php
+++ b/tests/Unit/Grid/Service/SystemColumnServiceTest.php
@@ -38,7 +38,7 @@ final class SystemColumnServiceTest extends Unit
             'filename' => 'string',
             'creationDate' => 'datetime',
             'modificationDate' => 'datetime',
-            'size' => 'fileSize',
+            'fileSize' => 'fileSize',
             'mimetype' => 'string',
         ], $systemColumnService->getSystemColumnsForAssets());
     }


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-ui-bundle/issues/624

## Additional info
In the core de column is called `size`but the getter is called `getFileSize` that's why in the index it is also called `fileSize` now we need some kind of mapping otherwise the sorting doesn't work. 
