### PR TITLE
[Perspectives] Integrate into user management

### DIFF
--- a/config/pimcore/default_perspective.yaml
+++ b/config/pimcore/default_perspective.yaml
@@ -53,3 +53,4 @@ studio_default_perspective:
   expandedLeft: "studio_document_tree_widget"
   expandedRight: null
   contextPermissions: []
+  isWriteable: false

--- a/config/users.yaml
+++ b/config/users.yaml
@@ -35,6 +35,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\User\Service\UserPermissionServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\User\Service\UserPermissionService
 
+  Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveService
+
   Pimcore\Bundle\StudioBackendBundle\User\Service\WorkspaceCloneServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\User\Service\WorkspaceCloneService
 
@@ -49,8 +52,6 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\User\Service\ImageServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\User\Service\ImageService
-
-
 
   Pimcore\Bundle\StudioBackendBundle\User\Service\MailServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\User\Service\MailService
@@ -95,3 +96,8 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\User\Repository\PermissionRepositoryInterface:
     class: Pimcore\Bundle\StudioBackendBundle\User\Repository\PermissionRepository
+
+  Pimcore\Bundle\StudioBackendBundle\User\Repository\PerspectiveRepositoryInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\User\Repository\PerspectiveRepository
+    arguments:
+      - "@doctrine.orm.studio_backend_entity_manager"

