### PR TITLE
[Task] Update cache after user save

### DIFF
--- a/src/Security/Voter/UserPermissionVoter.php
+++ b/src/Security/Voter/UserPermissionVoter.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\StaticResolverBundle\Db\DbResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Lib\CacheResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\CacheKeys;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use function in_array;
@@ -32,8 +33,6 @@ use function sprintf;
  */
 final class UserPermissionVoter extends Voter
 {
-    private const USER_PERMISSIONS_CACHE_KEY = 'studio_backend_user_permissions';
-
     private array $userPermissions;
 
     public function __construct(
@@ -70,7 +69,7 @@ final class UserPermissionVoter extends Voter
      */
     private function getUserPermissions(): void
     {
-        $userPermissions = $this->cacheResolver->load(self::USER_PERMISSIONS_CACHE_KEY);
+        $userPermissions = $this->cacheResolver->load(CacheKeys::USER_PERMISSIONS->value);
 
         if ($userPermissions !== false && is_array($userPermissions)) {
             $this->userPermissions = $userPermissions;
@@ -82,7 +81,7 @@ final class UserPermissionVoter extends Voter
 
         $this->cacheResolver->save(
             $userPermissions,
-            self::USER_PERMISSIONS_CACHE_KEY
+            CacheKeys::USER_PERMISSIONS->value
         );
 
         $this->userPermissions = $userPermissions;

--- a/src/User/Service/UserUpdateService.php
+++ b/src/User/Service/UserUpdateService.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\User\Service;
 
 use JsonException;
+use Pimcore\Bundle\StaticResolverBundle\Lib\CacheResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Lib\Tools\Authentication\AuthenticationResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
@@ -28,6 +29,7 @@ use Pimcore\Bundle\StudioBackendBundle\User\MappedParameter\UpdatePasswordParame
 use Pimcore\Bundle\StudioBackendBundle\User\MappedParameter\UpdateUserParameter;
 use Pimcore\Bundle\StudioBackendBundle\User\Repository\UserRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Schema\KeyBinding;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\CacheKeys;
 use function sprintf;
 use function strlen;
 
@@ -40,7 +42,8 @@ final class UserUpdateService implements UserUpdateServiceInterface
         private readonly UserRepositoryInterface $userRepository,
         private readonly SecurityServiceInterface $securityService,
         private readonly UpdateServiceInterface $updateService,
-        private readonly AuthenticationResolverInterface $authenticationResolver
+        private readonly AuthenticationResolverInterface $authenticationResolver,
+        private readonly CacheResolverInterface $cacheResolver,
     ) {
     }
 
@@ -88,6 +91,9 @@ final class UserUpdateService implements UserUpdateServiceInterface
         $user = $this->updateService->updateDocumentWorkspaces($updateUserParameter->getDocumentWorkspaces(), $user);
 
         $this->userRepository->updateUser($user);
+
+        $this->cacheResolver->remove(CacheKeys::USER_PERMISSIONS->value);
+
     }
 
     /**

--- a/src/Util/Constant/CacheKeys.php
+++ b/src/Util/Constant/CacheKeys.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Util\Constant;
+
+enum CacheKeys: string
+{
+    case USER_PERMISSIONS = 'studio_backend_user_permissions';
+}

--- a/src/Util/Constant/CacheKeys.php
+++ b/src/Util/Constant/CacheKeys.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * Pimcore
  *
@@ -9,8 +10,8 @@ declare(strict_types=1);
  * Full copyright and license information is available in
  * LICENSE.md which is distributed with this source code.
  *
- * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
- * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
 namespace Pimcore\Bundle\StudioBackendBundle\Util\Constant;


### PR DESCRIPTION
## Changes in this pull request
Resolves #873 

## Additional info
Introducing enum cache keys and removing permissions from cache if user is saved