### PR TITLE
[Adapters] fix various adapter related issues

### DIFF
--- a/config/metadata.yaml
+++ b/config/metadata.yaml
@@ -60,4 +60,6 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\Metadata\Data\Adapter\BooleanAdapter: ~
 
+  Pimcore\Bundle\StudioBackendBundle\Metadata\Data\Adapter\DateAdapter: ~
+
   Pimcore\Bundle\StudioBackendBundle\Metadata\Data\Adapter\ManyToOneRelationAdapter: ~

--- a/config/pimcore/config.yaml
+++ b/config/pimcore/config.yaml
@@ -106,6 +106,8 @@ pimcore_studio_backend:
             - "asset"
             - "document"
             - "object"
+        Pimcore\Bundle\StudioBackendBundle\Metadata\Data\Adapter\DateAdapter:
+            - "date"
 
     data_object_data_adapter_mapping:
         Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Adapter\AdvancedManyToManyRelationAdapter:

--- a/src/DataObject/Data/Adapter/HotspotImageAdapter.php
+++ b/src/DataObject/Data/Adapter/HotspotImageAdapter.php
@@ -131,9 +131,10 @@ final readonly class HotspotImageAdapter implements
 
         $value['image'] = [
             ... $value['image'],
-            ...$this->normalizeElementData($id, $type),
+            ... $this->normalizeElementData($id, $type),
         ];
-        $value['hotspots'] = $this->normalizeHotSpotData($value['hotspots']);
+        $value['hotspots'] = $this->normalizeLocationData($value['hotspots']);
+        $value['marker'] = $this->normalizeLocationData($value['marker']);
 
         return $value;
     }
@@ -150,10 +151,10 @@ final readonly class HotspotImageAdapter implements
         return $elementData;
     }
 
-    private function normalizeHotSpotData(array $hotSpotData): array
+    private function normalizeLocationData(array $locationData): array
     {
-        foreach ($hotSpotData as &$hotSpot) {
-            $data = $hotSpot['data'] ?? null;
+        foreach ($locationData as &$location) {
+            $data = $location['data'] ?? null;
             if (!is_array($data)) {
                 continue;
             }
@@ -161,7 +162,7 @@ final readonly class HotspotImageAdapter implements
                 if ($item instanceof MarkerHotspotItem &&
                     $this->isValidItem($item)
                 ) {
-                    $hotSpot['data'] = [
+                    $location['data'] = [
                         ... $this->normalizeImageData($item),
                         ... $this->normalizeElementData($item->getValue(), $item->getType()),
                         ];
@@ -169,7 +170,7 @@ final readonly class HotspotImageAdapter implements
             }
         }
 
-        return $hotSpotData;
+        return $locationData;
     }
 
     private function getElementData(int $id, string $type): Asset|Document|AbstractObject
@@ -192,6 +193,8 @@ final readonly class HotspotImageAdapter implements
             if (isset($element['data']) && is_array($element['data']) && $element['data'] !== []) {
                 $element['data'] = $this->processMetaData($element['data']);
             }
+
+            $element['data'] = $element['data'] ?? [];
         }
 
         return $data;

--- a/src/Metadata/Data/Adapter/DateAdapter.php
+++ b/src/Metadata/Data/Adapter/DateAdapter.php
@@ -43,9 +43,9 @@ final readonly class DateAdapter implements MetaDataAdapterInterface, DataNormal
         UserInterface $user,
         array $existingMetadata = [],
         bool $isPatch = false
-    ): ?float
-    {
+    ): ?float {
         $value = $customMetadata['data'] ?? null;
+
         return $value ?? null;
     }
 }

--- a/src/Metadata/Data/Adapter/DateAdapter.php
+++ b/src/Metadata/Data/Adapter/DateAdapter.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Metadata\Data\Adapter;
+
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\DataDenormalizerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\DataNormalizerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\MetaDataAdapterInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\AdapterLoader;
+use Pimcore\Model\UserInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * @internal
+ */
+#[AutoconfigureTag(AdapterLoader::METADATA_ADAPTER_TAG->value)]
+final readonly class DateAdapter implements MetaDataAdapterInterface, DataNormalizerInterface, DataDenormalizerInterface
+{
+    public function normalize(mixed $value, string $type): ?int
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return (int)$value;
+    }
+
+    public function denormalize(
+        array $customMetadata,
+        UserInterface $user,
+        array $existingMetadata = [],
+        bool $isPatch = false
+    ): ?float
+    {
+        $value = $customMetadata['data'] ?? null;
+        return $value ?? null;
+    }
+}

--- a/src/Metadata/Data/Adapter/ManyToOneRelationAdapter.php
+++ b/src/Metadata/Data/Adapter/ManyToOneRelationAdapter.php
@@ -54,7 +54,7 @@ final readonly class ManyToOneRelationAdapter implements
 
         return [
             'id' => $value->getId(),
-            'type' => $value->getType(),
+            'type' => $this->getElementType($value, true),
             'fullPath' => $value->getRealFullPath(),
             'subtype' => $value->getType(),
             'isPublished' => ($value instanceof Concrete || $value instanceof Document) ?

--- a/src/Metadata/Data/Adapter/ManyToOneRelationAdapter.php
+++ b/src/Metadata/Data/Adapter/ManyToOneRelationAdapter.php
@@ -48,7 +48,7 @@ final readonly class ManyToOneRelationAdapter implements
 
     public function normalize(mixed $value, string $type): ?array
     {
-        if ($value === null) {
+        if (!$value instanceof ElementInterface) {
             return null;
         }
 

--- a/src/Setting/Provider/ConfigSettingsProvider.php
+++ b/src/Setting/Provider/ConfigSettingsProvider.php
@@ -37,7 +37,7 @@ final readonly class ConfigSettingsProvider implements SettingsProviderInterface
             'asset_tree_paging_limit' => $this->config['assets']['tree_paging_limit'],
             'document_tree_paging_limit' => $this->config['documents']['tree_paging_limit'],
             'object_tree_paging_limit' => $this->config['objects']['tree_paging_limit'],
-            'timezone' => $this->config['general']['timezone'],
+            'timezone' => $this->config['general']['timezone'] ?: date_default_timezone_get(),
             'maps' => $this->config['maps'],
         ];
 


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-backend-bundle/issues/970
Resolves https://github.com/pimcore/studio-backend-bundle/issues/971
Resolves https://github.com/pimcore/studio-backend-bundle/issues/979
Resolves https://github.com/pimcore/generic-data-index-bundle/issues/302

## Additional info
- asset metadata date adapter should return int timestamp
- asset metadata many to one adapter should return actual type for element
- data object adapter for advanced images should default to empty array as default data and not null
- settings endpoint should return fallback for timezone, see https://github.com/pimcore/admin-ui-classic-bundle/pull/862