--- a/src/Element/Controller/GetIdByPathController.php
+++ b/src/Element/Controller/GetIdByPathController.php
@@ -85,7 +85,7 @@ final class GetIdByPathController extends AbstractApiController
 
         return $this->jsonResponse(
             [
-                'id' => $this->elementService->getElementIdByPath(
+                'id' => $this->elementService->getAllowedElementIdByPath(
                     (new MappedElementTypeParameter($elementType))->getType(),
                     $pathParameter,
                     $this->securityService->getCurrentUser()

--- a/src/Element/Service/ElementService.php
+++ b/src/Element/Service/ElementService.php
@@ -62,9 +62,21 @@ final readonly class ElementService implements ElementServiceInterface
     }
 
     /**
-     * @throws ForbiddenException|NotFoundException
+     * @throws NotFoundException
      */
     public function getElementIdByPath(
+        string $elementType,
+        PathParameter $pathParameter,
+        UserInterface $user
+    ): int {
+
+        return $this->getElementByPath($this->serviceResolver, $elementType, $pathParameter->getPath())->getId();
+    }
+
+    /**
+     * @throws ForbiddenException|NotFoundException
+     */
+    public function getAllowedElementIdByPath(
         string $elementType,
         PathParameter $pathParameter,
         UserInterface $user

--- a/src/Element/Service/ElementServiceInterface.php
+++ b/src/Element/Service/ElementServiceInterface.php
@@ -35,9 +35,18 @@ use Pimcore\Model\UserInterface;
 interface ElementServiceInterface
 {
     /**
-     * @throws ForbiddenException|NotFoundException
+     * @throws NotFoundException
      */
     public function getElementIdByPath(
+        string $elementType,
+        PathParameter $pathParameter,
+        UserInterface $user
+    ): int;
+
+    /**
+     * @throws ForbiddenException|NotFoundException
+     */
+    public function getAllowedElementIdByPath(
         string $elementType,
         PathParameter $pathParameter,
         UserInterface $user

--- a/src/Entity/Perspective/UserPerspectiveData.php
+++ b/src/Entity/Perspective/UserPerspectiveData.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Entity\Perspective;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @internal
+ */
+#[ORM\Entity]
+#[ORM\Table(name: UserPerspectiveData::TABLE_NAME)]
+class UserPerspectiveData
+{
+    public const string TABLE_NAME = 'bundle_studio_perspectives_user_perspectives';
+
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    private int $user;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    private ?string $perspectives = null;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    private ?string $activePerspective = null;
+
+    public function getUser(): int
+    {
+        return $this->user;
+    }
+
+    public function setUser(int $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function getPerspectives(): ?string
+    {
+        return $this->perspectives;
+    }
+
+    public function setPerspectives(?string $perspectives): void
+    {
+        $this->perspectives = $perspectives;
+    }
+
+    public function getActivePerspective(): ?string
+    {
+        return $this->activePerspective;
+    }
+
+    public function setActivePerspective(?string $activePerspective): void
+    {
+        $this->activePerspective = $activePerspective;
+    }
+}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -25,6 +25,7 @@ use Doctrine\DBAL\Schema\SchemaException;
 use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfigurationFavorite;
 use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfigurationShare;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Perspective\UserPerspectiveData;
 use Pimcore\Bundle\StudioBackendBundle\Translation\Service\TranslatorService;
 use Pimcore\Extension\Bundle\Installer\Exception\InstallationException;
 use Pimcore\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
@@ -53,6 +54,7 @@ final class Installer extends SettingsStoreAwareInstaller
         $this->createGridConfigurationTable($schema);
         $this->createGridConfigurationSharesTable($schema);
         $this->createGridConfigurationFavoritesTable($schema);
+        $this->createUserPerspectivesTable($schema);
         $this->executeDiffSql($schema);
 
         parent::install();
@@ -76,6 +78,10 @@ final class Installer extends SettingsStoreAwareInstaller
 
         if ($schema->hasTable(GridConfigurationFavorite::TABLE_NAME)) {
             $schema->dropTable(GridConfigurationFavorite::TABLE_NAME);
+        }
+
+        if ($schema->hasTable(UserPerspectiveData::TABLE_NAME)) {
+            $schema->dropTable(UserPerspectiveData::TABLE_NAME);
         }
 
         $this->executeDiffSql($schema);
@@ -289,6 +295,43 @@ final class Installer extends SettingsStoreAwareInstaller
             ['onDelete' => 'CASCADE'],
             'fk_'.GridConfiguration::TABLE_NAME.'_assetFolderId_id'
         );
+    }
+
+    /**
+     * @throws SchemaException
+     */
+    public function createUserPerspectivesTable(Schema $schema): void
+    {
+        if ($schema->hasTable(UserPerspectiveData::TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schema->createTable(UserPerspectiveData::TABLE_NAME);
+
+        $table->addColumn(
+            'user',
+            'integer',
+            ['notnull' => true, 'unsigned' => true]
+        );
+
+        $table->addColumn('perspectives', 'text', [
+            'notnull' => false
+        ]);
+
+        $table->addColumn('activePerspective', 'string', [
+            'notnull' => false,
+            'length' => 255,
+        ]);
+
+        $table->addForeignKeyConstraint(
+            'users',
+            ['user'],
+            ['id'],
+            ['onDelete' => 'CASCADE'],
+            'fk_' . UserPerspectiveData::TABLE_NAME.'_users'
+        );
+
+        $table->setPrimaryKey(['user'], 'pk_' . UserPerspectiveData::TABLE_NAME);
     }
 
     /**

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -315,7 +315,7 @@ final class Installer extends SettingsStoreAwareInstaller
         );
 
         $table->addColumn('perspectives', 'text', [
-            'notnull' => false
+            'notnull' => false,
         ]);
 
         $table->addColumn('activePerspective', 'string', [

--- a/src/OpenApi/Schema/UserInformation.php
+++ b/src/OpenApi/Schema/UserInformation.php
@@ -19,6 +19,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\OpenApi\Schema;
 use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
 
@@ -28,7 +30,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
 #[Schema(
     title: 'User Information',
     description: 'Information about the user',
-    required: ['id', 'username', 'permissions', 'isAdmin', 'classes', 'docTypes'],
+    required: ['id', 'username', 'permissions', 'isAdmin', 'classes', 'docTypes', 'activePerspective', 'perspectives'],
     type: 'object'
 )]
 final class UserInformation implements AdditionalAttributesInterface
@@ -60,6 +62,18 @@ final class UserInformation implements AdditionalAttributesInterface
             items: new Items(type: 'string')
         )]
         private readonly array $docTypes,
+        #[Property(
+            description: 'Active studio perspective ID',
+            type: 'string',
+            example: Perspectives::DEFAULT_ID->value)
+        ]
+        private readonly ?string $activePerspective = null,
+        #[Property(
+            description: 'Allowed studio perspectives',
+            type: 'array',
+            items: new Items(ref: PerspectiveConfig::class))
+        ]
+        private readonly array $perspectives = [],
     ) {
     }
 
@@ -91,5 +105,18 @@ final class UserInformation implements AdditionalAttributesInterface
     public function getDocTypes(): array
     {
         return $this->docTypes;
+    }
+
+    public function getActivePerspective(): ?string
+    {
+        return $this->activePerspective;
+    }
+
+    /**
+     * @return PerspectiveConfig[]
+     */
+    public function getPerspectives(): array
+    {
+        return $this->perspectives;
     }
 }

--- a/src/Perspective/Service/PerspectiveService.php
+++ b/src/Perspective/Service/PerspectiveService.php
@@ -107,13 +107,18 @@ final readonly class PerspectiveService implements PerspectiveServiceInterface
     {
         $perspectives = [];
         foreach ($this->configRepository->listConfigurations() as $configData) {
-            $hydrated = $this->configHydrator->hydrate($configData);
-            $this->dispatchEvent($hydrated);
-
-            $perspectives[] = $hydrated;
+            $perspectives[] = $this->hydrateListEntry($configData);
         }
 
         return $perspectives;
+    }
+
+    public function hydrateListEntry(array $configData): PerspectiveConfig
+    {
+        $hydrated = $this->configHydrator->hydrate($configData);
+        $this->dispatchEvent($hydrated);
+
+        return $hydrated;
     }
 
     /**

--- a/src/Perspective/Service/PerspectiveServiceInterface.php
+++ b/src/Perspective/Service/PerspectiveServiceInterface.php
@@ -52,6 +52,8 @@ interface PerspectiveServiceInterface
      */
     public function listConfigurations(): array;
 
+    public function hydrateListEntry(array $configData): PerspectiveConfig;
+
     /**
      * @throws NotWriteableException
      */

--- a/src/Role/Hydrator/RoleHydrator.php
+++ b/src/Role/Hydrator/RoleHydrator.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Role\Hydrator;
 
 use Pimcore\Bundle\StudioBackendBundle\Role\Schema\DetailedRole;
 use Pimcore\Bundle\StudioBackendBundle\User\Hydrator\WorkspaceHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\PermissionSanitationTrait;
 use Pimcore\Model\User\UserRoleInterface;
 
@@ -29,7 +30,8 @@ final readonly class RoleHydrator implements RoleHydratorInterface
     use PermissionSanitationTrait;
 
     public function __construct(
-        private WorkspaceHydratorInterface $workspaceHydrator
+        private WorkspaceHydratorInterface $workspaceHydrator,
+        private UserPerspectiveServiceInterface $userPerspectiveService
     ) {
     }
 
@@ -47,6 +49,7 @@ final readonly class RoleHydrator implements RoleHydratorInterface
             assetWorkspaces: $this->workspaceHydrator->hydrateAssetWorkspace($role),
             dataObjectWorkspaces: $this->workspaceHydrator->hydrateDataObjectWorkspace($role),
             documentWorkspaces: $this->workspaceHydrator->hydrateDocumentWorkspace($role),
+            perspectives: $this->userPerspectiveService->getConfigPerspectives($role),
         );
     }
 }

--- a/src/Role/MappedParameter/UpdateRoleParameter.php
+++ b/src/Role/MappedParameter/UpdateRoleParameter.php
@@ -35,6 +35,7 @@ final readonly class UpdateRoleParameter
         private array $assetWorkspaces,
         private array $dataObjectWorkspaces,
         private array $documentWorkspaces,
+        private array $perspectives,
     ) {
     }
 
@@ -90,5 +91,13 @@ final readonly class UpdateRoleParameter
     public function getDocumentWorkspaces(): array
     {
         return $this->documentWorkspaces;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPerspectives(): array
+    {
+        return $this->perspectives;
     }
 }

--- a/src/Role/Schema/DetailedRole.php
+++ b/src/Role/Schema/DetailedRole.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Role\Schema;
 use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
 use Pimcore\Bundle\StudioBackendBundle\User\Schema\UserWorkspace;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
@@ -38,6 +39,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
         'assetWorkspaces',
         'dataObjectWorkspaces',
         'documentWorkspaces',
+        'perspectives'
     ],
     type: 'object'
 )]
