### PR TITLE
Do not set text asset data when data not sent to server

### DIFF
--- a/src/Asset/Updater/Adapter/DataAdapter.php
+++ b/src/Asset/Updater/Adapter/DataAdapter.php
@@ -36,6 +36,10 @@ final readonly class DataAdapter implements UpdateAdapterInterface
             return;
         }
 
+        if (!isset($data[$this->getIndexKey()])) {
+            return;
+        }
+
         $element->setData($data[$this->getIndexKey()]);
 
     }


### PR DESCRIPTION
With our patch update approach it should not be mandatory to send the text file content in asset updates.