### PR TITLE
[Website Settings]: Update fails for type Text and field data

### DIFF
--- a/config/website_settings.yaml
+++ b/config/website_settings.yaml
@@ -31,3 +31,10 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Repository\WebsiteSettingsRepositoryInterface:
     class: Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Repository\WebsiteSettingsRepository
+
+
+  #
+  # Denormalizers
+  #
+  Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Request\WebsiteSettingsUpdateDenormalizer:
+    tags: [ 'serializer.normalizer' ]

--- a/src/WebsiteSetting/Controller/UpdateController.php
+++ b/src/WebsiteSetting/Controller/UpdateController.php
@@ -74,7 +74,6 @@ final class UpdateController extends AbstractApiController
         int $id,
         #[MapRequestPayload] WebsiteSettingsUpdate $parameters
     ): JsonResponse {
-
         return $this->jsonResponse($this->websiteSettingsService->updateWebsiteSetting($id, $parameters));
     }
 }

--- a/src/WebsiteSetting/Request/WebsiteSettingsUpdateDenormalizer.php
+++ b/src/WebsiteSetting/Request/WebsiteSettingsUpdateDenormalizer.php
@@ -33,7 +33,7 @@ final readonly class WebsiteSettingsUpdateDenormalizer implements DenormalizerIn
         return $type === WebsiteSettingsUpdate::class;
     }
 
-    public static function getSupportedTypes(?string $format): array
+    public function getSupportedTypes(?string $format): array
     {
         return [
             WebsiteSettingsUpdate::class => true,
@@ -65,7 +65,7 @@ final readonly class WebsiteSettingsUpdateDenormalizer implements DenormalizerIn
         );
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return false;
     }

--- a/src/WebsiteSetting/Request/WebsiteSettingsUpdateDenormalizer.php
+++ b/src/WebsiteSetting/Request/WebsiteSettingsUpdateDenormalizer.php
@@ -24,13 +24,28 @@ use function is_string;
 
 final readonly class WebsiteSettingsUpdateDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function supportsDenormalization($data, $type, $format = null): bool
-    {
+    public function supportsDenormalization(
+        mixed $data,
+        string $type,
+        ?string $format = null,
+        array $context = []
+    ): bool {
         return $type === WebsiteSettingsUpdate::class;
     }
 
-    public function denormalize($data, $type, $format = null, array $context = []): WebsiteSettingsUpdate
+    public static function getSupportedTypes(?string $format): array
     {
+        return [
+            WebsiteSettingsUpdate::class => true,
+        ];
+    }
+
+    public function denormalize(
+        mixed $data,
+        string $type,
+        ?string $format = null,
+        array $context = []
+    ): WebsiteSettingsUpdate {
         $rawData = $data['data'] ?? null;
 
         if (is_array($rawData)) {

--- a/src/WebsiteSetting/Request/WebsiteSettingsUpdateDenormalizer.php
+++ b/src/WebsiteSetting/Request/WebsiteSettingsUpdateDenormalizer.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Request;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
-use Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Schema\WebsiteSettingsUpdate;
 use Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Schema\ElementParameter;
+use Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Schema\WebsiteSettingsUpdate;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use function is_array;
+use function is_bool;
+use function is_string;
 
 final readonly class WebsiteSettingsUpdateDenormalizer implements DenormalizerInterface, NormalizerInterface
 {

--- a/src/WebsiteSetting/Request/WebsiteSettingsUpdateDenormalizer.php
+++ b/src/WebsiteSetting/Request/WebsiteSettingsUpdateDenormalizer.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Request;
+
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Schema\WebsiteSettingsUpdate;
+use Pimcore\Bundle\StudioBackendBundle\WebsiteSetting\Schema\ElementParameter;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final readonly class WebsiteSettingsUpdateDenormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    public function supportsDenormalization($data, $type, $format = null): bool
+    {
+        return $type === WebsiteSettingsUpdate::class;
+    }
+
+    public function denormalize($data, $type, $format = null, array $context = []): WebsiteSettingsUpdate
+    {
+        $rawData = $data['data'] ?? null;
+
+        if (is_array($rawData)) {
+            $rawData = new ElementParameter(
+                $rawData['id'] ?? null,
+                $rawData['fullPath'] ?? null
+            );
+        } elseif (!is_string($rawData) && !is_bool($rawData) && $rawData !== null) {
+            throw new InvalidArgumentException('Unsupported `data` type');
+        }
+
+        return new WebsiteSettingsUpdate(
+            name: $data['name'],
+            language: $data['language'],
+            data: $rawData,
+            siteId: $data['siteId'] ?? null
+        );
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    {
+        return false;
+    }
+
+    public function normalize(mixed $object, ?string $format = null, array $context = []): null
+    {
+        return null;
+    }
+}

--- a/src/WebsiteSetting/Request/WebsiteSettingsUpdateDenormalizer.php
+++ b/src/WebsiteSetting/Request/WebsiteSettingsUpdateDenormalizer.php
@@ -22,6 +22,9 @@ use function is_array;
 use function is_bool;
 use function is_string;
 
+/**
+ * @internal
+ */
 final readonly class WebsiteSettingsUpdateDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
     public function supportsDenormalization(


### PR DESCRIPTION
## Changes in this pull request
Resolves #1210 

## Additional info
Symfony maps data always to the object (ElementParameter) when using MapRequestPayload. 
Introduced custom denormalizer to tackle this issue.