@@ -68,6 +70,12 @@ final class DetailedRole implements AdditionalAttributesInterface
         private readonly array $dataObjectWorkspaces,
         #[Property(description: 'Document Workspace', type: 'array', items: new Items(ref: UserWorkspace::class))]
         private readonly array $documentWorkspaces,
+        #[Property(
+            description: 'Allowed studio perspectives',
+            type: 'array',
+            items: new Items(ref: PerspectiveConfig::class))
+        ]
+        private readonly array $perspectives = [],
     ) {
     }
 
@@ -133,5 +141,13 @@ final class DetailedRole implements AdditionalAttributesInterface
     public function getDocTypes(): array
     {
         return $this->docTypes;
+    }
+
+    /**
+     * @return PerspectiveConfig[]
+     */
+    public function getPerspectives(): array
+    {
+        return $this->perspectives;
     }
 }

--- a/src/Role/Schema/DetailedRole.php
+++ b/src/Role/Schema/DetailedRole.php
@@ -39,7 +39,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
         'assetWorkspaces',
         'dataObjectWorkspaces',
         'documentWorkspaces',
-        'perspectives'
+        'perspectives',
     ],
     type: 'object'
 )]

--- a/src/Role/Schema/UpdateRole.php
+++ b/src/Role/Schema/UpdateRole.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Role\Schema;
 use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
 use Pimcore\Bundle\StudioBackendBundle\User\Schema\UserWorkspace;
 
 #[Schema(
@@ -35,6 +36,7 @@ use Pimcore\Bundle\StudioBackendBundle\User\Schema\UserWorkspace;
         'assetWorkspaces',
         'dataObjectWorkspaces',
         'documentWorkspaces',
+        'perspectives'
     ],
     type: 'object'
 )]
@@ -61,6 +63,12 @@ final readonly class UpdateRole
         private array $dataObjectWorkspaces,
         #[Property(description: 'Document Workspace', type: 'array', items: new Items(ref: UserWorkspace::class))]
         private array $documentWorkspaces,
+        #[Property(
+            description: 'Allowed studio perspectives',
+            type: 'object',
+            example: [Perspectives::DEFAULT_ID->value, 'some_otherPerspective_Id']
+        )]
+        private array $perspectives = [],
     ) {
     }
 
@@ -121,5 +129,13 @@ final readonly class UpdateRole
     public function getDocTypes(): array
     {
         return $this->docTypes;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPerspectives(): array
+    {
+        return $this->perspectives;
     }
 }

--- a/src/Role/Schema/UpdateRole.php
+++ b/src/Role/Schema/UpdateRole.php
@@ -36,7 +36,7 @@ use Pimcore\Bundle\StudioBackendBundle\User\Schema\UserWorkspace;
         'assetWorkspaces',
         'dataObjectWorkspaces',
         'documentWorkspaces',
-        'perspectives'
+        'perspectives',
     ],
     type: 'object'
 )]

--- a/src/Role/Service/RoleService.php
+++ b/src/Role/Service/RoleService.php
@@ -186,6 +186,7 @@ final readonly class RoleService implements RoleServiceInterface
             $role
         );
         $role = $this->updateService->updateDocumentWorkspaces($updateRoleParameter->getDocumentWorkspaces(), $role);
+        $role = $this->updateService->updatePerspectives($updateRoleParameter->getPerspectives(), $role);
 
         $this->roleRepository->updateRole($role);
     }

--- a/src/Security/Voter/UserPerspectiveVoter.php
+++ b/src/Security/Voter/UserPerspectiveVoter.php
@@ -20,7 +20,9 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NoRequestException;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\PerspectivePermissions;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\RequestTrait;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -37,7 +39,8 @@ final class UserPerspectiveVoter extends Voter
 
     public function __construct(
         private readonly RequestStack $requestStack,
-        private readonly SecurityServiceInterface $securityService
+        private readonly SecurityServiceInterface $securityService,
+        private readonly UserPerspectiveServiceInterface $userPerspectiveService
     ) {
     }
 
