### PR TITLE
[Documents] DocType list endpoint

### DIFF
--- a/config/documents.yaml
+++ b/config/documents.yaml
@@ -27,6 +27,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Document\Service\DocumentServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Document\Service\DocumentService
 
+  Pimcore\Bundle\StudioBackendBundle\Document\Service\DocTypeServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Document\Service\DocTypeService
+
   Pimcore\Bundle\StudioBackendBundle\Document\Service\SiteServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Document\Service\SiteService
 
@@ -44,6 +47,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Document\Repository\SiteRepositoryInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Document\Repository\SiteRepository
 
+  Pimcore\Bundle\StudioBackendBundle\Document\Repository\DocTypeRepositoryInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Document\Repository\DocTypeRepository
+
 
   #
   # Hydrators
@@ -51,3 +57,6 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\Document\Hydrator\SiteHydratorInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Document\Hydrator\SiteHydrator
+
+  Pimcore\Bundle\StudioBackendBundle\Document\Hydrator\DocTypeHydratorInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Document\Hydrator\DocTypeHydrator

--- a/doc/05_Additional_Custom_Attributes.md
+++ b/doc/05_Additional_Custom_Attributes.md
@@ -66,6 +66,9 @@ final class AssetEvent extends AbstractPreResponseEvent
 - `additionalCssClasses` - Additional CSS classes that should be added to the tree element.
 
 ### List of available events
+- `asset.delete`
+- `data_object.delete`
+- `document.delete`
 - `pre_response.asset`
 - `pre_response.asset_custom_metadata`
 - `pre_response.asset_custom_settings`
@@ -91,6 +94,7 @@ final class AssetEvent extends AbstractPreResponseEvent
 - `pre_response.data_object_version`
 - `pre_response.dependency`
 - `pre_response.document`
+- `pre_response.document.doc_type_list`
 - `pre_response.document.sites_list_available`
 - `pre_response.document_version`
 - `pre_response.email.blocklist.entry`

--- a/src/Asset/Event/AssetDeleteEvent.php
+++ b/src/Asset/Event/AssetDeleteEvent.php
@@ -18,7 +18,7 @@ use Pimcore\Event\Model\AssetEvent;
 
 final class AssetDeleteEvent extends AssetEvent
 {
-    public const EVENT_NAME = 'asset.delete';
+    public const string EVENT_NAME = 'asset.delete';
 
     use ElementDeleteParamsTrait;
 }

--- a/src/DataObject/Event/DataObjectDeleteEvent.php
+++ b/src/DataObject/Event/DataObjectDeleteEvent.php
@@ -18,7 +18,7 @@ use Pimcore\Event\Model\DataObjectEvent;
 
 final class DataObjectDeleteEvent extends DataObjectEvent
 {
-    public const EVENT_NAME = 'dataObject.delete';
+    public const string EVENT_NAME = 'data_object.delete';
 
     use ElementDeleteParamsTrait;
 }

--- a/src/Document/Controller/DocType/ListController.php
+++ b/src/Document/Controller/DocType/ListController.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Document\MappedParameter\TypeParameter;
 use Pimcore\Bundle\StudioBackendBundle\Document\Schema\DocType;
 use Pimcore\Bundle\StudioBackendBundle\Document\Service\DocTypeServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\TextFieldParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\ItemsJson;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
@@ -45,6 +46,9 @@ final class ListController extends AbstractApiController
         parent::__construct($serializer);
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     #[Route(
         path: self::ROUTE,
         name: 'pimcore_studio_api_list_document_doc_type',

