### PR TITLE
[Dataobject Editor] unable to save structured table with checkboxes

### DIFF
--- a/src/DataObject/Data/Adapter/StructuredTableAdapter.php
+++ b/src/DataObject/Data/Adapter/StructuredTableAdapter.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Adapter;
 
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\DataNormalizerInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Model\FieldContextData;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\SetterDataInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataAdapterLoaderInterface;
@@ -30,7 +31,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * @internal
  */
 #[AutoconfigureTag(DataAdapterLoaderInterface::ADAPTER_TAG)]
-final readonly class StructuredTableAdapter implements SetterDataInterface
+final readonly class StructuredTableAdapter implements SetterDataInterface, DataNormalizerInterface
 {
     public function getDataForSetter(
         Concrete $element,
@@ -47,11 +48,57 @@ final readonly class StructuredTableAdapter implements SetterDataInterface
             /** @var StructuredTableDefinition $fieldDefinition */
             $cols = $fieldDefinition->getCols();
             foreach ($cols as $col) {
-                $tableData[$id][$col['key']] = $dataLine[$col['key']];
+                $tableData[$id][$col['key']] = $this->transformBoolValues($dataLine[$col['key']]);
             }
         }
         $table->setData($tableData);
 
         return $table;
+    }
+    
+    public function normalize(mixed $value, Data $fieldDefinition): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!$fieldDefinition instanceof StructuredTableDefinition) {
+            return null;
+        }
+
+        $rows = $fieldDefinition->normalize($value);
+
+        $returnValue = [];
+        foreach ($rows as $rowKey => $columns) {
+            foreach ($columns as $colKey => $colValue) {
+                if ($colKey !== '' && $rowKey !== '') {
+                    $colType = $this->getColumnType($fieldDefinition, $colKey);
+                    $returnValue[$rowKey][$colKey] = $colType === 'bool' ? (bool)$colValue: $colValue;
+                }
+            }
+        }
+
+        return $returnValue;
+    }
+
+    private function getColumnType(StructuredTableDefinition $definition, string $colKey): ?string
+    {
+        $cols = $definition->getCols();
+        foreach ($cols as $col) {
+            if ($col['key'] === $colKey) {
+                return $col['type'];
+            }
+        }
+
+        return null;
+    }
+
+    private function transformBoolValues(mixed $value): mixed
+    {
+        if (is_bool($value)) {
+            return $value ? 1 : 0;
+        }
+
+        return $value;
     }
 }

--- a/src/DataObject/Data/Adapter/StructuredTableAdapter.php
+++ b/src/DataObject/Data/Adapter/StructuredTableAdapter.php
@@ -26,6 +26,7 @@ use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Data\StructuredTable;
 use Pimcore\Model\UserInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use function is_bool;
 
 /**
  * @internal
@@ -55,7 +56,7 @@ final readonly class StructuredTableAdapter implements SetterDataInterface, Data
 
         return $table;
     }
-    
+
     public function normalize(mixed $value, Data $fieldDefinition): ?array
     {
         if ($value === null) {
@@ -73,7 +74,7 @@ final readonly class StructuredTableAdapter implements SetterDataInterface, Data
             foreach ($columns as $colKey => $colValue) {
                 if ($colKey !== '' && $rowKey !== '') {
                     $colType = $this->getColumnType($fieldDefinition, $colKey);
-                    $returnValue[$rowKey][$colKey] = $colType === 'bool' ? (bool)$colValue: $colValue;
+                    $returnValue[$rowKey][$colKey] = $colType === 'bool' ? (bool)$colValue : $colValue;
                 }
             }
         }

--- a/src/DataObject/Data/Adapter/StructuredTableAdapter.php
+++ b/src/DataObject/Data/Adapter/StructuredTableAdapter.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Adapter;
 
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\DataNormalizerInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Model\FieldContextData;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\SearchPreviewDataInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\SetterDataInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataAdapterLoaderInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
@@ -32,7 +33,10 @@ use function is_bool;
  * @internal
  */
 #[AutoconfigureTag(DataAdapterLoaderInterface::ADAPTER_TAG)]
-final readonly class StructuredTableAdapter implements SetterDataInterface, DataNormalizerInterface
+final readonly class StructuredTableAdapter implements
+    SetterDataInterface,
+    DataNormalizerInterface,
+    SearchPreviewDataInterface
 {
     public function getDataForSetter(
         Concrete $element,
@@ -80,6 +84,11 @@ final readonly class StructuredTableAdapter implements SetterDataInterface, Data
         }
 
         return $returnValue;
+    }
+
+    public function getPreviewFieldData(mixed $value, Data $fieldDefinition, array $data): array
+    {
+        return [];
     }
 
     private function getColumnType(StructuredTableDefinition $definition, string $colKey): ?string


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/generic-data-index-bundle/issues/306

## Additional info
Structured tables are internally handling checkboxes as integer values
In studio we handle them as boolean (this creates conflict in GDI field mapping). This PR allows usage of bool values for studio. 