### PR TITLE
Update PublicTranslations.php

### DIFF
--- a/src/Util/Constant/PublicTranslations.php
+++ b/src/Util/Constant/PublicTranslations.php
@@ -19,9 +19,13 @@ namespace Pimcore\Bundle\StudioBackendBundle\Util\Constant;
 final readonly class PublicTranslations
 {
     public const PUBLIC_KEYS = [
-        'username',
-        'password',
-        'login',
-        'Forgot your password',
+        'aria.login-form-additional-logins.remember-me-checkbox',
+        'login-form.remember-me',
+        'login-form.forgot-password',
+        'login-form.login',
+        'login-form-additional-logins.or',
+        'aria.login-form-additional-logins.additional-login-provider',
+        'login-form.username',
+        'login-form.password'
     ];
 }

--- a/src/Util/Constant/PublicTranslations.php
+++ b/src/Util/Constant/PublicTranslations.php
@@ -26,6 +26,6 @@ final readonly class PublicTranslations
         'login-form-additional-logins.or',
         'aria.login-form-additional-logins.additional-login-provider',
         'login-form.username',
-        'login-form.password'
+        'login-form.password',
     ];
 }


### PR DESCRIPTION
## Changes in this pull request
Related to: https://github.com/pimcore/studio-ui-bundle/issues/1504

## Additional info
This pull request updates the `PUBLIC_KEYS` constant in the `PublicTranslations` class to use more descriptive and structured keys for translation identifiers. This change improves clarity and consistency in the codebase.

Key changes:

* [`src/Util/Constant/PublicTranslations.php`](diffhunk://#diff-a53107c0595e7e66f62c9f53de91b79e819a7440fc526c8b456eda7c11a8ba32L22-R29): Replaced generic translation keys like `'username'` and `'password'` with more descriptive and structured keys such as `'login-form.username'` and `'login-form.password'`. This ensures better organization and readability of translation keys.