--- a/src/Document/Controller/DocType/ListController.php
+++ b/src/Document/Controller/DocType/ListController.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Document\Controller\DocType;
+
+use OpenApi\Attributes\Get;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Document\MappedParameter\TypeParameter;
+use Pimcore\Bundle\StudioBackendBundle\Document\Schema\DocType;
+use Pimcore\Bundle\StudioBackendBundle\Document\Service\DocTypeServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\TextFieldParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\ItemsJson;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapQueryString;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class ListController extends AbstractApiController
+{
+    private const string ROUTE = '/documents/doc-types';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly DocTypeServiceInterface $docTypeService,
+    ) {
+        parent::__construct($serializer);
+    }
+
+    #[Route(
+        path: self::ROUTE,
+        name: 'pimcore_studio_api_list_document_doc_type',
+        methods: ['GET']
+    )]
+    #[IsGranted(UserPermissions::DOCUMENTS->value)]
+    #[Get(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'document_doc_type_list',
+        description: 'document_doc_type_list_description',
+        summary: 'document_doc_type_list_summary',
+        tags: [Tags::Documents->value]
+    )]
+    #[TextFieldParameter(name: 'type', description: 'Filter results by docType type', example: 'page')]
+    #[SuccessResponse(
+        description: 'document_doc_type_list_success_response',
+        content: new ItemsJson(DocType::class),
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::NOT_FOUND,
+    ])]
+    public function getDocTypeList(#[MapQueryString] TypeParameter $parameter = new TypeParameter()): JsonResponse
+    {
+        return $this->jsonResponse(['items' => $this->docTypeService->listDocTypes($parameter->getType())]);
+    }
+}

--- a/src/Document/Event/PreResponse/DocTypeEvent.php
+++ b/src/Document/Event/PreResponse/DocTypeEvent.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Document\Event\PreResponse;
+
+use Pimcore\Bundle\StudioBackendBundle\Document\Schema\DocType;
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+
+final class DocTypeEvent extends AbstractPreResponseEvent
+{
+    public const string EVENT_NAME = 'pre_response.document.doc_type_list';
+
+    public function __construct(
+        private readonly DocType $docType
+    ) {
+        parent::__construct($docType);
+    }
+
+    /**
+     * Use this to get additional info out of the response object
+     */
+    public function getDocType(): DocType
+    {
+        return $this->docType;
+    }
+}

--- a/src/Document/Hydrator/DocTypeHydrator.php
+++ b/src/Document/Hydrator/DocTypeHydrator.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Document\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\Document\Schema\DocType;
+use Pimcore\Model\Document\DocType as DocTypeModel;
+
+/**
+ * @internal
+ */
+final class DocTypeHydrator implements DocTypeHydratorInterface
+{
+    public function hydrate(DocTypeModel $docType): DocType
+    {
+        return new DocType(
+            id: $docType->getId(),
+            name: $docType->getName(),
+            type: $docType->getType(),
+            group: $docType->getGroup(),
+            controller: $docType->getController(),
+            template: $docType->getTemplate(),
+            priority: $docType->getPriority(),
+            creationDate: $docType->getCreationDate(),
+            modificationDate: $docType->getModificationDate(),
+            staticGeneratorEnabled: $docType->getStaticGeneratorEnabled(),
+            writeable: $docType->isWriteable()
+        );
+    }
+}

--- a/src/Document/Hydrator/DocTypeHydratorInterface.php
+++ b/src/Document/Hydrator/DocTypeHydratorInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Document\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\Document\Schema\DocType;
+use Pimcore\Model\Document\DocType as DocTypeModel;
+
+/**
+ * @internal
+ */
+interface DocTypeHydratorInterface
+{
+    public function hydrate(DocTypeModel $docType): DocType;
+}

