### PR TITLE
[Asset Metadata] Implement adapter approach

### DIFF
--- a/config/metadata.yaml
+++ b/config/metadata.yaml
@@ -16,6 +16,16 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Metadata\Service\MetadataServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Metadata\Service\MetadataService
 
+  Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataAdapterLoaderInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Metadata\Service\Loader\TaggedIteratorMetadataAdapter
+
+  Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataResolverServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataResolverServiceService
+
+  Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataAdapterServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataAdapterService
+    arguments:
+      $loader: '@pimcore.implementation_loader.asset.metadata.data'
 
   # Hydrator
   Pimcore\Bundle\StudioBackendBundle\Metadata\Hydrator\MetadataHydratorInterface:

--- a/config/pimcore/config.yaml
+++ b/config/pimcore/config.yaml
@@ -99,6 +99,8 @@ pimcore_studio_backend:
             document: ['content', 'seo', 'warning', 'notice']
             data-object: ['content', 'seo', 'warning', 'notice']
 
+    asset_metadata_adapter_mapping: []
+
     data_object_data_adapter_mapping:
         Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Adapter\AdvancedManyToManyRelationAdapter:
             - "advancedManyToManyRelation"

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -72,6 +72,7 @@ class Configuration implements ConfigurationInterface
         $this->addGridConfiguration($rootNode);
         $this->addSearchGridConfiguration($rootNode);
         $this->addNoteTypes($rootNode);
+        $this->addAssetMetadataAdapterMapping($rootNode);
         $this->addDataObjectAdapterMapping($rootNode);
         $this->addUserNode($rootNode);
         $this->addServerNode($rootNode);
@@ -362,6 +363,18 @@ class Configuration implements ConfigurationInterface
     {
         $node->children()
             ->arrayNode('data_object_data_adapter_mapping')
+                ->useAttributeAsKey('class')
+                ->arrayPrototype()
+                    ->scalarPrototype()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addAssetMetadataAdapterMapping(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('asset_metadata_adapter_mapping')
                 ->useAttributeAsKey('class')
                 ->arrayPrototype()
                     ->scalarPrototype()

--- a/src/DependencyInjection/PimcoreStudioBackendExtension.php
+++ b/src/DependencyInjection/PimcoreStudioBackendExtension.php
@@ -30,6 +30,7 @@ use Pimcore\Bundle\StudioBackendBundle\Export\Csv\CsvExportService;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\Collector\DataObject\AdvancedColumnCollector;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ConfigurationServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\HubServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataAdapterServiceInterface as MetadataAdapterServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Note\Service\NoteServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Service\OpenApiServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Repository\ElementTreeWidgetConfigRepository;
@@ -162,6 +163,9 @@ class PimcoreStudioBackendExtension extends Extension implements PrependExtensio
             '$perspectiveConfigurations' => $config[Configuration::PERSPECTIVES_NODE],
             '$storageConfig' => $config['config_location'][Configuration::PERSPECTIVES_NODE],
         ]);