@@ -54,13 +57,14 @@ final class UserPerspectiveVoter extends Voter
      */
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
-        $perspectiveId = $this->getPerspectiveFromRequest();
-        if ($perspectiveId === Perspectives::DEFAULT_ID->value) {
+        $user = $this->securityService->getCurrentUser();
+        if ($user->isAllowed(UserPermissions::PERSPECTIVE_EDITOR->value)) {
             return true;
         }
-        $user = $this->securityService->getCurrentUser();
 
-        return in_array($perspectiveId, $user->getPerspectives(), true);
+        $this->userPerspectiveService->validatePerspectiveAccess($user, $this->getPerspectiveFromRequest());
+
+        return true;
     }
 
     /**

--- a/src/Security/Voter/UserPerspectiveVoter.php
+++ b/src/Security/Voter/UserPerspectiveVoter.php
@@ -18,7 +18,6 @@ namespace Pimcore\Bundle\StudioBackendBundle\Security\Voter;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NoRequestException;
-use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\PerspectivePermissions;
@@ -28,7 +27,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
-use function in_array;
 
 /**
  * @internal

--- a/src/User/Controller/UpdateActivePerspectiveController.php
+++ b/src/User/Controller/UpdateActivePerspectiveController.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\User\Controller;
+
+use OpenApi\Attributes\Put;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotWriteableException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\StringParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UserUpdateServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class UpdateActivePerspectiveController extends AbstractApiController
+{
+    private const string ROUTE = '/user/active-perspective/{perspectiveId}';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly UserUpdateServiceInterface $userUpdateService
+    ) {
+        parent::__construct($serializer);
+    }
+
+    /**
+     * @throws ForbiddenException|NotFoundException|NotWriteableException|UserNotFoundException
+     */
+    #[Route(self::ROUTE, name: 'pimcore_studio_api_user_active_perspective_update', methods: ['PUT'])]
+    #[Put(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'user_update_active_perspective',
+        summary: 'user_update_active_perspective_summary',
+        tags: [Tags::User->value]
+    )]
+    #[StringParameter('perspectiveId', 'd061699e_da42_4075_b504_c2c93c687819', 'Set active perspective by Id')]
+    #[SuccessResponse(description: 'user_update_active_perspective_success_response')]
+    #[DefaultResponses([
+        HttpResponseCodes::FORBIDDEN,
+        HttpResponseCodes::INTERNAL_SERVER_ERROR,
+        HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::UNAUTHORIZED,
+    ])]
+    public function updateActivePerspective(string $perspectiveId): Response
+    {
+        $this->userUpdateService->updateActivePerspective($perspectiveId);
+
+        return new Response();
+    }
+}

--- a/src/User/Hydrator/UserHydrator.php
+++ b/src/User/Hydrator/UserHydrator.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\StaticResolverBundle\Lib\ToolResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Lib\Tools\AdminResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Schema\User as UserSchema;
 use Pimcore\Bundle\StudioBackendBundle\User\Service\ObjectDependenciesServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\PermissionSanitationTrait;
 use Pimcore\Model\User;
 use Pimcore\Model\UserInterface;
@@ -40,6 +41,7 @@ final readonly class UserHydrator implements UserHydratorInterface
         private WorkspaceHydratorInterface $workspaceHydrator,
         private ObjectDependenciesServiceInterface $objectDependenciesService,
         private KeyBindingHydratorInterface $keyBindingHydrator,
+        private UserPerspectiveServiceInterface $userPerspectiveService
     ) {
     }
 
@@ -74,6 +76,7 @@ final readonly class UserHydrator implements UserHydratorInterface
             dataObjectWorkspaces: $this->workspaceHydrator->hydrateDataObjectWorkspace($user),
             documentWorkspaces: $this->workspaceHydrator->hydrateDocumentWorkspace($user),
             objectDependencies: $this->objectDependenciesService->getDependenciesForUser($user),
+            perspectives: $this->userPerspectiveService->getConfigPerspectives($user),
         );
     }
 

--- a/src/User/Hydrator/UserInformationHydrator.php
+++ b/src/User/Hydrator/UserInformationHydrator.php
@@ -25,7 +25,8 @@ use Pimcore\Model\UserInterface;
  */
 final readonly class UserInformationHydrator implements UserInformationHydratorInterface
 {
-    public function __construct(private UserPerspectiveServiceInterface $userPerspectiveService) {
+    public function __construct(private UserPerspectiveServiceInterface $userPerspectiveService)
+    {
     }
 
     public function hydrate(UserInterface $user): UserInformation

--- a/src/User/Hydrator/UserInformationHydrator.php
+++ b/src/User/Hydrator/UserInformationHydrator.php
@@ -17,13 +17,17 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\User\Hydrator;
 
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Schema\UserInformation;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveServiceInterface;
 use Pimcore\Model\UserInterface;
 
 /**
  * @internal
  */
-final class UserInformationHydrator implements UserInformationHydratorInterface
+final readonly class UserInformationHydrator implements UserInformationHydratorInterface
 {
+    public function __construct(private UserPerspectiveServiceInterface $userPerspectiveService) {
+    }
+
     public function hydrate(UserInterface $user): UserInformation
     {
         return new UserInformation(
@@ -32,7 +36,9 @@ final class UserInformationHydrator implements UserInformationHydratorInterface
             $user->getPermissions(),
             $user->isAdmin(),
             $user->getClasses(),
-            $user->getDocTypes()
+            $user->getDocTypes(),
+            $this->userPerspectiveService->getActivePerspective($user),
+            $this->userPerspectiveService->getAllowedPerspectives($user),
         );
     }
 }

--- a/src/User/MappedParameter/UpdateUserParameter.php
+++ b/src/User/MappedParameter/UpdateUserParameter.php
@@ -52,6 +52,7 @@ final readonly class UpdateUserParameter
         private array $assetWorkspaces,
         private array $dataObjectWorkspaces,
         private array $documentWorkspaces,
+        private array $perspectives = [],
     ) {
     }
 
@@ -175,5 +176,13 @@ final readonly class UpdateUserParameter
     public function getDocumentWorkspaces(): array
     {
         return $this->documentWorkspaces;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPerspectives(): array
+    {
+        return $this->perspectives;
     }
 }

--- a/src/User/Repository/PerspectiveRepository.php
+++ b/src/User/Repository/PerspectiveRepository.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\User\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Perspective\UserPerspectiveData;
+
+/**
+ * @internal
+ */
+final readonly class PerspectiveRepository implements PerspectiveRepositoryInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager
+    ) {
+    }
+
+    public function update(UserPerspectiveData $userPerspectives): UserPerspectiveData
+    {
+        $this->entityManager->persist($userPerspectives);
+        $this->entityManager->flush();
+
+        return $userPerspectives;
+    }
+
+    public function getByUser(int $user): ?UserPerspectiveData
+    {
+        return $this->entityManager->getRepository(UserPerspectiveData::class)
+            ->findOneBy(['user' => $user]);
+    }
+
+    public function getUserActivePerspective(int $user): ?string {
+
+        return $this->getByUser($user)?->getActivePerspective();
+    }
+
+    public function listUserPerspectives(int $user): array {
+        $perspectives = $this->getByUser($user)?->getPerspectives();
+
+        return $perspectives ? explode(',', $perspectives) : [];
+    }
+}

