### PR TITLE
[Data Objects Editor] Delete autosave versions only after save

### DIFF
--- a/src/Element/Service/ElementSaveService.php
+++ b/src/Element/Service/ElementSaveService.php
@@ -100,15 +100,6 @@ final readonly class ElementSaveService implements ElementSaveServiceInterface
             return;
         }
 
-        $this->handlePublishTasks($element, $user, $task);
-        $element->save();
-    }
-
-    /**
-     * @throws ForbiddenException
-     */
-    private function handlePublishTasks(Concrete|Document $element, UserInterface $user, string $task): void
-    {
         if ($task === ElementSaveTasks::PUBLISH->value) {
             $this->publishElement($element, $user);
 
@@ -119,22 +110,24 @@ final readonly class ElementSaveService implements ElementSaveServiceInterface
     }
 
     /**
-     * @throws ForbiddenException
+     * @throws Exception|ForbiddenException
      */
     private function publishElement(Concrete|Document $element, UserInterface $user): void
     {
         $this->securityService->hasElementPermission($element, $user, ElementPermissions::PUBLISH_PERMISSION);
-        $element->deleteAutoSaveVersions($user->getId());
         $element->setPublished(true);
+        $element->save();
+        $element->deleteAutoSaveVersions($user->getId());
     }
 
     /**
-     * @throws ForbiddenException
+     * @throws Exception|ForbiddenException
      */
     private function unpublishElement(Concrete|Document $element, UserInterface $user): void
     {
         $this->securityService->hasElementPermission($element, $user, ElementPermissions::UNPUBLISH_PERMISSION);
         $element->setOmitMandatoryCheck(true);
         $element->setPublished(false);
+        $element->save();
     }
 }

--- a/src/Patcher/Adapter/PublishAdapter.php
+++ b/src/Patcher/Adapter/PublishAdapter.php
@@ -90,7 +90,6 @@ final readonly class PublishAdapter implements PatchAdapterInterface
     private function publishElement(Concrete|Document $element, UserInterface $user): void
     {
         $this->securityService->hasElementPermission($element, $user, ElementPermissions::PUBLISH_PERMISSION);
-        $element->deleteAutoSaveVersions($user->getId());
         $element->setPublished(true);
     }
 


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-backend-bundle/issues/1024

## Additional info
If we remove the autosave versions already before saving of the element, this breaks the version count and does not update e.g. localized fields accordingly 

see:
https://github.com/pimcore/pimcore/blob/12.x/models/DataObject/Concrete.php#L197

if dirty detection is not disabled, then this condition is true and localized fields are not updated:

https://github.com/pimcore/pimcore/blob/12.x/models/DataObject/Localizedfield.php#L632
https://github.com/pimcore/pimcore/blob/12.x/models/DataObject/ClassDefinition/Data/Localizedfields.php#L401