+
+        $definition = $container->getDefinition(MetadataAdapterServiceInterface::class);
+        $definition->setArgument('$studioAdapters', $config['asset_metadata_adapter_mapping']);
     }
 
     /**

--- a/src/Metadata/Data/DataDenormalizerInterface.php
+++ b/src/Metadata/Data/DataDenormalizerInterface.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Data;
+
+use Pimcore\Model\UserInterface;
+
+interface DataDenormalizerInterface
+{
+    public function denormalize(
+        mixed $value,
+        string $type,
+        UserInterface $user
+    ): mixed;
+}

--- a/src/Metadata/Data/DataNormalizerInterface.php
+++ b/src/Metadata/Data/DataNormalizerInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Data;
+
+interface DataNormalizerInterface
+{
+    public function normalize(
+        mixed $value,
+        string $type
+    ): mixed;
+}

--- a/src/Metadata/Data/MetaDataAdapterInterface.php
+++ b/src/Metadata/Data/MetaDataAdapterInterface.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Data;
+
+interface MetaDataAdapterInterface
+{
+}

--- a/src/Metadata/Hydrator/MetadataHydrator.php
+++ b/src/Metadata/Hydrator/MetadataHydrator.php
@@ -18,8 +18,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Hydrator;
 
 use Pimcore\Bundle\StudioBackendBundle\Metadata\Schema\CustomMetadata;
 use Pimcore\Bundle\StudioBackendBundle\Metadata\Schema\PredefinedMetadata;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataResolverServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Resolver\Element\ReferenceResolverInterface;
-use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Metadata\Predefined;
 
 /**
@@ -27,7 +27,10 @@ use Pimcore\Model\Metadata\Predefined;
  */
 final readonly class MetadataHydrator implements MetadataHydratorInterface
 {
-    public function __construct(private ReferenceResolverInterface $referenceResolver)
+    public function __construct(
+        private DataResolverServiceInterface $dataResolverService,
+        private ReferenceResolverInterface $referenceResolver
+    )
     {
     }
 
@@ -37,10 +40,7 @@ final readonly class MetadataHydrator implements MetadataHydratorInterface
             $customMetadata['name'],
             $customMetadata['language'],
             $customMetadata['type'],
-            $this->resolveData(
-                $customMetadata['data'],
-                $customMetadata['type']
-            )
+            $this->dataResolverService->normalizeData($customMetadata),
         );
     }
 
@@ -63,19 +63,6 @@ final readonly class MetadataHydrator implements MetadataHydratorInterface
             $predefined->getModificationDate(),
             $predefined->isWriteable()
         );
-    }
-
-    private function resolveData(mixed $data, string $type): mixed
-    {
-        return match (true) {
-            $data instanceof ElementInterface => $this->referenceResolver->resolve($data),
-            $type === 'manyToManyRelation' => array_map(
-                fn (ElementInterface $element): array => $this->referenceResolver->resolve($element),
-                $data
-            ),
-            $type === 'checkbox' => (bool)$data,
-            default => $data,
-        };
     }
 
     private function resolveDefinitionData(mixed $data, string $type): mixed

--- a/src/Metadata/Hydrator/MetadataHydrator.php
+++ b/src/Metadata/Hydrator/MetadataHydrator.php
@@ -30,8 +30,7 @@ final readonly class MetadataHydrator implements MetadataHydratorInterface
     public function __construct(
         private DataResolverServiceInterface $dataResolverService,
         private ReferenceResolverInterface $referenceResolver
-    )
-    {
+    ) {
     }
 
     public function hydrate(array $customMetadata): CustomMetadata

--- a/src/Metadata/Patcher/Adapter/CustomMetadataAdapter.php
+++ b/src/Metadata/Patcher/Adapter/CustomMetadataAdapter.php
@@ -29,6 +29,7 @@ use Pimcore\Model\UserInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use function array_key_exists;
 use function in_array;
