### PR TITLE
Update ContextPermissionService.php

### DIFF
--- a/src/Perspective/Service/ContextPermissionService.php
+++ b/src/Perspective/Service/ContextPermissionService.php
@@ -25,7 +25,7 @@ use function sprintf;
 final class ContextPermissionService implements ContextPermissionsServiceInterface
 {
     private array $extraPermissions = [
-        'applicationLog' => true,
+        'applicationlog' => true,
         'emails' => true,
         'gdpr_data_extractor' => true,
         'glossary' => true,


### PR DESCRIPTION
Hi Team, 

according to: 
https://github.com/pimcore/pimcore/blob/f2ec89bb94fdf6fd2bca66472a7b179b69164269/bundles/ApplicationLoggerBundle/public/js/startup.js#L26

the permission should be named `applicationlog`.  (not camelcase).

## Additional info

This pull request includes a minor adjustment to the `ContextPermissionService` class. The change corrects the casing of the `applicationLog` key in the `$extraPermissions` array to ensure consistency with other keys.