--- a/src/Document/MappedParameter/TypeParameter.php
+++ b/src/Document/MappedParameter/TypeParameter.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Document\MappedParameter;
+
+/**
+ * @internal
+ */
+final readonly class TypeParameter
+{
+    public function __construct(
+        private ?string $type = null
+    ) {
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+}

--- a/src/Document/Repository/DocTypeRepository.php
+++ b/src/Document/Repository/DocTypeRepository.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Document\Repository;
+
+use Pimcore\Bundle\StaticResolverBundle\Models\Document\DocumentServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Model\Document\DocType;
+use Pimcore\Model\Document\DocType\Listing;
+
+/**
+ * @internal
+ */
+final readonly class DocTypeRepository implements DocTypeRepositoryInterface
+{
+    public function __construct(
+        private DocumentServiceResolverInterface $documentServiceResolver,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function listDocTypes(string $type = null): array
+    {
+        $listing = new Listing();
+        if ($type !== null) {
+            if (!$this->documentServiceResolver->isValidType($type)) {
+                throw new InvalidArgumentException(sprintf('Invalid DocType type %s', $type));
+            }
+
+            $listing->setFilter(static function (DocType $docType) use ($type) {
+                return $docType->getType() === $type;
+            });
+        }
+
+        return $listing->getDocTypes();
+    }
+}

--- a/src/Document/Repository/DocTypeRepository.php
+++ b/src/Document/Repository/DocTypeRepository.php
@@ -17,6 +17,7 @@ use Pimcore\Bundle\StaticResolverBundle\Models\Document\DocumentServiceResolverI
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Model\Document\DocType;
 use Pimcore\Model\Document\DocType\Listing;
+use function sprintf;
 
 /**
  * @internal

--- a/src/Document/Repository/DocTypeRepository.php
+++ b/src/Document/Repository/DocTypeRepository.php
@@ -32,7 +32,7 @@ final readonly class DocTypeRepository implements DocTypeRepositoryInterface
     /**
      * {@inheritDoc}
      */
-    public function listDocTypes(string $type = null): array
+    public function listDocTypes(?string $type = null): array
     {
         $listing = new Listing();
         if ($type !== null) {

--- a/src/Document/Repository/DocTypeRepositoryInterface.php
+++ b/src/Document/Repository/DocTypeRepositoryInterface.php
@@ -23,6 +23,7 @@ interface DocTypeRepositoryInterface
 {
     /**
      * @throws InvalidArgumentException
+     *
      * @return DocType[]
      */
     public function listDocTypes(?string $type = null): array;

--- a/src/Document/Repository/DocTypeRepositoryInterface.php
+++ b/src/Document/Repository/DocTypeRepositoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Document\Repository;
+
+use Pimcore\Model\Document\DocType;
+
+/**
+ * @internal
+ */
+interface DocTypeRepositoryInterface
+{
+    /**
+     * @return DocType[]
+     */
+    public function listDocTypes(string $type = null): array;
+}

--- a/src/Document/Repository/DocTypeRepositoryInterface.php
+++ b/src/Document/Repository/DocTypeRepositoryInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Document\Repository;
 
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Model\Document\DocType;
 
 /**
@@ -21,6 +22,7 @@ use Pimcore\Model\Document\DocType;
 interface DocTypeRepositoryInterface
 {
     /**
+     * @throws InvalidArgumentException
      * @return DocType[]
      */
     public function listDocTypes(?string $type = null): array;

--- a/src/Document/Repository/DocTypeRepositoryInterface.php
+++ b/src/Document/Repository/DocTypeRepositoryInterface.php
@@ -23,5 +23,5 @@ interface DocTypeRepositoryInterface
     /**
      * @return DocType[]
      */
-    public function listDocTypes(string $type = null): array;
+    public function listDocTypes(?string $type = null): array;
 }

--- a/src/Document/Schema/DocType.php
+++ b/src/Document/Schema/DocType.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Document\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Document\DocumentTypes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+#[Schema(
+    schema: 'DocType',
+    title: 'DocType',
+    required: [
+        'id', 'name', 'type', 'group', 'controller', 'template', 'priority',
+        'creationDate', 'modificationDate', 'staticGeneratorEnabled', 'writeable'
+    ],
+    type: 'object'
+)]
+final class DocType implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(description: 'ID', type: 'string', example: '1')]
+        private readonly string $id,
+        #[Property(description: 'Name', type: 'string', example: 'Default Page')]
+        private readonly string $name,
+        #[Property(description: 'Type', type: 'string', example: DocumentTypes::PAGE->value)]
+        private readonly string $type,
+        #[Property(description: 'Group', type: 'string', example: 'Default')]
+        private readonly ?string $group = null,
+        #[Property(
+            description: 'Controller',
+            type: 'string',
+            example: 'App\\Controller\\DefaultController::indexAction'
+        )]
+        private readonly ?string $controller = null,
+        #[Property(description: 'Template', type: 'string', example: '@App/Resources/views/default.html.twig')]
+        private readonly ?string $template = null,
+        #[Property(description: 'Priority', type: 'integer', example: 0)]
+        private readonly int $priority = 0,
+        #[Property(description: 'Creation date', type: 'integer', example: null)]
+        private readonly ?int $creationDate = null,
+        #[Property(description: 'Modification date', type: 'integer', example: null)]
+        private readonly ?int $modificationDate = null,
+        #[Property(description: 'Static generator enabled', type: 'boolean', example: false)]
+        private readonly bool $staticGeneratorEnabled = false,
+        #[Property(description: 'Is writeable', type: 'boolean', example: false)]
+        private readonly bool $writeable = false,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getGroup(): ?string
+    {
+        return $this->group;
+    }
+
+    public function getController(): ?string
+    {
+        return $this->controller;
+    }
+
+    public function getTemplate(): ?string
+    {
+        return $this->template;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+
+    public function getCreationDate(): ?int
+    {
+        return $this->creationDate;
+    }
+
+    public function getModificationDate(): ?int
+    {
+        return $this->modificationDate;
+    }
+
+    public function isStaticGeneratorEnabled(): bool
+    {
+        return $this->staticGeneratorEnabled;
+    }
+
+    public function isWriteable(): bool
+    {
+        return $this->writeable;
+    }
+}

