### PR TITLE
[Data objects] localized fields are empty

### DIFF
--- a/src/Security/Service/LanguageService.php
+++ b/src/Security/Service/LanguageService.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Security\Service;
 
+use Pimcore\Bundle\StaticResolverBundle\Lib\ToolResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Model\DataObject;
@@ -26,7 +27,8 @@ use function sprintf;
 final readonly class LanguageService implements LanguageServiceInterface
 {
     public function __construct(
-        private SecurityServiceInterface $securityService
+        private SecurityServiceInterface $securityService,
+        private ToolResolverInterface $toolResolver,
     ) {
     }
 
@@ -39,10 +41,21 @@ final readonly class LanguageService implements LanguageServiceInterface
             throw new InvalidArgumentException(sprintf('Invalid permission "%s"', $permission));
         }
 
-        return $this->securityService->getSpecialDataObjectPermissions(
+        $languagePermissions =  $this->securityService->getSpecialDataObjectPermissions(
             $dataObject,
             $user,
             $permission
         );
+
+        if (empty($languagePermissions) || $this->isDefaultLanguagePermission($languagePermissions)) {
+            return $this->toolResolver->getValidLanguages();
+        }
+
+        return $languagePermissions;
+    }
+
+    private function isDefaultLanguagePermission(array $permissions): bool
+    {
+        return count($permissions) === 1 && in_array($permissions[0], ['', 'default'], true);
     }
 }

--- a/src/Security/Service/LanguageService.php
+++ b/src/Security/Service/LanguageService.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\UserInterface;
+use function count;
 use function in_array;
 use function sprintf;
 

--- a/src/User/Schema/KeyBinding.php
+++ b/src/User/Schema/KeyBinding.php
@@ -30,7 +30,7 @@ final readonly class KeyBinding
     public function __construct(
         #[Property(description: 'ASCII Code for a key on the Keyboard', type: 'integer', example: '83')]
         private int $key,
-        #[Property(description: 'The action the key binding shoudl execute', type: 'string', example: 'save')]
+        #[Property(description: 'The action the key binding should execute', type: 'string', example: 'save')]
         private string $action,
         #[Property(description: 'If CTRL key should be pressed', type: 'boolean', example: 'true')]
         private bool $ctrl,

--- a/src/User/Schema/User.php
+++ b/src/User/Schema/User.php
@@ -50,7 +50,7 @@ final class User implements AdditionalAttributesInterface
         #[Property(description: 'If a User is active', type: 'boolean', example: true)]
         private readonly bool $active,
         #[Property(description: 'If User is admin', type: 'boolean', example: false)]
-        private bool $admin,
+        private readonly bool $admin,
         #[Property(description: 'Classes the user is allows to see', type: 'object', example: ['CAR'])]
         private readonly array $classes,
         #[Property(type: 'boolean', example: true)]


### PR DESCRIPTION
## Changes in this pull request
Pat of https://github.com/pimcore/studio-ui-bundle/issues/1525

## Additional info
When user has no restricted languages in view permissions, consider it as all of them are allowed (same as in the Classic UI)