### PR TITLE
Remove exception existing translation keys

### DIFF
--- a/src/Translation/Controller/CreateController.php
+++ b/src/Translation/Controller/CreateController.php
@@ -64,7 +64,6 @@ final class CreateController extends AbstractApiController
         description: 'translation_create_success_response'
     )]
     #[DefaultResponses([
-        HttpResponseCodes::CONFLICT,
         HttpResponseCodes::NOT_FOUND,
         HttpResponseCodes::UNAUTHORIZED,
     ])]

--- a/src/Translation/Repository/TranslationRepository.php
+++ b/src/Translation/Repository/TranslationRepository.php
@@ -53,9 +53,6 @@ final readonly class TranslationRepository implements TranslationRepositoryInter
         return $list->getTranslations();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function createTranslations(array $translationData): void
     {
         $languages = $this->adminResolver->getLanguages();

--- a/src/Translation/Repository/TranslationRepository.php
+++ b/src/Translation/Repository/TranslationRepository.php
@@ -63,9 +63,7 @@ final readonly class TranslationRepository implements TranslationRepositoryInter
         /** @var CreateTranslationData $translation */
         foreach ($translationData as $translation) {
             if ($this->getTranslationByKey($translation->getKey()) !== null) {
-                throw new ElementExistsException(
-                    sprintf("Translation with key '%s' already exists", $translation->getKey()),
-                );
+                continue;
             }
 
             $this->createTranslationEntry($translation->getKey(), $translation->getType(), $languages);

--- a/src/Translation/Repository/TranslationRepository.php
+++ b/src/Translation/Repository/TranslationRepository.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Translation\Repository;
 
 use Pimcore\Bundle\StaticResolverBundle\Lib\Tools\AdminResolverInterface;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementExistsException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidLocaleException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Translation\Schema\CreateTranslationData;
@@ -26,7 +25,6 @@ use Pimcore\Bundle\StudioBackendBundle\Translation\Service\TranslatorServiceInte
 use Pimcore\Model\Translation;
 use Pimcore\Model\Translation\Listing;
 use function in_array;
-use function sprintf;
 
 /**
  * @internal

--- a/src/Translation/Repository/TranslationRepositoryInterface.php
+++ b/src/Translation/Repository/TranslationRepositoryInterface.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Translation\Repository;
 
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementExistsException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidLocaleException;
 use Pimcore\Bundle\StudioBackendBundle\Translation\Schema\TranslationData;
 use Pimcore\Model\Translation;

--- a/src/Translation/Repository/TranslationRepositoryInterface.php
+++ b/src/Translation/Repository/TranslationRepositoryInterface.php
@@ -33,9 +33,6 @@ interface TranslationRepositoryInterface
      */
     public function getAllTranslations(string $locale): array;
 
-    /**
-     * @throws ElementExistsException
-     */
     public function createTranslations(array $translationData): void;
 
     /**

--- a/src/Translation/Service/TranslatorService.php
+++ b/src/Translation/Service/TranslatorService.php
@@ -42,9 +42,6 @@ final readonly class TranslatorService implements TranslatorServiceInterface
         $this->translatorBag = $this->getTranslatorBag();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function createTranslations(CreateTranslation $translation): void
     {
         $this->translationRepository->createTranslations($translation->getTranslationData());

--- a/src/Translation/Service/TranslatorServiceInterface.php
+++ b/src/Translation/Service/TranslatorServiceInterface.php
@@ -29,9 +29,6 @@ interface TranslatorServiceInterface
 {
     public const string DOMAIN = 'studio';
 
-    /**
-     * @throws ElementExistsException
-     */
     public function createTranslations(CreateTranslation $translation): void;
 
     /**

--- a/src/Translation/Service/TranslatorServiceInterface.php
+++ b/src/Translation/Service/TranslatorServiceInterface.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Translation\Service;
 
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementExistsException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidLocaleException;
 use Pimcore\Bundle\StudioBackendBundle\Translation\Schema\CreateTranslation;
 use Pimcore\Bundle\StudioBackendBundle\Translation\Schema\Translation;


### PR DESCRIPTION
## Additional info
This pull request includes several changes to the translation creation functionality, focusing on simplifying method signatures and removing exception handling for existing elements.

### Simplification of method signatures:

* [`src/Translation/Repository/TranslationRepository.php`](diffhunk://#diff-507737046a2058f6097ea24eac958429112b4a89dea87f5424c18c9e3fdd15d2L56-R63): Removed the `@inheritdoc` docblock and the `ElementExistsException` throw statement from the `createTranslations` method. Instead of throwing an exception when a translation key already exists, the method now continues to the next item.

* [`src/Translation/Repository/TranslationRepositoryInterface.php`](diffhunk://#diff-f08e35e51f7a418b669f492d33a3a766239e661be714a9801e3c8335d8c94cefL36-L38): Removed the `@throws ElementExistsException` docblock from the `createTranslations` method.

* [`src/Translation/Service/TranslatorService.php`](diffhunk://#diff-d855f7abf5c421df7023fd6730440f395189b03e184971ba0fad5ed65a752403L45-L47): Removed the `@inheritdoc` docblock from the `createTranslations` method.

* [`src/Translation/Service/TranslatorServiceInterface.php`](diffhunk://#diff-7a9d7757cd0cda5539b775691907a0afbd8658e485df17a6b6cdb7d2718d6c6bL32-L34): Removed the `@throws ElementExistsException` docblock from the `createTranslations` method.

### Removal of unnecessary response code:

* [`src/Translation/Controller/CreateController.php`](diffhunk://#diff-84b75417e410b036bad89e9f60fff1b15f800684639f88648a7ce3b021675dcaL67): Removed the `HttpResponseCodes::CONFLICT` from the default responses in the `__construct` method.
