### PR TITLE
[Docs] Fixed mercure configuration docs

### DIFF
--- a/doc/00_Installation.md
+++ b/doc/00_Installation.md
@@ -113,13 +113,13 @@ pimcore_studio_backend:
         # Optional configuration
 
         # The url to the mercure hub for the (frontend) client.
-        # If it is not set, the default will be set to "http(s)://<PIMCORE_HOST>/hub/.well-known/mercure".
-        # It is possible to use "<PIMCORE_SCHEMA_HOST>" as a placeholder for the current schema and host.
+        # If it is not set, the default will be set to "http(s)://<YOUR_CURRENT_PIMCORE_HOST>/hub".
+        # It is possible to use "<PIMCORE_SCHEMA_HOST>" as a placeholder for the current schema and host if path to mercure should be different.
         hub_url_client: 'https://your-app-domain.com/hub'
 
         # The url to the mercure hub for the server. 
         # This can also be the docker container name (e.g., http://mercure/.well-known/mercure).
-        # If it is not set, the default will be set to "http(s)://<PIMCORE_HOST>/hub/.well-known/mercure".
+        # If it is not set, the default will be set to "http(s)://<PIMCORE_HOST>/hub".
         hub_url_server: 'http://mercure/.well-known/mercure'
         cookie_lifetime: 3600
         cookie_same_site: 'Strict'

--- a/doc/00_Installation.md
+++ b/doc/00_Installation.md
@@ -119,7 +119,7 @@ pimcore_studio_backend:
 
         # The url to the mercure hub for the server. 
         # This can also be the docker container name (e.g., http://mercure/.well-known/mercure).
-        # If it is not set, the default will be set to "http(s)://<PIMCORE_HOST>/hub".
+        # If it is not set, the default will be set to "http(s)://<YOUR_CURRENT_PIMCORE_HOST>/hub/.well-known/mercure".
         hub_url_server: 'http://mercure/.well-known/mercure'
         cookie_lifetime: 3600
         cookie_same_site: 'Strict'

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -284,16 +284,16 @@ class Configuration implements ConfigurationInterface
                             'This can also be the docker container name '.
                             '(e.g., http://mercure/.well-known/mercure). ' .
                             'If it is not set, default will be set to ' .
-                            '"http(s)://<PIMCORE_HOST>/hub/.well-known/mercure".'
+                            '"http(s)://<YOUR_PIMCORE_MAIN_DOMAIN>/hub".'
                         )
                         ->defaultNull()
                     ->end()
                     ->scalarNode('hub_url_client')
                         ->info('The url to the mercure hub for the (frontend) client. ' .
                             'If it is not set, the default will be set to ' .
-                            '"http(s)://<PIMCORE_HOST>/hub/.well-known/mercure". ' .
+                            '"http(s)://<YOUR_CURRENT_PIMCORE_HOST>/hub". ' .
                             'It is possible to use "<PIMCORE_SCHEMA_HOST>" ' .
-                            'as a placeholder for the current schema and host.'
+                            'as a placeholder for the current schema and host if path to mercure should be different.'
                         )
                         ->defaultNull()
                     ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -284,7 +284,7 @@ class Configuration implements ConfigurationInterface
                             'This can also be the docker container name '.
                             '(e.g., http://mercure/.well-known/mercure). ' .
                             'If it is not set, default will be set to ' .
-                            '"http(s)://<YOUR_PIMCORE_MAIN_DOMAIN>/hub".'
+                            '"http(s)://<YOUR_PIMCORE_MAIN_DOMAIN>/hub/.well-known/mercure".'
                         )
                         ->defaultNull()
                     ->end()

--- a/src/Mercure/Service/UrlService.php
+++ b/src/Mercure/Service/UrlService.php
@@ -31,7 +31,7 @@ final readonly class UrlService implements UrlServiceInterface
     public function getServerSideUrl(): string
     {
         if (empty($this->serverSideUrl)) {
-            return $this->getDefaultUrl();
+            return $this->getDefaultServerUrl();
         }
 
         return $this->serverSideUrl;
@@ -40,13 +40,18 @@ final readonly class UrlService implements UrlServiceInterface
     public function getClientSideUrl(): string
     {
         if (empty($this->clientSideUrl)) {
-            return $this->getDefaultUrl();
+            return $this->getDefaultClientUrl();
         }
 
         return str_replace(Mercure::HOST_PLACEHOLDER->value, $this->toolResolver->getHostUrl(), $this->clientSideUrl);
     }
 
-    private function getDefaultUrl(): string
+    private function getDefaultServerUrl(): string
+    {
+        return $this->toolResolver->getHostUrl() . '/hub/.well-known/mercure';
+    }
+
+    private function getDefaultClientUrl(): string
     {
         return $this->toolResolver->getHostUrl() . '/hub';
     }


### PR DESCRIPTION
followup to https://github.com/pimcore/studio-backend-bundle/pull/1070

@lukmzig I updated the docs to the behavior I noticed during my tests. Could you please double check. Also I'm not sure, if it makes sense, if the default `hub_url_server` ends with `/hub` ... of if it would be better to have a different default value than `hub_url_client` and end it with `/.well-known/mercure` ... as `/hub` probably will never fit? WDYT? 

Thx for checking.