### PR TITLE
[Task] $iconPath can be null and empty.

### DIFF
--- a/src/Icon/Service/IconService.php
+++ b/src/Icon/Service/IconService.php
@@ -111,7 +111,8 @@ final readonly class IconService implements IconServiceInterface
     public function getIconForClassDefinition(?string $iconPath): ElementIcon
     {
         $type = ElementIconTypes::PATH->value;
-        if ($iconPath === null) {
+        // $iconPath can be null and empty string
+        if (empty($iconPath)) {
             $type = ElementIconTypes::NAME->value;
             $iconPath = 'class';
         }


### PR DESCRIPTION
## Changes in this pull request
Resolves #893 

## Additional info
Fix check for $iconPath since it can be null and an empty string.
