### PR TITLE
[RecycleBin] Rename perspective permission name

### DIFF
--- a/src/Perspective/Service/ContextPermissionService.php
+++ b/src/Perspective/Service/ContextPermissionService.php
@@ -31,7 +31,7 @@ final class ContextPermissionService implements ContextPermissionsServiceInterfa
         'hidden' => false,
         'maintenance' => true,
         'notesEvents' => true,
-        'recycle_bin' => true,
+        'recyclebin' => true,
         'systemTools_hidden' => false,
         'systemTools_requirements' => true,
         'translations' => true,


### PR DESCRIPTION
## Additional info

According to the admin-ui the perspective permission should be named `recyclebin` instead of `recycle_bin`

https://github.com/pimcore/admin-ui-classic-bundle/blob/7bf40f83bc1e93bd58decc2db98a85015a5d8461/public/js/pimcore/layout/toolbar.js#L316C83-L316C93

Dont know if that's all it takes to rename the permission. Please double check ....