--- a/src/User/Repository/PerspectiveRepository.php
+++ b/src/User/Repository/PerspectiveRepository.php
@@ -43,12 +43,14 @@ final readonly class PerspectiveRepository implements PerspectiveRepositoryInter
             ->findOneBy(['user' => $user]);
     }
 
-    public function getUserActivePerspective(int $user): ?string {
+    public function getUserActivePerspective(int $user): ?string
+    {
 
         return $this->getByUser($user)?->getActivePerspective();
     }
 
-    public function listUserPerspectives(int $user): array {
+    public function listUserPerspectives(int $user): array
+    {
         $perspectives = $this->getByUser($user)?->getPerspectives();
 
         return $perspectives ? explode(',', $perspectives) : [];

--- a/src/User/Repository/PerspectiveRepositoryInterface.php
+++ b/src/User/Repository/PerspectiveRepositoryInterface.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\User\Repository;
+
+use Pimcore\Bundle\StudioBackendBundle\Entity\Perspective\UserPerspectiveData;
+
+/**
+ * @internal
+ */
+interface PerspectiveRepositoryInterface
+{
+    public function update(UserPerspectiveData $userPerspectives): UserPerspectiveData;
+
+    public function getByUser(int $user): ?UserPerspectiveData;
+
+    public function getUserActivePerspective(int $user): ?string;
+
+    /**
+     * @return string[]
+     */
+    public function listUserPerspectives(int $user): array;
+}

--- a/src/User/Schema/UpdateUser.php
+++ b/src/User/Schema/UpdateUser.php
@@ -19,7 +19,6 @@ namespace Pimcore\Bundle\StudioBackendBundle\User\Schema;
 use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
-use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
 
 /**
@@ -32,7 +31,7 @@ use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
         'active', 'classes', 'closeWarning', 'allowDirtyClose', 'contentLanguages', 'keyBindings',
         'language', 'memorizeTabs', 'parentId', 'permissions', 'roles', 'twoFactorAuthenticationEnabled',
         'websiteTranslationLanguagesEdit', 'websiteTranslationLanguagesView', 'welcomeScreen',
-        'assetWorkspaces', 'dataObjectWorkspaces', 'documentWorkspaces', 'perspectives'
+        'assetWorkspaces', 'dataObjectWorkspaces', 'documentWorkspaces', 'perspectives',
     ],
     type: 'object'
 )]

--- a/src/User/Schema/UpdateUser.php
+++ b/src/User/Schema/UpdateUser.php
@@ -19,6 +19,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\User\Schema;
 use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
 
 /**
  * @internal
@@ -30,7 +32,7 @@ use OpenApi\Attributes\Schema;
         'active', 'classes', 'closeWarning', 'allowDirtyClose', 'contentLanguages', 'keyBindings',
         'language', 'memorizeTabs', 'parentId', 'permissions', 'roles', 'twoFactorAuthenticationEnabled',
         'websiteTranslationLanguagesEdit', 'websiteTranslationLanguagesView', 'welcomeScreen',
-        'assetWorkspaces', 'dataObjectWorkspaces', 'documentWorkspaces',
+        'assetWorkspaces', 'dataObjectWorkspaces', 'documentWorkspaces', 'perspectives'
     ],
     type: 'object'
 )]
@@ -85,6 +87,12 @@ final readonly class UpdateUser
         private array $dataObjectWorkspaces,
         #[Property(description: 'Document Workspace', type: 'array', items: new Items(ref: UserWorkspace::class))]
         private array $documentWorkspaces,
+        #[Property(
+            description: 'Allowed studio perspectives',
+            type: 'object',
+            example: [Perspectives::DEFAULT_ID->value, 'some_otherPerspective_Id']
+        )]
+        private array $perspectives = [],
     ) {
     }
 
@@ -208,5 +216,13 @@ final readonly class UpdateUser
     public function getDocumentWorkspaces(): array
     {
         return $this->documentWorkspaces;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPerspectives(): array
+    {
+        return $this->perspectives;
     }
 }

--- a/src/User/Schema/User.php
+++ b/src/User/Schema/User.php
@@ -19,6 +19,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\User\Schema;
 use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
 
@@ -30,6 +32,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
         'keyBindings', 'language', 'memorizeTabs', 'parentId', 'permissions', 'roles',
         'twoFactorAuthenticationEnabled', 'websiteTranslationLanguagesEdit', 'websiteTranslationLanguagesView',
         'welcomeScreen', 'assetWorkspaces', 'dataObjectWorkspaces', 'documentWorkspaces', 'objectDependencies',
+        'perspectives'
     ],
     type: 'object'
 )]
@@ -96,6 +99,12 @@ final class User implements AdditionalAttributesInterface
         private readonly array $documentWorkspaces,
         #[Property(ref: ObjectDependencies::class, description: 'Object Dependencies', type: 'object')]
         private readonly ObjectDependencies $objectDependencies,
+        #[Property(
+            description: 'Allowed studio perspectives',
+            type: 'array',
+            items: new Items(ref: PerspectiveConfig::class))
+        ]
+        private readonly array $perspectives = [],
     ) {
     }
 
@@ -244,5 +253,13 @@ final class User implements AdditionalAttributesInterface
     public function getObjectDependencies(): ObjectDependencies
     {
         return $this->objectDependencies;
+    }
+
+    /**
+     * @return PerspectiveConfig[]
+     */
+    public function getPerspectives(): array
+    {
+        return $this->perspectives;
     }
 }

--- a/src/User/Schema/User.php
+++ b/src/User/Schema/User.php
@@ -20,7 +20,6 @@ use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
-use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
 
@@ -32,7 +31,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
         'keyBindings', 'language', 'memorizeTabs', 'parentId', 'permissions', 'roles',
         'twoFactorAuthenticationEnabled', 'websiteTranslationLanguagesEdit', 'websiteTranslationLanguagesView',
         'welcomeScreen', 'assetWorkspaces', 'dataObjectWorkspaces', 'documentWorkspaces', 'objectDependencies',
-        'perspectives'
+        'perspectives',
     ],
     type: 'object'
 )]