--- a/src/Document/Schema/DocType.php
+++ b/src/Document/Schema/DocType.php
@@ -24,7 +24,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
     title: 'DocType',
     required: [
         'id', 'name', 'type', 'group', 'controller', 'template', 'priority',
-        'creationDate', 'modificationDate', 'staticGeneratorEnabled', 'writeable'
+        'creationDate', 'modificationDate', 'staticGeneratorEnabled', 'writeable',
     ],
     type: 'object'
 )]

--- a/src/Document/Service/DocTypeService.php
+++ b/src/Document/Service/DocTypeService.php
@@ -46,8 +46,8 @@ final readonly class DocTypeService implements DocTypeServiceInterface
         foreach ($docTypeList as $docType) {
             if (!$this->securityService->getCurrentUser()->isAllowed(
                 $docType->getId(),
-                ElementTypes::DOC_TYPE)
-            ) {
+                ElementTypes::DOC_TYPE
+            )) {
                 continue;
             }
 

--- a/src/Document/Service/DocTypeService.php
+++ b/src/Document/Service/DocTypeService.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Document\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Document\Event\PreResponse\DocTypeEvent;
+use Pimcore\Bundle\StudioBackendBundle\Document\Hydrator\DocTypeHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\Document\Repository\DocTypeRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\UserPermissionTrait;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+final readonly class DocTypeService implements DocTypeServiceInterface
+{
+    use UserPermissionTrait;
+
+    public function __construct(
+        private DocTypeHydratorInterface $hydrator,
+        private DocTypeRepositoryInterface $docTypeRepository,
+        private EventDispatcherInterface $eventDispatcher,
+        private SecurityServiceInterface $securityService,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function listDocTypes(?string $type): array
+    {
+        $docTypes = [];
+        $docTypeList = $this->docTypeRepository->listDocTypes($type);
+        foreach ($docTypeList as $docType) {
+            if (!$this->securityService->getCurrentUser()->isAllowed(
+                $docType->getId(),
+                ElementTypes::DOC_TYPE)
+            ) {
+                continue;
+            }
+
+            $hydrated = $this->hydrator->hydrate($docType);
+            $this->eventDispatcher->dispatch(new DocTypeEvent($hydrated), DocTypeEvent::EVENT_NAME);
+
+            $docTypes[] = $hydrated;
+        }
+
+        return $docTypes;
+    }
+}

--- a/src/Document/Service/DocTypeServiceInterface.php
+++ b/src/Document/Service/DocTypeServiceInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Document\Service;
 
 use Pimcore\Bundle\StudioBackendBundle\Document\Schema\DocType;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 
 /**
  * @internal
@@ -21,6 +22,7 @@ use Pimcore\Bundle\StudioBackendBundle\Document\Schema\DocType;
 interface DocTypeServiceInterface
 {
     /**
+     * @throws InvalidArgumentException
      * @return DocType[]
      */
     public function listDocTypes(?string $type): array;

--- a/src/Document/Service/DocTypeServiceInterface.php
+++ b/src/Document/Service/DocTypeServiceInterface.php
@@ -23,6 +23,7 @@ interface DocTypeServiceInterface
 {
     /**
      * @throws InvalidArgumentException
+     *
      * @return DocType[]
      */
     public function listDocTypes(?string $type): array;

--- a/src/Document/Service/DocTypeServiceInterface.php
+++ b/src/Document/Service/DocTypeServiceInterface.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Document\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Document\Schema\DocType;
+
+/**
+ * @internal
+ */
+interface DocTypeServiceInterface
+{
+    /**
+     * @return DocType[]
+     */
+    public function listDocTypes(?string $type): array;
+}

--- a/src/Icon/Service/IconService.php
+++ b/src/Icon/Service/IconService.php
@@ -19,6 +19,7 @@ use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchR
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Util\Trait\ValidateObjectDataTrait;
 use Pimcore\Bundle\StudioBackendBundle\Response\ElementIcon;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Document\DocumentTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementIconTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\DataObject;
@@ -103,12 +104,12 @@ final readonly class IconService implements IconServiceInterface
     public function getIconForDocument(string $documentType): ElementIcon
     {
         $value = match ($documentType) {
-            'email' => 'email',
-            'hardlink' => 'hardlink',
-            'folder' => 'folder',
-            'link' => 'link',
-            'page' => 'page',
-            'snippet' => 'snippet',
+            DocumentTypes::EMAIL->value => 'email',
+            DocumentTypes::HARDLINK->value => 'hardlink',
+            ElementTypes::TYPE_FOLDER => 'folder',
+            DocumentTypes::LINK->value => 'link',
+            DocumentTypes::PAGE->value => 'page',
+            DocumentTypes::SNIPPET->value => 'snippet',
             default => self::DEFAULT_ICON
         };
 

--- a/src/OpenApi/Attribute/Response/Content/ItemsJson.php
+++ b/src/OpenApi/Attribute/Response/Content/ItemsJson.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content;
+
+use OpenApi\Attributes\Items;
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Property;
+
+/**
+ * @internal
+ */
+final class ItemsJson extends JsonContent
+{
+    public function __construct(string $itemsClass)
+    {
+        parent::__construct(
+            required: ['items'],
+            properties: [
+                new Property(
+                    'items',
+                    type: 'array',
+                    items: new Items(ref: $itemsClass)
+                ),
+            ],
+            type: 'object',
+        );
+    }
+}

--- a/src/Util/Constant/ElementTypes.php
+++ b/src/Util/Constant/ElementTypes.php
@@ -15,27 +15,29 @@ namespace Pimcore\Bundle\StudioBackendBundle\Util\Constant;
 
 final readonly class ElementTypes
 {
-    public const TYPE_ASSET = 'asset';
+    public const string  TYPE_ASSET = 'asset';
 
-    public const TYPE_DOCUMENT = 'document';
+    public const string  TYPE_DOCUMENT = 'document';
 
-    public const TYPE_DATA_OBJECT = 'data-object';
+    public const string  TYPE_DATA_OBJECT = 'data-object';
 
-    public const TYPE_ELEMENT = 'element';
+    public const string  TYPE_ELEMENT = 'element';
 
-    public const TYPE_OBJECT = 'object';
+    public const string  TYPE_OBJECT = 'object';
 
-    public const TYPE_VARIANT = 'variant';
+    public const string  TYPE_VARIANT = 'variant';
 
-    public const TYPE_ARCHIVE = 'zip archive';
+    public const string  TYPE_ARCHIVE = 'zip archive';
 
-    public const TYPE_FOLDER = 'folder';
+    public const string  TYPE_FOLDER = 'folder';
 
-    public const TYPE_EMAIL = 'E-Mail';
+    public const string TYPE_EMAIL = 'E-Mail';
 
-    public const TYPE_CLASS_DEFINITION = 'class definition';
+    public const string TYPE_CLASS_DEFINITION = 'class definition';
 
-    public const ALLOWED_TYPES = [
+    public const string DOC_TYPE = 'docType';
+
+    public const array ALLOWED_TYPES = [
         self::TYPE_DATA_OBJECT,
         self::TYPE_OBJECT,
         self::TYPE_ASSET,

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -212,6 +212,10 @@ document_add_description: |
   Add a new data object to the given <strong>{parentId}</strong>. <br> The <strong>{parentId}</strong> must be an ID of a folder or another data object. See the full description of request fields with the schema <strong>DocumentAdd</strong>
 document_add_success_response: ID of added document
 document_add_summary: Add a new document
+document_doc_type_list_description: |
+  List all DocTypes. Results can be filtered based on the given <strong>{type}</strong>. <br> The <strong>{type}</strong> must be an existing DocType type.
+document_doc_type_list_success_response: List of all DocTypes
+document_doc_type_list_summary: List all document DocTypes
 document_get_by_id_description: |
   Retrieves a specific document based on the given <strong>{id}</strong>. <br> The <strong>{id}</strong> must be an ID of existing document or folder.
 document_get_by_id_success_response: Successfully retrieved document data as JSON


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-backend-bundle/issues/1078

## Additional info
This endpoint can be also used when building the context menu to add different document types based on the DocTypes and groups