### PR TITLE
[Data Object Editor] Consider doDelete when getting brick data

### DIFF
--- a/src/DataObject/Data/Adapter/ObjectBricksAdapter.php
+++ b/src/DataObject/Data/Adapter/ObjectBricksAdapter.php
@@ -100,22 +100,22 @@ final readonly class ObjectBricksAdapter implements
         }
 
         $resultItems = [];
-        $items = $value->getObjectVars();
-        foreach ($items as $item) {
+        $allowedTypes = $value->getAllowedBrickTypes();
+        foreach ($allowedTypes as $type) {
+            $resultItems[$type] = null;
+            $item = $value->get($type);
+
             if (!$item instanceof AbstractData) {
                 continue;
             }
 
-            $type = $item->getType();
-            $resultItems[$type] = [];
             $definition = $this->definitionResolver->getByKey($type);
             if ($definition === null) {
                 continue;
             }
 
             foreach ($definition->getFieldDefinitions() as $brickFieldDefinition) {
-                $getter = 'get' . ucfirst($brickFieldDefinition->getName());
-                $value = $item->$getter();
+                $value = $item->get($brickFieldDefinition->getName());
                 $resultItems[$type][$brickFieldDefinition->getName()] = $this->dataService->getNormalizedValue(
                     $value,
                     $brickFieldDefinition,
@@ -139,8 +139,7 @@ final readonly class ObjectBricksAdapter implements
 
         $inheritanceData = [];
         foreach ($value->getAllowedBrickTypes() as $type) {
-            $brickGetter = 'get' . $type;
-            $brick = $value->$brickGetter();
+            $brick = $value->get($type);
             if (!$brick) {
                 continue;
             }
@@ -175,24 +174,28 @@ final readonly class ObjectBricksAdapter implements
             return $data;
         }
 
-        $items = $value->getObjectVars();
-        foreach ($items as $item) {
+        $allowedTypes = $value->getAllowedBrickTypes();
+        foreach ($allowedTypes as $type) {
+            $item = $value->get($type);
             if (!$item instanceof AbstractData) {
+                $data[$type] = null;
                 continue;
             }
 
-            $type = $item->getType();
-            $brickName = ucfirst($type);
             $definition = $this->definitionResolver->getByKey($type);
             if ($definition === null) {
+                $data[$type] = null;
                 continue;
             }
 
             foreach ($definition->getFieldDefinitions() as $brickFieldDefinition) {
-                $getter = 'get' . ucfirst($brickFieldDefinition->getName());
-                $fieldValues = $this->dataService->getPreviewFieldData($item->$getter(), $brickFieldDefinition, []);
+                $fieldValues = $this->dataService->getPreviewFieldData(
+                    $item->get($brickFieldDefinition->getName()),
+                    $brickFieldDefinition,
+                    []
+                );
                 foreach ($fieldValues as $fieldKey => $fieldValue) {
-                    $data[$brickName . ' - ' . $fieldKey] = $fieldValue;
+                    $data[ucfirst($type) . ' - ' . $fieldKey] = $fieldValue;
                 }
 
             }

--- a/src/DataObject/Data/Adapter/ObjectBricksAdapter.php
+++ b/src/DataObject/Data/Adapter/ObjectBricksAdapter.php
@@ -179,12 +179,14 @@ final readonly class ObjectBricksAdapter implements
             $item = $value->get($type);
             if (!$item instanceof AbstractData) {
                 $data[$type] = null;
+
                 continue;
             }
 
             $definition = $this->definitionResolver->getByKey($type);
             if ($definition === null) {
                 $data[$type] = null;
+
                 continue;
             }
 

--- a/src/DataObject/Service/DataService.php
+++ b/src/DataObject/Service/DataService.php
@@ -109,12 +109,8 @@ final readonly class DataService implements DataServiceInterface
     /**
      * {@inheritdoc}
      */
-    public function getPreviewObjectData(DataObjectModel $dataObject): array
+    public function getPreviewObjectData(Concrete $dataObject): array
     {
-        if (!$dataObject instanceof Concrete) {
-            return [];
-        }
-
         $class = $this->getValidClass($this->classDefinitionResolver, $dataObject->getClassId());
         $data = [];
         foreach ($class->getFieldDefinitions() as $key => $fieldDefinition) {

--- a/src/DataObject/Service/DataServiceInterface.php
+++ b/src/DataObject/Service/DataServiceInterface.php
@@ -50,7 +50,7 @@ interface DataServiceInterface
     /**
      * @throws DatabaseException|NotFoundException
      */
-    public function getPreviewObjectData(DataObjectModel $dataObject): array;
+    public function getPreviewObjectData(Concrete $dataObject): array;
 
     /**
      * @throws DatabaseException|NotFoundException

--- a/src/Search/Hydrator/Preview/DataObjectHydrator.php
+++ b/src/Search/Hydrator/Preview/DataObjectHydrator.php
@@ -18,6 +18,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\Search\Hydrator\Preview;
 
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Search\Schema\DataObjectSearchPreview;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityService;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Service\UserServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
 use Pimcore\Model\DataObject;
@@ -33,7 +35,8 @@ final readonly class DataObjectHydrator implements DataObjectHydratorInterface
 
     public function __construct(
         private DataServiceInterface $dataService,
-        private UserServiceInterface $userService
+        private SecurityServiceInterface $securityService,
+        private UserServiceInterface $userService,
     ) {
     }
 
@@ -54,8 +57,20 @@ final readonly class DataObjectHydrator implements DataObjectHydratorInterface
             $dataObject->getCreationDate(),
             $dataObject->getModificationDate(),
             $this->getClassData($dataObject),
-            $this->dataService->getPreviewObjectData($dataObject),
+            $this->hydratePreviewDetailData($dataObject),
         );
+    }
+
+    private function hydratePreviewDetailData(DataObject $dataObject): array
+    {
+        $version = $this->getLatestVersionForUser($dataObject, $this->securityService->getCurrentUser());
+        $versionData = $this->getVersionData($dataObject, $version);
+
+        if (!$versionData instanceof Concrete) {
+            return [];
+        }
+
+        return $this->dataService->getPreviewObjectData($versionData);
     }
 
     private function getClassData(DataObject $dataObject): ?string

--- a/src/Search/Hydrator/Preview/DataObjectHydrator.php
+++ b/src/Search/Hydrator/Preview/DataObjectHydrator.php
@@ -18,7 +18,6 @@ namespace Pimcore\Bundle\StudioBackendBundle\Search\Hydrator\Preview;
 
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Search\Schema\DataObjectSearchPreview;
-use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityService;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Service\UserServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;


### PR DESCRIPTION
## Changes in this pull request
Resolves #889

## Additional info
When using a draft and deleting the brick, the brick itself is not deleted but rather flagged with doDelete. This is respected in the brick getter so this PR is using brick getters instead of object vars in order to stick to the default behavior.

Also adapts simple search preview to respect and unify the approach