--- a/src/User/Service/UpdateService.php
+++ b/src/User/Service/UpdateService.php
@@ -18,10 +18,13 @@ namespace Pimcore\Bundle\StudioBackendBundle\User\Service;
 
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Perspective\UserPerspectiveData;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ParseException;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Repository\PerspectiveConfigRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Role\Repository\RoleRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Repository\PermissionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\User\Repository\PerspectiveRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Schema\UserWorkspace;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\User\UserRoleInterface;
@@ -42,6 +45,7 @@ final readonly class UpdateService implements UpdateServiceInterface
         private RoleRepositoryInterface $roleRepository,
         private ClassDefinitionRepositoryInterface $classDefinitionRepository,
         private ServiceResolverInterface $elementServiceResolver,
+        private UserPerspectiveServiceInterface $userPerspectiveService,
     ) {
     }
 
@@ -217,6 +221,22 @@ final readonly class UpdateService implements UpdateServiceInterface
 
         /** @var DocumentWorkspace[] $workspaces */
         $user->setWorkspacesDocument($workspaces);
+
+        return $user;
+    }
+
+    /**
+     * @template T of UserInterface|UserRoleInterface
+     *
+     * @param T $user
+     *
+     * @return T
+     */
+    public function updatePerspectives(
+        array $perspectivesToSet,
+        UserInterface|UserRoleInterface $user
+    ): UserInterface|UserRoleInterface {
+        $this->userPerspectiveService->updatePerspectives($perspectivesToSet, $user);
 
         return $user;
     }

--- a/src/User/Service/UpdateService.php
+++ b/src/User/Service/UpdateService.php
@@ -18,13 +18,10 @@ namespace Pimcore\Bundle\StudioBackendBundle\User\Service;
 
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
-use Pimcore\Bundle\StudioBackendBundle\Entity\Perspective\UserPerspectiveData;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ParseException;
-use Pimcore\Bundle\StudioBackendBundle\Perspective\Repository\PerspectiveConfigRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Role\Repository\RoleRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Repository\PermissionRepositoryInterface;
-use Pimcore\Bundle\StudioBackendBundle\User\Repository\PerspectiveRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Schema\UserWorkspace;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\User\UserRoleInterface;

--- a/src/User/Service/UpdateServiceInterface.php
+++ b/src/User/Service/UpdateServiceInterface.php
@@ -104,4 +104,16 @@ interface UpdateServiceInterface
         array $documentWorkspacesToSet,
         UserInterface|UserRoleInterface $user
     ): UserInterface|UserRoleInterface;
+
+    /**
+     * @template T of UserInterface|UserRoleInterface
+     *
+     * @param T $user
+     *
+     * @return T
+     */
+    public function updatePerspectives(
+        array $perspectivesToSet,
+        UserInterface|UserRoleInterface $user
+    ): UserInterface|UserRoleInterface;
 }

--- a/src/User/Service/UserPerspectiveService.php
+++ b/src/User/Service/UserPerspectiveService.php
@@ -27,6 +27,7 @@ use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
 use Pimcore\Bundle\StudioBackendBundle\User\Repository\PerspectiveRepositoryInterface;
 use Pimcore\Model\User\UserRoleInterface;
 use Pimcore\Model\UserInterface;
