### PR TITLE
[Task] Return null if parent does not have field definition

### DIFF
--- a/src/DataObject/Util/Trait/ValidateObjectDataTrait.php
+++ b/src/DataObject/Util/Trait/ValidateObjectDataTrait.php
@@ -38,9 +38,6 @@ trait ValidateObjectDataTrait
         return !($fieldDefinition instanceof EncryptedFieldDefinition && (!$value instanceof EncryptedField));
     }
 
-    /**
-     * @throws NotFoundException
-     */
     private function getValidFieldValue(
         Concrete $object,
         string $key,
@@ -53,7 +50,12 @@ trait ValidateObjectDataTrait
 
             return $object->get($key, $contextData?->getLanguage());
         } catch (Exception) {
-            throw new NotFoundException(type: 'field', id: $key);
+            /*
+                do not throw exception, in case only the child element has e.g. an object brick and the parent does not
+                this might lead to an unwanted side effect that you cannot load the child element anymore
+                See ticket https://github.com/pimcore/studio-backend-bundle/issues/879
+            */
+            return null;
         }
     }
 


### PR DESCRIPTION
## Changes in this pull request
Resolves #879

## Additional info
Do not throw an exception if field definition is not found in case only the child element has e.g. the object brick but the parent does not.