### PR TITLE
[XLSX Export] Make delimiter optional

### DIFF
--- a/doc/04_Generic_Execution_Engine.md
+++ b/doc/04_Generic_Execution_Engine.md
@@ -34,8 +34,8 @@ There are some configuration options available for the CSV export, which can be 
 ```yaml
 pimcore_studio_backend:
     csv_settings:
-        # Default delimiter for CSV files when no value is passed by grid configuration. Default value is ','.
-        default_delimiter: ','
+        # Default delimiter for CSV files when no value is passed by grid configuration. Default value is ';'.
+        default_delimiter: ';'
 ```
 
 ### Elements Cloning

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -324,7 +324,7 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('default_delimiter')
                         ->info('Default delimiter to be used for csv operations.')
-                        ->defaultValue(',')
+                        ->defaultValue(';')
                     ->end()
                 ->end()
             ->end();

--- a/src/Export/Attribute/Request/ExportDataRequestBody.php
+++ b/src/Export/Attribute/Request/ExportDataRequestBody.php
@@ -31,8 +31,23 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 #[Attribute(Attribute::TARGET_METHOD)]
 final class ExportDataRequestBody extends RequestBody
 {
-    public function __construct()
+    public function __construct(bool $addDelimiter = true)
     {
+        $configProperties = [
+            new Property(
+                property: StepConfig::SETTINGS_HEADER->value,
+                type: 'string',
+                enum: StepConfig::values(),
+                example: StepConfig::SETTINGS_HEADER_TITLE->value
+            ),
+        ];
+        if ($addDelimiter) {
+            $configProperties[] = new Property(
+                property: StepConfig::SETTINGS_DELIMITER->value,
+                type: 'string',
+                example: ';'
+            );
+        }
         parent::__construct(
             content: new JsonContent(
                 properties: [
@@ -42,15 +57,7 @@ final class ExportDataRequestBody extends RequestBody
                         type: 'array',
                         items: new Items(ref: Column::class)
                     ),
-                    new Property(property: 'config', properties: [
-                        new Property(property: StepConfig::SETTINGS_DELIMITER->value, type: 'string', example: ';'),
-                        new Property(
-                            property: StepConfig::SETTINGS_HEADER->value,
-                            type: 'string',
-                            enum: StepConfig::values(),
-                            example: StepConfig::SETTINGS_HEADER_TITLE->value
-                        ),
-                    ], type: 'object'),
+                    new Property(property: 'config', properties: $configProperties, type: 'object'),
                     new Property(
                         property: 'elementType',
                         type: 'string',

--- a/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
+++ b/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
@@ -32,8 +32,24 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 #[Attribute(Attribute::TARGET_METHOD)]
 final class ExportFolderDataRequestBody extends RequestBody
 {
-    public function __construct()
+    public function __construct(bool $addDelimiter = true)
     {
+        $configProperties = [
+            new Property(
+                property: StepConfig::SETTINGS_HEADER->value,
+                type: 'string',
+                enum: StepConfig::values(),
+                example: StepConfig::SETTINGS_HEADER_TITLE->value
+            ),
+        ];
+        if ($addDelimiter) {
+            $configProperties[] = new Property(
+                property: StepConfig::SETTINGS_DELIMITER->value,
+                type: 'string',
+                example: ';'
+            );
+        }
+
         parent::__construct(
             content: new JsonContent(
                 properties: [
@@ -48,15 +64,7 @@ final class ExportFolderDataRequestBody extends RequestBody
                         ref: Filter::class,
                         type: 'object'
                     ),
-                    new Property(property: 'config', properties: [
-                        new Property(property: StepConfig::SETTINGS_DELIMITER->value, type: 'string', example: ';'),
-                        new Property(
-                            property: StepConfig::SETTINGS_HEADER->value,
-                            type: 'string',
-                            enum: StepConfig::values(),
-                            example: StepConfig::SETTINGS_HEADER_TITLE->value
-                        ),
-                    ], type: 'object'),
+                    new Property(property: 'config', properties: $configProperties, type: 'object'),
                     new Property(
                         property: 'elementType',
                         type: 'string',

--- a/src/Export/Controller/Xlsx/ElementController.php
+++ b/src/Export/Controller/Xlsx/ElementController.php
@@ -52,7 +52,7 @@ final class ElementController extends AbstractApiController
         summary: 'export_xlsx_summary',
         tags: [Tags::Export->name]
     )]
-    #[ExportDataRequestBody]
+    #[ExportDataRequestBody(addDelimiter: false)]
     #[CreatedResponse(
         description: 'export_xlsx_created_response',
         content: new IdJson('ID of created jobRun', 'jobRunId')

--- a/src/Export/Controller/Xlsx/FolderController.php
+++ b/src/Export/Controller/Xlsx/FolderController.php
@@ -55,7 +55,7 @@ final class FolderController extends AbstractApiController
         summary: 'export_xlsx_folder_summary',
         tags: [Tags::Export->name]
     )]
-    #[ExportFolderDataRequestBody]
+    #[ExportFolderDataRequestBody(addDelimiter: false)]
     #[CreatedResponse(
         description: 'export_xlsx_created_response',
         content: new IdJson('ID of created jobRun', 'jobRunId')

--- a/src/Export/ExecutionEngine/AutomationAction/Messenger/Handler/XlsxCreationHandler.php
+++ b/src/Export/ExecutionEngine/AutomationAction/Messenger/Handler/XlsxCreationHandler.php
@@ -66,7 +66,6 @@ final class XlsxCreationHandler extends AbstractHandler
         $columns = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CONFIG_COLUMNS->value);
         $settings = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CONFIG_CONFIGURATION->value);
         $headers = $settings[StepConfig::SETTINGS_HEADER->value] ?? StepConfig::SETTINGS_HEADER_NO_HEADER->value;
-        $delimiter = $settings[StepConfig::SETTINGS_DELIMITER->value] ?? null;
 
         if (!isset($jobRun->getContext()[StepConfig::GRID_EXPORT_DATA->value])) {
             $this->abort($this->getAbortData(
@@ -88,8 +87,7 @@ final class XlsxCreationHandler extends AbstractHandler
                     $headers !== StepConfig::SETTINGS_HEADER_NO_HEADER->value,
                     $headers === StepConfig::SETTINGS_HEADER_NAME
                 ),
-                $user,
-                $delimiter
+                $user
             );
         } catch (Exception $e) {
             $this->abort($this->getAbortData(

--- a/src/Export/Util/Trait/ExportConfigValidationTrait.php
+++ b/src/Export/Util/Trait/ExportConfigValidationTrait.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Export\Util\Trait;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
-use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use function in_array;
 

--- a/src/Export/Util/Trait/ExportConfigValidationTrait.php
+++ b/src/Export/Util/Trait/ExportConfigValidationTrait.php
@@ -37,10 +37,6 @@ trait ExportConfigValidationTrait
             throw new InvalidArgumentException('No settings provided');
         }
 
-        if (!isset($this->getConfig()[StepConfig::SETTINGS_DELIMITER->value])) {
-            throw new InvalidArgumentException('No delimiter provided');
-        }
-
         if (!in_array($this->getElementType(), ElementTypes::ALLOWED_TYPES, true)) {
             throw new InvalidArgumentException('Invalid type provided');
         }

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -316,7 +316,9 @@ export_csv_description: |
     <li><strong>columns</strong>: Describes the columns that should be exported. Can be obtained via the grid endpoint</li>
     <li><strong>config</strong>: Delimiter and header options</li>
     <li><strong>elementType</strong>: Type of element that should be exported</li>
-  </ul> Delimiter can be set to anything, but the default is a <strong>semicolon</strong> <br> Header options are: <strong>no_header</strong>, <strong>title</strong> and <strong>name</strong><br>
+  </ul> 
+  Delimiter can be set to anything, but the default is a <strong>semicolon</strong> <br> 
+  Header options are: <strong>no_header</strong>, <strong>title</strong> and <strong>name</strong><br>
   Download has to be triggered separately via the csv download route with the <strong>{jobRunId}</strong> returned in the response
 export_csv_summary: Creating CSV file for elements
 export_csv_folder_description: |
@@ -325,7 +327,9 @@ export_csv_folder_description: |
     <li><strong>columns</strong>: Describes the columns that should be exported. Can be obtained via the grid endpoint. For folders you can also use filters and sorting</li>
     <li><strong>filters</strong>: Filter elements from folder based on the grid filter schema</li>
     <li><strong>config</strong>: Delimiter and header options</li>
-  </ul> Delimiter can be set to anything, but the default is a <strong>semicolon</strong> <br> Header options are: <strong>no_header</strong>, <strong>title</strong> and <strong>name</strong><br>
+  </ul> 
+  Delimiter can be set to anything, but the default is a <strong>semicolon</strong> <br> 
+  Header options are: <strong>no_header</strong>, <strong>title</strong> and <strong>name</strong><br>
   Download has to be triggered separately via the csv download route with the <strong>{jobRunId}</strong> returned in the response
 export_csv_folder_summary: Creating CSV file for elements based on folder
 export_delete_csv_description: |
@@ -348,9 +352,10 @@ export_xlsx_description: |
   Creating the XLSX file for elements. <br> Parameters are: <ul>
     <li><strong>elements</strong>: Array of element ids</li>
     <li><strong>columns</strong>: Describes the columns that should be exported. Can be obtained via the grid endpoint</li>
-    <li><strong>config</strong>: Delimiter and header options</li>
+    <li><strong>config</strong>: Header options</li>
     <li><strong>elementType</strong>: Type of element that should be exported</li>
-  </ul> Delimiter can be set to anything, but the default is a <strong>semicolon</strong> <br> Header options are: <strong>no_header</strong>, <strong>title</strong> and <strong>name</strong><br>
+  </ul>
+  Header options are: <strong>no_header</strong>, <strong>title</strong> and <strong>name</strong><br>
   Download has to be triggered separately via the xlsx download route with the <strong>{jobRunId}</strong> returned in the response
 export_xlsx_summary: Creating XLSX file export for elements
 export_xlsx_folder_description: |
@@ -358,8 +363,9 @@ export_xlsx_folder_description: |
     <li><strong>folders</strong>: Array of folder ids</li>
     <li><strong>columns</strong>: Describes the columns that should be exported. Can be obtained via the grid endpoint. For folders you can also use filters and sorting</li>
     <li><strong>filters</strong>: Filter elements from folder based on the grid filter schema</li>
-    <li><strong>config</strong>: Delimiter and header options</li>
-  </ul> Delimiter can be set to anything, but the default is a <strong>semicolon</strong> <br> Header options are: <strong>no_header</strong>, <strong>title</strong> and <strong>name</strong><br>
+    <li><strong>config</strong>: Header options</li>
+  </ul> 
+  Header options are: <strong>no_header</strong>, <strong>title</strong> and <strong>name</strong><br>
   Download has to be triggered separately via the xlsx download route with the <strong>{jobRunId}</strong> returned in the response
 export_xlsx_folder_summary: Creating XLSX file for elements based on folder
 login_description: Logs in a user with the provided credentials and returns the user information.


### PR DESCRIPTION
## Changes in this pull request
Resolves #1033

## Additional info
- XLSX export should always use default delimiter when preparing data for export
- use default delimiter if not provided (as stated in the endpoint description)
- make default delimiter `;` as described in the endpoint description