### PR TITLE
Fix double array

### DIFF
--- a/src/Translation/Schema/Translation.php
+++ b/src/Translation/Schema/Translation.php
@@ -39,7 +39,7 @@ final readonly class Translation
         #[Property(description: 'Keys', type: 'array', items: new Items(
             type: 'string', example: 'not_your_typical_key'
         ))]
-        private array $keys = [PublicTranslations::PUBLIC_KEYS]
+        private array $keys = PublicTranslations::PUBLIC_KEYS
     ) {
     }
 


### PR DESCRIPTION
## Changes in this pull request
Since `PublicTranslations::PUBLIC_KEYS` is already an array I guess we do not need to nest it.
This would make the second param `keys` optional in the request ...

## Additional info
This pull request includes a small change to the `src/Translation/Schema/Translation.php` file. The change modifies the initialization of the `$keys` property to directly assign `PublicTranslations::PUBLIC_KEYS` instead of wrapping it in an array.

* [`src/Translation/Schema/Translation.php`](diffhunk://#diff-6e97ab719bae7ba40470c81408a0b9472566d10c7304ab282e4c3e16bdd0e667L42-R42): Changed the initialization of the `$keys` property to directly assign `PublicTranslations::PUBLIC_KEYS` instead of wrapping it in an array.