### PR TITLE
[Website Settings] - Update Call Fails on data: null for elements

### DIFF
--- a/src/WebsiteSetting/Repository/WebsiteSettingsRepository.php
+++ b/src/WebsiteSetting/Repository/WebsiteSettingsRepository.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\Listing\Service\ListingFilterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
+use Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Schema\ElementParameter;
 use Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Schema\WebsiteSettingsUpdate;
 use Pimcore\Model\WebsiteSetting;
 use Pimcore\Model\WebsiteSetting\Listing;
@@ -68,7 +69,7 @@ final readonly class WebsiteSettingsRepository implements WebsiteSettingsReposit
         $setting->setName($parameters->getName());
         $setting->setLanguage($parameters->getLanguage());
         $setting->setSiteId($parameters->getSiteId());
-        $this->updateData($setting, $parameters->getData());
+        $this->updateData($setting, $parameters);
 
         try {
             $setting->save();
@@ -100,12 +101,15 @@ final readonly class WebsiteSettingsRepository implements WebsiteSettingsReposit
         return $setting;
     }
 
-    private function updateData(WebsiteSetting $setting, null|string|bool $parameterData): void
+    private function updateData(WebsiteSetting $setting, WebsiteSettingsUpdate $parameters): void
     {
-        $data = $parameterData;
-        if (in_array($setting->getType(), ElementTypes::ALLOWED_TYPES, true)) {
+        $data = $parameters->getData();
+        if (
+            $data instanceof ElementParameter &&
+            in_array($setting->getType(), ElementTypes::ALLOWED_TYPES, true)
+        ) {
             try {
-                $data = $this->getElementByPath($this->serviceResolver, $setting->getType(), $parameterData);
+                $data = $this->getElementByPath($this->serviceResolver, $setting->getType(), $data->getFullPath());
             } catch (NotFoundException) {
                 $data = null;
             }

--- a/src/WebsiteSetting/Schema/ElementParameter.php
+++ b/src/WebsiteSetting/Schema/ElementParameter.php
@@ -19,16 +19,16 @@ use OpenApi\Attributes\Schema;
 #[Schema(
     schema: 'WebsiteSettingsObjectData',
     title: 'Website Settings Object Data',
-    required: ['id', 'path'],
+    required: ['id', 'fullPath'],
     type: 'object'
 )]
 final readonly class ElementParameter
 {
     public function __construct(
-        #[Property(description: 'id', type: 'int', example: 1020)]
+        #[Property(description: 'element id', type: 'int', example: 1020)]
         private int $id,
-        #[Property(description: 'path', type: 'string', example: '/path/to/object')]
-        private string $path,
+        #[Property(description: 'element fullPath', type: 'string', example: '/path/to/object')]
+        private string $fullPath,
     ) {
 
     }
@@ -38,8 +38,8 @@ final readonly class ElementParameter
         return $this->id;
     }
 
-    public function getPath(): string
+    public function getFullPath(): string
     {
-        return $this->path;
+        return $this->fullPath;
     }
 }

--- a/src/WebsiteSetting/Schema/WebsiteSettingsUpdate.php
+++ b/src/WebsiteSetting/Schema/WebsiteSettingsUpdate.php
@@ -34,13 +34,14 @@ final readonly class WebsiteSettingsUpdate
         private string $language,
         #[Property(
             description: 'Data',
-            example: true,
+            example: '{"id": 136,"fullPath": "/de"}',
             anyOf: [
                 new Schema(type: 'string'),
                 new Schema(type: 'boolean'),
+                new Schema(ref: ElementParameter::class, type: 'object'),
             ]
         )]
-        private null|string|bool $data = null,
+        private null|string|bool|ElementParameter $data = null,
         #[Property(description: 'Site ID', type: 'integer', example: 1)]
         private ?int $siteId = null,
     ) {
@@ -56,7 +57,7 @@ final readonly class WebsiteSettingsUpdate
         return $this->language;
     }
 
-    public function getData(): null|string|bool
+    public function getData(): null|string|bool|ElementParameter
     {
         return $this->data;
     }

--- a/src/WebsiteSetting/Service/WebsiteSettingsService.php
+++ b/src/WebsiteSetting/Service/WebsiteSettingsService.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Service;
 
+use Pimcore\Bundle\StaticResolverBundle\Lib\ToolResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Listing\Service\FilterMapperServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\CollectionFilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
@@ -36,6 +38,7 @@ final readonly class WebsiteSettingsService implements WebsiteSettingsServiceInt
     public function __construct(
         private EventDispatcherInterface $eventDispatcher,
         private FilterMapperServiceInterface $filterMapper,
+        private ToolResolverInterface $toolResolver,
         private WebsiteSettingsHydratorInterface $hydrator,
         private WebsiteSettingsRepositoryInterface $websiteSettingsRepository
     ) {
@@ -57,6 +60,7 @@ final readonly class WebsiteSettingsService implements WebsiteSettingsServiceInt
     public function updateWebsiteSetting(int $id, WebsiteSettingsUpdate $parameters): WebsiteSetting
     {
         $setting = $this->websiteSettingsRepository->getById($id);
+        $this->validateLanguage($parameters->getLanguage());
         $setting = $this->websiteSettingsRepository->update($setting, $parameters);
 
         return $this->getHydratedSetting($setting);
@@ -119,5 +123,20 @@ final readonly class WebsiteSettingsService implements WebsiteSettingsServiceInt
         );
 
         return $entry;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function validateLanguage(string $language): void
+    {
+        if (empty($language)) {
+            return;
+        }
+
+        $validLanguages = $this->toolResolver->getValidLanguages();
+        if (!in_array($language, $validLanguages, true)) {
+            throw new InvalidArgumentException(sprintf('Invalid language (%s) provided.', $language));
+        }
     }
 }

--- a/src/WebsiteSetting/Service/WebsiteSettingsService.php
+++ b/src/WebsiteSetting/Service/WebsiteSettingsService.php
@@ -29,6 +29,8 @@ use Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Schema\WebsiteSettingsUpda
 use Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Schema\WebsiteSettingType;
 use Pimcore\Model\WebsiteSetting as WebsiteSettingModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function in_array;
+use function sprintf;
 
 /**
  * @internal


### PR DESCRIPTION
## Changes in this pull request
Resolves #1198

## Additional info
- allow null data values for element website settings
- align request and response schema for data
- add language validation