### PR TITLE
Set properties as required

### DIFF
--- a/src/OpenApi/Schema/UserInformation.php
+++ b/src/OpenApi/Schema/UserInformation.php
@@ -28,7 +28,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
 #[Schema(
     title: 'User Information',
     description: 'Information about the user',
-    required: ['id', 'username', 'permissions', 'isAdmin'],
+    required: ['id', 'username', 'permissions', 'isAdmin', 'classes', 'docTypes'],
     type: 'object'
 )]
 final class UserInformation implements AdditionalAttributesInterface


### PR DESCRIPTION
## Changes in this pull request
Followup: https://github.com/pimcore/studio-backend-bundle/pull/913

## Additional info
This pull request includes an update to the `UserInformation` schema in the `src/OpenApi/Schema/UserInformation.php` file. The change adds two required fields to the schema definition.

Schema update:

* [`src/OpenApi/Schema/UserInformation.php`](diffhunk://#diff-d63c884c6a849d537c63b63b6c6e301c624450d10ca19f66b7e71095dda3780cL31-R31): Added `classes` and `docTypes` to the list of required fields in the `UserInformation` schema.
