### PR TITLE
[Data Object Editor] Adapter issues

### DIFF
--- a/src/DataObject/Data/Adapter/LocalizedFieldsAdapter.php
+++ b/src/DataObject/Data/Adapter/LocalizedFieldsAdapter.php
@@ -36,6 +36,7 @@ use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
+use Pimcore\Model\DataObject\ClassDefinition\Layout;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Localizedfield;
 use Pimcore\Model\UserInterface;
@@ -129,7 +130,7 @@ final readonly class LocalizedFieldsAdapter implements
 
         $value->loadLazyData();
         $originalValue = $fieldDefinition->normalize($value);
-        if ($originalValue === null) {
+        if (empty($originalValue)) {
             return null;
         }
         $languages = $this->languageService->getUserAllowedLanguages(
@@ -177,7 +178,7 @@ final readonly class LocalizedFieldsAdapter implements
 
         $inheritedData = [];
         $contextObject = $contextData?->getContextObject();
-        $fields = $fieldDefinition->getChildren();
+        $fields = $this->processFieldChildren($fieldDefinition->getChildren());
 
         foreach ($fields as $field) {
             foreach ($this->toolResolver->getValidLanguages() as $language) {
@@ -305,5 +306,23 @@ final readonly class LocalizedFieldsAdapter implements
         }
 
         throw new InvalidArgumentException('Invalid context provided.');
+    }
+
+    private function processFieldChildren(array $children): array
+    {
+        $fields = [];
+
+        foreach ($children as $child) {
+            if (!$child instanceof Layout) {
+                $fields[] = $child;
+                continue;
+            }
+
+            foreach ($this->processFieldChildren($child->getChildren()) as $nestedChild) {
+                $fields[] = $nestedChild;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/DataObject/Data/Adapter/LocalizedFieldsAdapter.php
+++ b/src/DataObject/Data/Adapter/LocalizedFieldsAdapter.php
@@ -315,6 +315,7 @@ final readonly class LocalizedFieldsAdapter implements
         foreach ($children as $child) {
             if (!$child instanceof Layout) {
                 $fields[] = $child;
+
                 continue;
             }
 

--- a/src/DataObject/Data/Adapter/RgbaColorAdapter.php
+++ b/src/DataObject/Data/Adapter/RgbaColorAdapter.php
@@ -41,7 +41,9 @@ final readonly class RgbaColorAdapter implements SetterDataInterface, DataNormal
         ?FieldContextData $contextData = null,
         bool $isPatch = false
     ): ?RgbaColor {
-
+        if (!is_string($data[$key])) {
+            return null;
+        }
         $colorData = trim($data[$key], '# ');
         [$r, $g, $b, $a] = sscanf($colorData, '%02x%02x%02x%02x');
 

--- a/src/DataObject/Data/Adapter/RgbaColorAdapter.php
+++ b/src/DataObject/Data/Adapter/RgbaColorAdapter.php
@@ -25,6 +25,7 @@ use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Data\RgbaColor;
 use Pimcore\Model\UserInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use function is_string;
 
 /**
  * @internal


### PR DESCRIPTION
## Changes in this pull request
Resolves #847
Resolves #846

## Additional info
- color adapter should process only string values, otherwise set null
- localized fields can have nested layouts so we need to loop iteratively till we find all field definitions  