+use function sprintf;
 
 /**
  * @internal
@@ -46,8 +47,7 @@ final class CustomMetadataAdapter implements PatchAdapterInterface
     public function __construct(
         private readonly DataResolverServiceInterface $dataResolverService,
         private readonly MetadataRepositoryInterface $metadataRepository
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/Metadata/Patcher/Adapter/CustomMetadataAdapter.php
+++ b/src/Metadata/Patcher/Adapter/CustomMetadataAdapter.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Patcher\Adapter;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Metadata\Repository\MetadataRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataResolverServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Metadata\Service\MetadataServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Patcher\Adapter\PatchAdapterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Patcher\Service\Loader\TaggedIteratorAdapter;
@@ -35,14 +36,17 @@ use function in_array;
 #[AutoconfigureTag(TaggedIteratorAdapter::ADAPTER_TAG)]
 final class CustomMetadataAdapter implements PatchAdapterInterface
 {
-    private const INDEX_KEY = 'metadata';
+    private const string INDEX_KEY = 'metadata';
 
-    private const PATCHABLE_KEYS = [
+    private const array PATCHABLE_KEYS = [
         'language',
         'data',
     ];
 
-    public function __construct(private readonly MetadataRepositoryInterface $metadataRepository)
+    public function __construct(
+        private readonly DataResolverServiceInterface $dataResolverService,
+        private readonly MetadataRepositoryInterface $metadataRepository
+    )
     {
     }
 
@@ -67,9 +71,9 @@ final class CustomMetadataAdapter implements PatchAdapterInterface
                 continue;
             }
 
-            foreach (self::PATCHABLE_KEYS as $patchKeys) {
-                if (array_key_exists($patchKeys, $metadataForPatch[$index])) {
-                    $metadata[$patchKeys] = $metadataForPatch[$index][$patchKeys];
+            foreach (self::PATCHABLE_KEYS as $patchKey) {
+                if (array_key_exists($patchKey, $metadataForPatch[$index])) {
+                    $metadata[$patchKey] = $this->getExistingEntryValue($metadataForPatch[$index], $patchKey, $user);
                 }
             }
             $patchedMetadata[] = $metadata;
@@ -81,7 +85,7 @@ final class CustomMetadataAdapter implements PatchAdapterInterface
         $patchedMetadata = [
             ...$patchedMetadata,
             ...array_map(
-                fn (array $metaData) => $this->processNewMetadataEntry($metaData),
+                fn (array $metaData) => $this->processNewMetadataEntry($metaData, $user),
                 $metadataForPatch
             ),
         ];
@@ -103,10 +107,19 @@ final class CustomMetadataAdapter implements PatchAdapterInterface
         ];
     }
 
+    private function getExistingEntryValue(array $metadata, string $key, UserInterface $user): mixed
+    {
+        if ($key !== 'data') {
+            return $metadata[$key];
+        }
+
+        return $this->dataResolverService->denormalizeData($metadata, $user);
+    }
+
     /**
      * @throws InvalidArgumentException
      */