+use function sprintf;
 
 /**
  * @internal
@@ -154,12 +155,14 @@ final readonly class UserPerspectiveService implements UserPerspectiveServiceInt
 
         return array_values(array_unique($userPerspectives));
     }
+
     private function getAllPerspectiveIds(): array
     {
-        return array_map(static fn($perspective) => $perspective->getId(), $this->getAllPerspectives());
+        return array_map(static fn ($perspective) => $perspective->getId(), $this->getAllPerspectives());
     }
 
-    private function getAllPerspectives(): array {
+    private function getAllPerspectives(): array
+    {
         $defaultPerspective = $this->configRepository->getConfiguration(Perspectives::DEFAULT_ID->value);
         $allowedPerspectives[] = $this->perspectiveService->hydrateListEntry($defaultPerspective);
 

--- a/src/User/Service/UserPerspectiveService.php
+++ b/src/User/Service/UserPerspectiveService.php
@@ -1,0 +1,179 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\User\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Entity\Perspective\UserPerspectiveData;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotWriteableException;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Repository\PerspectiveConfigRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Service\PerspectiveServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
+use Pimcore\Bundle\StudioBackendBundle\User\Repository\PerspectiveRepositoryInterface;
+use Pimcore\Model\User\UserRoleInterface;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+final readonly class UserPerspectiveService implements UserPerspectiveServiceInterface
+{
+    public function __construct(
+        private PerspectiveRepositoryInterface $repository,
+        private PerspectiveConfigRepositoryInterface $configRepository,
+        private PerspectiveServiceInterface $perspectiveService,
+    ) {
+    }
+
+    /**
+     * @throws NotFoundException|NotWriteableException
+     *
+     * @return PerspectiveConfig[]
+     */
+    public function getAllowedPerspectives(UserInterface $user): array
+    {
+        $allowedPerspectives = [];
+        $userPerspectives = $this->getAllUserPerspectives($user);
+        if (empty($userPerspectives)) {
+            return $this->getAllPerspectives();
+        }
+
+        foreach ($userPerspectives as $userPerspective) {
+            $config = $this->configRepository->getConfiguration($userPerspective);
+            $allowedPerspectives[] = $this->perspectiveService->hydrateListEntry($config);
+        }
+
+        return $allowedPerspectives;
+    }
+
+    /**
+     * @throws NotFoundException|NotWriteableException
+     *
+     * @return PerspectiveConfig[]
+     */
+    public function getConfigPerspectives(UserInterface|UserRoleInterface $user): array
+    {
+        $allowedPerspectives = [];
+        $userPerspectives = $this->repository->listUserPerspectives($user->getId());
+
+        foreach ($userPerspectives as $userPerspective) {
+            $config = $this->configRepository->getConfiguration($userPerspective);
+            $allowedPerspectives[] = $this->perspectiveService->hydrateListEntry($config);
+        }
+
+        return $allowedPerspectives;
+    }
+
+    public function getActivePerspective(UserInterface $user): string
+    {
+        $activePerspective = $this->repository->getUserActivePerspective($user->getId());
+        $userPerspectives = $this->getAllUserPerspectives($user);
+        if (empty($userPerspectives)) {
+            $userPerspectives = $this->getAllPerspectiveIds();
+        }
+
+        $userPerspectivesSet = array_flip($userPerspectives);
+        if ($activePerspective !== null && isset($userPerspectivesSet[$activePerspective])) {
+            return $activePerspective;
+        }
+
+        return $userPerspectives[0];
+    }
+
+    /**
+     * @throws NotFoundException|NotWriteableException
+     */
+    public function updatePerspectives(
+        array $perspectivesToSet,
+        UserInterface|UserRoleInterface $user
+    ): void {
+        foreach ($perspectivesToSet as $perspectiveId) {
+            $this->configRepository->getConfiguration($perspectiveId);
+        }
+        $userPerspectiveData = $this->getPerspectiveData($user);
+        $userPerspectiveData->setPerspectives(implode(',', $perspectivesToSet));
+        $this->repository->update($userPerspectiveData);
+    }
+
+    /**
+     * @throws ForbiddenException|NotFoundException|NotWriteableException
+     */
+    public function updateActivePerspective(string $perspectiveId, UserInterface $user): void
+    {
+        $this->configRepository->getConfiguration($perspectiveId);
+        $this->validatePerspectiveAccess($user, $perspectiveId);
+        $userPerspectiveData = $this->getPerspectiveData($user);
+        $userPerspectiveData->setActivePerspective($perspectiveId);
+        $this->repository->update($userPerspectiveData);
+    }
+
+    /**
+     * @throws ForbiddenException
+     */
+    public function validatePerspectiveAccess(UserInterface $user, string $perspectiveId): void
+    {
+        $userPerspectives = $this->getAllUserPerspectives($user);
+        if (empty($userPerspectives)) {
+            $userPerspectives = $this->getAllPerspectiveIds();
+        }
+        $userPerspectivesSet = array_flip($userPerspectives);
+        if (!isset($userPerspectivesSet[$perspectiveId])) {
+            throw new ForbiddenException(
+                sprintf('User does not have access to perspective with ID: %s', $perspectiveId)
+            );
+        }
+    }
+
+    private function getAllUserPerspectives(UserInterface|UserRoleInterface $user): array
+    {
+        $userPerspectives = $this->repository->listUserPerspectives($user->getId());
+        if (!$user instanceof UserInterface) {
+            return $userPerspectives;
+        }
+
+        $roles = $user->getRoles();
+        foreach ($roles as $roleId) {
+            $rolePerspectives = $this->repository->listUserPerspectives($roleId);
+            $userPerspectives = [...$userPerspectives, ...$rolePerspectives];
+        }
+
+        return array_values(array_unique($userPerspectives));
+    }
+    private function getAllPerspectiveIds(): array
+    {
+        return array_map(static fn($perspective) => $perspective->getId(), $this->getAllPerspectives());
+    }
+
+    private function getAllPerspectives(): array {
+        $defaultPerspective = $this->configRepository->getConfiguration(Perspectives::DEFAULT_ID->value);
+        $allowedPerspectives[] = $this->perspectiveService->hydrateListEntry($defaultPerspective);
+
+        return array_merge($allowedPerspectives, $this->perspectiveService->listConfigurations());
+    }
+
+    private function getPerspectiveData(UserInterface|UserRoleInterface $user): UserPerspectiveData
+    {
+        $userPerspectiveData = $this->repository->getByUser($user->getId());
+        if ($userPerspectiveData === null) {
+            $userPerspectiveData = new UserPerspectiveData();
+            $userPerspectiveData->setUser($user->getId());
+        }
+
+        return $userPerspectiveData;
+    }
+}

