### PR TITLE
[Fix]: Simple search doesn't work for assets with document-type extensions

### DIFF
--- a/src/Asset/Service/ThumbnailService.php
+++ b/src/Asset/Service/ThumbnailService.php
@@ -30,11 +30,12 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset\ResizeModes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Thumbnails;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ConsoleExecutableTrait;
 use Pimcore\Model\Asset\Document;
+use Pimcore\Model\Asset\Document\ImageThumbnailInterface as DocumentThumbnail;
 use Pimcore\Model\Asset\Image;
 use Pimcore\Model\Asset\Image\Thumbnail\Config as ImageThumbnailConfig;
 use Pimcore\Model\Asset\Image\ThumbnailInterface;
 use Pimcore\Model\Asset\Video;
-use Pimcore\Model\Asset\Video\ImageThumbnailInterface;
+use Pimcore\Model\Asset\Video\ImageThumbnailInterface as VideoImageThumbnail;
 use Pimcore\Model\Asset\Video\Thumbnail\Config as VideoThumbnailConfig;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
@@ -109,7 +110,7 @@ final readonly class ThumbnailService implements ThumbnailServiceInterface
     /**
      * @throws InvalidThumbnailException
      */
-    public function getAssetImagePreviewThumbnail(Video|Document $asset): ImageThumbnailInterface
+    public function getAssetImagePreviewThumbnail(Video|Document $asset): DocumentThumbnail|VideoImageThumbnail
     {
         $thumbnailConfig = $this->getSystemImageThumbnailConfig();
         if ($thumbnailConfig === null) {

--- a/src/Asset/Service/ThumbnailServiceInterface.php
+++ b/src/Asset/Service/ThumbnailServiceInterface.php
@@ -22,10 +22,11 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailConfigurati
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidThumbnailException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ThumbnailResizingFailedException;
 use Pimcore\Model\Asset\Document;
+use Pimcore\Model\Asset\Document\ImageThumbnailInterface as DocumentThumbnail;
 use Pimcore\Model\Asset\Image;
 use Pimcore\Model\Asset\Image\ThumbnailInterface;
 use Pimcore\Model\Asset\Video;
-use Pimcore\Model\Asset\Video\ImageThumbnailInterface;
+use Pimcore\Model\Asset\Video\ImageThumbnailInterface as VideoImageThumbnail;
 use Pimcore\Model\Asset\Video\Thumbnail\Config as VideoThumbnailConfig;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
@@ -56,7 +57,7 @@ interface ThumbnailServiceInterface
     /**
      * @throws InvalidThumbnailException
      */
-    public function getAssetImagePreviewThumbnail(Video|Document $asset): ImageThumbnailInterface;
+    public function getAssetImagePreviewThumbnail(Video|Document $asset): DocumentThumbnail|VideoImageThumbnail;
 
     /**
      * @throws InvalidThumbnailException


### PR DESCRIPTION
## Changes in this pull request
Resolves #955