-    private function processNewMetadataEntry(array $metadata): array
+    private function processNewMetadataEntry(array $metadata, UserInterface $user): array
     {
         if (!isset($metadata['name'])) {
             throw new InvalidArgumentException('Metadata name is required');
@@ -119,14 +132,14 @@ final class CustomMetadataAdapter implements PatchAdapterInterface
         $predefined = $this->metadataRepository->getPredefinedMetadataByName($metadata['name']);
 
         if (!$predefined) {
-            throw new InvalidArgumentException('Predefined metadata not found');
+            throw new InvalidArgumentException(sprintf('Predefined metadata %s not found', $metadata['name']));
         }
 
         return [
             'name' => $predefined->getName(),
             'language' => $metadata['language'] ?? '',
             'type' => $predefined->getType(),
-            'data' => $metadata['data'] ?? null,
+            'data' => $metadata['data'] ? $this->dataResolverService->denormalizeData($metadata, $user) : null,
         ];
     }
 

--- a/src/Metadata/Service/DataAdapterLoaderInterface.php
+++ b/src/Metadata/Service/DataAdapterLoaderInterface.php
@@ -14,20 +14,20 @@ declare(strict_types=1);
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Service;
+namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Service;
 
-use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\SetterDataInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\MetaDataAdapterInterface;
 
 /**
  * @internal
  */
 interface DataAdapterLoaderInterface
 {
-    public const string ADAPTER_TAG = 'pimcore.studio_backend.data_adapter';
+    public const string ADAPTER_TAG = 'pimcore.studio_backend.metadata_adapter';
 
     /**
      * @throws InvalidArgumentException
      */
-    public function loadAdapter(string $adapterClass): SetterDataInterface;
+    public function loadAdapter(string $adapterClass): MetaDataAdapterInterface;
 }

--- a/src/Metadata/Service/DataAdapterService.php
+++ b/src/Metadata/Service/DataAdapterService.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\DataDenormalizerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\DataNormalizerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\MetaDataAdapterInterface;
+use Pimcore\Loader\ImplementationLoader\Exception\UnsupportedException;
+use Pimcore\Model\Asset\Metadata\Loader\DataLoader;
+use Pimcore\Normalizer\NormalizerInterface;
+
+/**
+ * @internal
+ */
+final readonly class DataAdapterService implements DataAdapterServiceInterface
+{
+    public function __construct(
+        private array $studioAdapters,
+        private DataAdapterLoaderInterface $dataAdapterLoader,
+        private DataLoader $loader,
+    ) {
+    }
+
+    public function getStudioAdaptersMapping(): array
+    {
+        return $this->studioAdapters;
+    }
+
+    /**
+     * {@inheritdoc}
+    */
+    public function getMetadataAdapter(string $type): ?MetadataAdapterInterface
+    {
+        $studioAdapters = $this->getStudioAdaptersMapping();
+        foreach ($studioAdapters as $adapter => $fieldTypes) {
+            if (in_array($type, $fieldTypes, true)) {
+                return $this->dataAdapterLoader->loadAdapter($adapter);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNormalizerAdapter(string $type): null|DataNormalizerInterface|NormalizerInterface
+    {
+        $studioAdapter = $this->getMetadataAdapter($type);
+        if ($studioAdapter instanceof DataNormalizerInterface) {
+            return $studioAdapter;
+        }
+
+        return $this->getCoreNormalizerAdapter($type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDenormalizerAdapter(string $type): null|DataDenormalizerInterface|NormalizerInterface
+    {
+        $studioAdapter = $this->getMetadataAdapter($type);
+        if ($studioAdapter instanceof DataDenormalizerInterface) {
+            return $studioAdapter;
+        }
+
+        return $this->getCoreNormalizerAdapter($type);
+    }
+
+    private function getCoreNormalizerAdapter(string $type): ?NormalizerInterface
+    {
+        try {
+            $coreAdapter = $this->loader->build($type);
+            if ($coreAdapter instanceof NormalizerInterface) {
+                return $coreAdapter;
+            }
+        } catch (UnsupportedException) {
+        }
+
+        return null;
+    }
+}

--- a/src/Metadata/Service/DataAdapterService.php
+++ b/src/Metadata/Service/DataAdapterService.php
@@ -90,6 +90,7 @@ final readonly class DataAdapterService implements DataAdapterServiceInterface
                 return $coreAdapter;
             }
         } catch (UnsupportedException) {
+            return null;
         }
 
         return null;

--- a/src/Metadata/Service/DataAdapterService.php
+++ b/src/Metadata/Service/DataAdapterService.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\MetaDataAdapterInterface;
 use Pimcore\Loader\ImplementationLoader\Exception\UnsupportedException;
 use Pimcore\Model\Asset\Metadata\Loader\DataLoader;
 use Pimcore\Normalizer\NormalizerInterface;
+use function in_array;
 
 /**
  * @internal
@@ -42,7 +43,7 @@ final readonly class DataAdapterService implements DataAdapterServiceInterface
 
     /**
      * {@inheritdoc}
-    */
+     */
     public function getMetadataAdapter(string $type): ?MetadataAdapterInterface
     {
         $studioAdapters = $this->getStudioAdaptersMapping();

--- a/src/Metadata/Service/DataAdapterServiceInterface.php
+++ b/src/Metadata/Service/DataAdapterServiceInterface.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\DataDenormalizerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\DataNormalizerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\MetaDataAdapterInterface;
+use Pimcore\Normalizer\NormalizerInterface;
+
+/**
+ * @internal
+ */
+interface DataAdapterServiceInterface
+{
+    public function getStudioAdaptersMapping(): array;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function getMetadataAdapter(string $type): ?MetadataAdapterInterface;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function getNormalizerAdapter(string $type): null|DataNormalizerInterface|NormalizerInterface;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function getDenormalizerAdapter(string $type): null|DataDenormalizerInterface|NormalizerInterface;
+}

--- a/src/Metadata/Service/DataResolverServiceInterface.php
+++ b/src/Metadata/Service/DataResolverServiceInterface.php
@@ -14,20 +14,23 @@ declare(strict_types=1);
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Service;
+namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Service;
 
-use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\SetterDataInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Model\UserInterface;
 
 /**
  * @internal
  */
-interface DataAdapterLoaderInterface
+interface DataResolverServiceInterface
 {
-    public const string ADAPTER_TAG = 'pimcore.studio_backend.data_adapter';
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function normalizeData(array $customMetadata): mixed;
 
     /**
      * @throws InvalidArgumentException
      */
-    public function loadAdapter(string $adapterClass): SetterDataInterface;
+    public function denormalizeData(array $customMetadata, UserInterface $user): mixed;
 }

--- a/src/Metadata/Service/DataResolverServiceService.php
+++ b/src/Metadata/Service/DataResolverServiceService.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Service;
+
+use Pimcore\Model\UserInterface;
+use Pimcore\Normalizer\NormalizerInterface;
+
+/**
+ * @internal
+ */
+final readonly class DataResolverServiceService implements DataResolverServiceInterface
+{
+    public function __construct(private DataAdapterServiceInterface $dataAdapterService) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalizeData(array $customMetadata): mixed
+    {
+        $adapter = $this->dataAdapterService->getNormalizerAdapter($customMetadata['type']);
+        if ($adapter === null) {
+            return $customMetadata['data'];
+        }
+
+        if ($adapter instanceof NormalizerInterface) {
+            return $adapter->normalize($customMetadata['data']);
+        }
+
+        return $adapter->normalize($customMetadata['data'], $customMetadata['type']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalizeData(array $customMetadata, UserInterface $user): mixed
+    {
+        $adapter = $this->dataAdapterService->getDenormalizerAdapter($customMetadata['type']);
+        if ($adapter === null) {
+            return $customMetadata['data'];
+        }
+
+        if ($adapter instanceof NormalizerInterface) {
+            return $adapter->denormalize($customMetadata['data']);
+        }
+
+
+        return $adapter->denormalize($customMetadata['data'], $customMetadata['type'], $user);
+    }
+}

--- a/src/Metadata/Service/DataResolverServiceService.php
+++ b/src/Metadata/Service/DataResolverServiceService.php
@@ -24,7 +24,8 @@ use Pimcore\Normalizer\NormalizerInterface;
  */
 final readonly class DataResolverServiceService implements DataResolverServiceInterface
 {
-    public function __construct(private DataAdapterServiceInterface $dataAdapterService) {
+    public function __construct(private DataAdapterServiceInterface $dataAdapterService)
+    {
     }
 
     /**
@@ -57,7 +58,6 @@ final readonly class DataResolverServiceService implements DataResolverServiceIn
         if ($adapter instanceof NormalizerInterface) {
             return $adapter->denormalize($customMetadata['data']);
         }
-
 
         return $adapter->denormalize($customMetadata['data'], $customMetadata['type'], $user);
     }

--- a/src/Metadata/Service/Loader/TaggedIteratorMetadataAdapter.php
+++ b/src/Metadata/Service/Loader/TaggedIteratorMetadataAdapter.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Service\Loader;
+
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\MetaDataAdapterInterface;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataAdapterLoaderInterface;
+use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use function get_class;
+use function sprintf;
+
+/**
+ * @internal
+ */
+final readonly class TaggedIteratorMetadataAdapter implements DataAdapterLoaderInterface
+{
+    public function __construct(
+        #[TaggedIterator(self::ADAPTER_TAG)]
+        private iterable $taggedAdapter,
+    ) {
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function loadAdapter(string $adapterClass): MetaDataAdapterInterface
+    {
+        $adapters = [...$this->taggedAdapter];
+        /** @var MetaDataAdapterInterface $adapter */
+        foreach ($adapters as $adapter) {
+            if (get_class($adapter) === $adapterClass) {
+                return $adapter;
+            }
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('No adapter found for the metadata adapter class "%s"', $adapterClass)
+        );
+    }
+}

--- a/src/Metadata/Updater/Adapter/CustomMetadataAdapter.php
+++ b/src/Metadata/Updater/Adapter/CustomMetadataAdapter.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Updater\Adapter;
 
 use Pimcore\Bundle\StudioBackendBundle\Metadata\Event\PreSet\CustomMetadataEvent;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataResolverServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Updater\Adapter\UpdateAdapterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\Asset;
@@ -31,10 +33,12 @@ use function array_key_exists;
 #[AutoconfigureTag('pimcore.studio_backend.update_adapter')]
 final readonly class CustomMetadataAdapter implements UpdateAdapterInterface
 {
-    private const INDEX_KEY = 'metadata';
+    private const string INDEX_KEY = 'metadata';
 
     public function __construct(
-        private EventDispatcherInterface $eventDispatcher
+        private DataResolverServiceInterface $dataResolverService,
+        private EventDispatcherInterface $eventDispatcher,
+        private SecurityServiceInterface $securityService,
     ) {
     }
 
@@ -44,7 +48,10 @@ final readonly class CustomMetadataAdapter implements UpdateAdapterInterface
             return;
         }
 
-        $metadataEvent = new CustomMetadataEvent($element->getId(), $data[$this->getIndexKey()]);
+        $metadataEvent = new CustomMetadataEvent(
+            $element->getId(),
+            $this->denormalizeMetadata($data[$this->getIndexKey()])
+        );
 
         $this->eventDispatcher->dispatch($metadataEvent, CustomMetadataEvent::EVENT_NAME);
 
@@ -61,5 +68,15 @@ final readonly class CustomMetadataAdapter implements UpdateAdapterInterface
         return [
             ElementTypes::TYPE_ASSET,
         ];
+    }
+
+    private function denormalizeMetadata(array $customMetadata): array
+    {
+        $user = $this->securityService->getCurrentUser();
+
+        return array_map(function ($metadataItem) use ($user) {
+            $metadataItem['data'] = $this->dataResolverService->denormalizeData($metadataItem, $user);
+            return $metadataItem;
+        }, $customMetadata);
     }
 }

--- a/src/Metadata/Updater/Adapter/CustomMetadataAdapter.php
+++ b/src/Metadata/Updater/Adapter/CustomMetadataAdapter.php
@@ -76,6 +76,7 @@ final readonly class CustomMetadataAdapter implements UpdateAdapterInterface
 
         return array_map(function ($metadataItem) use ($user) {
             $metadataItem['data'] = $this->dataResolverService->denormalizeData($metadataItem, $user);
+
             return $metadataItem;
         }, $customMetadata);
     }

--- a/src/Version/Hydrator/CustomMetadataVersionHydrator.php
+++ b/src/Version/Hydrator/CustomMetadataVersionHydrator.php
@@ -16,16 +16,15 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Version\Hydrator;
 
-use Pimcore\Bundle\StudioBackendBundle\Resolver\Element\ReferenceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataResolverServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Version\Schema\CustomMetadataVersion;
-use Pimcore\Model\Element\ElementInterface;
 
 /**
  * @internal
  */
 final readonly class CustomMetadataVersionHydrator implements CustomMetadataVersionHydratorInterface
 {
-    public function __construct(private ReferenceResolverInterface $referenceResolver)
+    public function __construct(private DataResolverServiceInterface $dataResolverService)
     {
     }
 
@@ -44,23 +43,7 @@ final readonly class CustomMetadataVersionHydrator implements CustomMetadataVers
             $customMetadata['name'],
             $customMetadata['language'],
             $customMetadata['type'],
-            $this->resolveData(
-                $customMetadata['data'],
-                $customMetadata['type']
-            )
+            $this->dataResolverService->normalizeData($customMetadata)
         );
-    }
-
-    private function resolveData(mixed $data, string $type): mixed
-    {
-        return match (true) {
-            $data instanceof ElementInterface => $this->referenceResolver->resolve($data),
-            $type === 'manyToManyRelation' => array_map(
-                fn (ElementInterface $element): array => $this->referenceResolver->resolve($element),
-                $data
-            ),
-            $type === 'checkbox' => (bool)$data,
-            default => $data,
-        };
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Resolves #941 

## Additional info

- User adapter approach for metada data processing (normalize and denormalize)

1. first load studio adapters
2. if studio adapter does not exists load core adapter
3. if that is not existing use raw value

- Use adapters in hydrators and updater and patcher