--- a/src/User/Service/UserPerspectiveServiceInterface.php
+++ b/src/User/Service/UserPerspectiveServiceInterface.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\User\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotWriteableException;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
+use Pimcore\Model\User\UserRoleInterface;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+interface UserPerspectiveServiceInterface
+{
+    /**
+     * @throws NotFoundException|NotWriteableException
+     *
+     * @return PerspectiveConfig[]
+     */
+    public function getAllowedPerspectives(UserInterface $user): array;
+
+    /**
+     * @throws NotFoundException|NotWriteableException
+     *
+     * @return PerspectiveConfig[]
+     */
+    public function getConfigPerspectives(UserInterface|UserRoleInterface $user): array;
+
+    public function getActivePerspective(UserInterface $user): string;
+
+    /**
+     * @throws NotFoundException|NotWriteableException
+     */
+    public function updatePerspectives(
+        array $perspectivesToSet,
+        UserInterface|UserRoleInterface $user
+    ): void;
+
+    /**
+     * @throws ForbiddenException|NotFoundException|NotWriteableException
+     */
+    public function updateActivePerspective(string $perspectiveId, UserInterface $user): void;
+
+    /**
+     * @throws ForbiddenException
+     */
+    public function validatePerspectiveAccess(UserInterface $user, string $perspectiveId): void;
+}

--- a/src/User/Service/UserUpdateService.php
+++ b/src/User/Service/UserUpdateService.php
@@ -23,7 +23,9 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotWriteableException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ParseException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\MappedParameter\UpdatePasswordParameter;
 use Pimcore\Bundle\StudioBackendBundle\User\MappedParameter\UpdateUserParameter;
@@ -36,14 +38,15 @@ use function strlen;
 /**
  * @internal
  */
-final class UserUpdateService implements UserUpdateServiceInterface
+final readonly class UserUpdateService implements UserUpdateServiceInterface
 {
     public function __construct(
-        private readonly UserRepositoryInterface $userRepository,
-        private readonly SecurityServiceInterface $securityService,
-        private readonly UpdateServiceInterface $updateService,
-        private readonly AuthenticationResolverInterface $authenticationResolver,
-        private readonly CacheResolverInterface $cacheResolver,
+        private AuthenticationResolverInterface $authenticationResolver,
+        private CacheResolverInterface $cacheResolver,
+        private SecurityServiceInterface $securityService,
+        private UserRepositoryInterface $userRepository,
+        private UpdateServiceInterface $updateService,
+        private UserPerspectiveServiceInterface $userPerspectiveService,
     ) {
     }
 
@@ -89,6 +92,7 @@ final class UserUpdateService implements UserUpdateServiceInterface
             $user
         );
         $user = $this->updateService->updateDocumentWorkspaces($updateUserParameter->getDocumentWorkspaces(), $user);
+        $user = $this->updateService->updatePerspectives($updateUserParameter->getPerspectives(), $user);
 
         $this->userRepository->updateUser($user);
 
@@ -126,6 +130,15 @@ final class UserUpdateService implements UserUpdateServiceInterface
 
         $user->setPassword($passwordHash);
         $this->userRepository->updateUser($user);
+    }
+
+    /**
+     * @throws ForbiddenException|NotFoundException|NotWriteableException|UserNotFoundException
+     */
+    public function updateActivePerspective(string $perspectiveId): void
+    {
+        $user = $this->securityService->getCurrentUser();
+        $this->userPerspectiveService->updateActivePerspective($perspectiveId, $user);
     }
 
     /**

--- a/src/User/Service/UserUpdateServiceInterface.php
+++ b/src/User/Service/UserUpdateServiceInterface.php
@@ -19,7 +19,9 @@ namespace Pimcore\Bundle\StudioBackendBundle\User\Service;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotWriteableException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ParseException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\User\MappedParameter\UpdatePasswordParameter;
 use Pimcore\Bundle\StudioBackendBundle\User\MappedParameter\UpdateUserParameter;
 
@@ -37,4 +39,9 @@ interface UserUpdateServiceInterface
      * @throws NotFoundException|DatabaseException|ForbiddenException
      */
     public function updatePasswordById(UpdatePasswordParameter $updateParameter, int $userId): void;
+
+    /**
+     * @throws ForbiddenException|NotFoundException|NotWriteableException|UserNotFoundException
+     */
+    public function updateActivePerspective(string $perspectiveId): void;
 }

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -638,6 +638,8 @@ user_get_current_information_summary: Retrieve information's about the current l
 user_get_tree_success_response: Collection of users including folders for the given parent id.
 user_get_tree_summary: Get collection of users for tree view.
 user_reset_password_summary: Sending username to reset password.
+user_update_active_perspective_summary: Update the active perspective for the current user.
+user_update_active_perspective_success_response: Updated active perspective for the current user.
 user_update_by_id_success_response: Updated data.
 user_update_by_id_summary: Update user by id.
 user_update_password_by_id_summary: Update password for a User by the User id.


### PR DESCRIPTION
## Changes in this pull request
Resolves #144 
Resolves #836 

## Additional info
- Add separate table to store studio perspectives user data
- Added info about available and active perspectives to user info endpoint
- Added possibility to read and update studio perspectives with user/role management
- Added endpoint to update user active perspective
- Adapted user permission checks based on the studio perspectives