### PR TITLE
[Grid] [Data Objects] Use original column key from request

### DIFF
--- a/src/Grid/Column/Resolver/DataObject/ObjectBrickResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/ObjectBrickResolver.php
@@ -71,16 +71,8 @@ final class ObjectBrickResolver implements ColumnResolverInterface, CoreElementC
         $classDefinition = $this->classDefinitionResolver->getById($element->getClassId());
         $fieldDefinition = $this->getFieldDefinition($objectBrickKey->getField(), $classDefinition);
 
-        $column = new Column(
-            key: $objectBrickKey->getField(),
-            locale: $column->getLocale(),
-            type: $column->getType(),
-            group: $column->getGroup(),
-            config: $column->getConfig(),
-        );
-
         $value = $this->dataService->getNormalizedValue(
-            $this->getLocalizedValue($column, $element),
+            $this->getLocalizedValueFromKey($objectBrickKey->getField(), $column->getLocale(), $element),
             $fieldDefinition
         );
 


### PR DESCRIPTION
## Changes in this pull request
Use original column key and not the internal. 

## Additional info
