### PR TITLE
Add language to user information

### DIFF
--- a/src/OpenApi/Schema/UserInformation.php
+++ b/src/OpenApi/Schema/UserInformation.php
@@ -30,7 +30,17 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
 #[Schema(
     title: 'User Information',
     description: 'Information about the user',
-    required: ['id', 'username', 'permissions', 'isAdmin', 'classes', 'docTypes', 'activePerspective', 'perspectives', 'language'],
+    required: [
+        'id',
+        'username',
+        'permissions',
+        'isAdmin',
+        'classes',
+        'docTypes',
+        'language',
+        'activePerspective',
+        'perspectives',
+    ],
     type: 'object'
 )]
 final class UserInformation implements AdditionalAttributesInterface

--- a/src/OpenApi/Schema/UserInformation.php
+++ b/src/OpenApi/Schema/UserInformation.php
@@ -63,6 +63,12 @@ final class UserInformation implements AdditionalAttributesInterface
         )]
         private readonly array $docTypes,
         #[Property(
+            description: 'User Language',
+            type: 'string',
+            example: 'en')
+        ]
+        private readonly string $language,
+        #[Property(
             description: 'Active studio perspective ID',
             type: 'string',
             example: Perspectives::DEFAULT_ID->value)
@@ -74,12 +80,6 @@ final class UserInformation implements AdditionalAttributesInterface
             items: new Items(ref: PerspectiveConfig::class))
         ]
         private readonly array $perspectives = [],
-        #[Property(
-            description: 'User Language',
-            type: 'string',
-            example: 'en')
-        ]
-        private readonly string $language,
     ) {
     }
 
@@ -113,6 +113,11 @@ final class UserInformation implements AdditionalAttributesInterface
         return $this->docTypes;
     }
 
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
     public function getActivePerspective(): ?string
     {
         return $this->activePerspective;
@@ -124,10 +129,5 @@ final class UserInformation implements AdditionalAttributesInterface
     public function getPerspectives(): array
     {
         return $this->perspectives;
-    }
-
-    public function getLanguage(): string
-    {
-        return $this->language;
     }
 }

--- a/src/OpenApi/Schema/UserInformation.php
+++ b/src/OpenApi/Schema/UserInformation.php
@@ -30,7 +30,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
 #[Schema(
     title: 'User Information',
     description: 'Information about the user',
-    required: ['id', 'username', 'permissions', 'isAdmin', 'classes', 'docTypes', 'activePerspective', 'perspectives'],
+    required: ['id', 'username', 'permissions', 'isAdmin', 'classes', 'docTypes', 'activePerspective', 'perspectives', 'language'],
     type: 'object'
 )]
 final class UserInformation implements AdditionalAttributesInterface
@@ -74,6 +74,12 @@ final class UserInformation implements AdditionalAttributesInterface
             items: new Items(ref: PerspectiveConfig::class))
         ]
         private readonly array $perspectives = [],
+        #[Property(
+            description: 'User Language',
+            type: 'string',
+            example: 'en')
+        ]
+        private readonly string $language,
     ) {
     }
 
@@ -118,5 +124,10 @@ final class UserInformation implements AdditionalAttributesInterface
     public function getPerspectives(): array
     {
         return $this->perspectives;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
     }
 }

--- a/src/User/Hydrator/UserInformationHydrator.php
+++ b/src/User/Hydrator/UserInformationHydrator.php
@@ -40,6 +40,7 @@ final readonly class UserInformationHydrator implements UserInformationHydratorI
             $user->getDocTypes(),
             $this->userPerspectiveService->getActivePerspective($user),
             $this->userPerspectiveService->getAllowedPerspectives($user),
+            $user->getLanguage()
         );
     }
 }

--- a/src/User/Hydrator/UserInformationHydrator.php
+++ b/src/User/Hydrator/UserInformationHydrator.php
@@ -38,9 +38,9 @@ final readonly class UserInformationHydrator implements UserInformationHydratorI
             $user->isAdmin(),
             $user->getClasses(),
             $user->getDocTypes(),
+            $user->getLanguage(),
             $this->userPerspectiveService->getActivePerspective($user),
-            $this->userPerspectiveService->getAllowedPerspectives($user),
-            $user->getLanguage()
+            $this->userPerspectiveService->getAllowedPerspectives($user)
         );
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Belongs to: https://github.com/pimcore/studio-ui-bundle/issues/1330

## Additional info
This pull request includes changes to the `UserInformation` schema to add a new `language` property. This involves updates to the schema definition, constructor, and relevant methods to handle the new property.

Updates to `UserInformation` schema:

* [`src/OpenApi/Schema/UserInformation.php`](diffhunk://#diff-d63c884c6a849d537c63b63b6c6e301c624450d10ca19f66b7e71095dda3780cL33-R33): Added `language` to the list of required properties in the schema definition.
* [`src/OpenApi/Schema/UserInformation.php`](diffhunk://#diff-d63c884c6a849d537c63b63b6c6e301c624450d10ca19f66b7e71095dda3780cR77-R82): Added `language` property with description, type, and example in the constructor.
* [`src/OpenApi/Schema/UserInformation.php`](diffhunk://#diff-d63c884c6a849d537c63b63b6c6e301c624450d10ca19f66b7e71095dda3780cR128-R132): Added `getLanguage` method to retrieve the `language` property.

Updates to `UserInformationHydrator`:

* [`src/User/Hydrator/UserInformationHydrator.php`](diffhunk://#diff-fc34cb616a3dc153d224a595cbc0e6d86d44ab1034b15109a45a9774c8481b3eR43): Modified the `hydrate` method to include the `language` property from the `UserInterface`.
