### PR TITLE
[Grid] Reuse Resolver in AdvancedColumnResolver

### DIFF
--- a/src/Grid/Column/Resolver/DataObject/AdapterResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/AdapterResolver.php
@@ -98,6 +98,7 @@ final class AdapterResolver implements
         return $this->getColumnData(
             $column,
             $value,
+            $fieldDefinition->getFieldType(),
             $inheritanceData
         );
     }

--- a/src/Grid/Column/Resolver/DataObject/AdapterResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/AdapterResolver.php
@@ -68,7 +68,7 @@ final class AdapterResolver implements
         $fieldDefinition = $this->getFieldDefinition($column->getKey(), $classDefinition);
         $value = $this->dataService->getExportFieldValue($element, $fieldDefinition, $column->getKey());
 
-        return $this->getColumnData($column, $value);
+        return $this->getColumnData($column, $value, $fieldDefinition->getFieldType());
     }
 
     /**

--- a/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\TransformerException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\CoreElementColumnResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\ResolverTypeGuesserInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\TransformerInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\AdvancedColumnConfig\RelationFieldConfig;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\AdvancedColumnConfig\SimpleFieldConfig;
@@ -27,6 +28,7 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\AdvancedColumnConfig\StaticTe
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\AdvancedColumnConfig\Transformer;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\GridServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\TransformerLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\AdvancedValue;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\FieldDefinitionTrait;
@@ -60,6 +62,8 @@ final class AdvancedColumnResolver implements ColumnResolverInterface, CoreEleme
         private readonly ClassDefinitionResolverInterface $classDefinitionResolver,
         private readonly DataServiceInterface $dataService,
         private readonly TransformerLoaderInterface $transformerLoader,
+        private readonly GridServiceInterface $gridService,
+        private readonly ResolverTypeGuesserInterface $resolverTypeGuesser
     ) {
     }
 
@@ -120,6 +124,7 @@ final class AdvancedColumnResolver implements ColumnResolverInterface, CoreEleme
         return new ColumnData(
             key: $column->getKey(),
             locale: $column->getLocale(),
+            fieldType: 'advanced',
             value: $this->values
         );
     }
@@ -132,20 +137,25 @@ final class AdvancedColumnResolver implements ColumnResolverInterface, CoreEleme
         Column $column,
         Concrete $element
     ): void {
-        $classDefinition = $this->classDefinitionResolver->getById($element->getClassId());
-        $fieldDefinition = $this->getFieldDefinition($fieldConfig->getField(), $classDefinition);
-        $value = $this->dataService->getNormalizedValue(
-            $this->getLocalizedValueFromKey($fieldConfig->getField(), $column->getLocale(), $element),
-            $fieldDefinition
-        );
+        $resolverType = $this->resolverTypeGuesser->guessType($fieldConfig->getField(), $element->getClassId());
 
-        if (!$value) {
-            return;
-        }
+       $resolver = $this->gridService->getColumnResolvers()[$resolverType];
+
+       if ($resolver instanceof CoreElementColumnResolverInterface) {
+           $subColumn = new Column(
+               key: $fieldConfig->getField(),
+               locale: $column->getLocale(),
+               type: $resolverType,
+               group: $column->getGroup(),
+               config: $column->getConfig()
+           );
+
+           $data = $resolver->resolveForCoreElement($subColumn, $element);
+       }
 
         $this->values[] = new AdvancedValue(
-            type: $fieldDefinition->getFieldType(),
-            value: $value
+            type: $data->getFieldType(),
+            value: $data->getValue()
         );
     }
 

--- a/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
@@ -59,8 +59,6 @@ final class AdvancedColumnResolver implements ColumnResolverInterface, CoreEleme
     private array $transformers = [];
 
     public function __construct(
-        private readonly ClassDefinitionResolverInterface $classDefinitionResolver,
-        private readonly DataServiceInterface $dataService,
         private readonly TransformerLoaderInterface $transformerLoader,
         private readonly GridServiceInterface $gridService,
         private readonly ResolverTypeGuesserInterface $resolverTypeGuesser
@@ -124,8 +122,8 @@ final class AdvancedColumnResolver implements ColumnResolverInterface, CoreEleme
         return new ColumnData(
             key: $column->getKey(),
             locale: $column->getLocale(),
-            fieldType: 'advanced',
-            value: $this->values
+            value: $this->values,
+            fieldType: 'advanced'
         );
     }
 
@@ -139,19 +137,19 @@ final class AdvancedColumnResolver implements ColumnResolverInterface, CoreEleme
     ): void {
         $resolverType = $this->resolverTypeGuesser->guessType($fieldConfig->getField(), $element->getClassId());
 
-        $resolver = $this->gridService->getColumnResolvers()[$resolverType];
+       $resolver = $this->gridService->getColumnResolvers()[$resolverType];
 
-        if ($resolver instanceof CoreElementColumnResolverInterface) {
-            $subColumn = new Column(
-                key: $fieldConfig->getField(),
-                locale: $column->getLocale(),
-                type: $resolverType,
-                group: $column->getGroup(),
-                config: $column->getConfig()
-            );
+       if ($resolver instanceof CoreElementColumnResolverInterface) {
+           $subColumn = new Column(
+               key: $fieldConfig->getField(),
+               locale: $column->getLocale(),
+               type: $resolverType,
+               group: $column->getGroup(),
+               config: $column->getConfig()
+           );
 
-            $data = $resolver->resolveForCoreElement($subColumn, $element);
-        }
+           $data = $resolver->resolveForCoreElement($subColumn, $element);
+       }
 
         $this->values[] = new AdvancedValue(
             type: $data->getFieldType(),

--- a/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
@@ -137,17 +137,19 @@ final class AdvancedColumnResolver implements ColumnResolverInterface, CoreEleme
 
         $resolver = $this->gridService->getColumnResolvers()[$resolverType];
 
-        if ($resolver instanceof CoreElementColumnResolverInterface) {
-            $subColumn = new Column(
-                key: $fieldConfig->getField(),
-                locale: $column->getLocale(),
-                type: $resolverType,
-                group: $column->getGroup(),
-                config: $column->getConfig()
-            );
-
-            $data = $resolver->resolveForCoreElement($subColumn, $element);
+        if (!$resolver instanceof CoreElementColumnResolverInterface) {
+            return;
         }
+
+        $subColumn = new Column(
+            key: $fieldConfig->getField(),
+            locale: $column->getLocale(),
+            type: $resolverType,
+            group: $column->getGroup(),
+            config: $column->getConfig()
+        );
+
+        $data = $resolver->resolveForCoreElement($subColumn, $element);
 
         $this->values[] = new AdvancedValue(
             type: $data->getFieldType(),

--- a/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
@@ -139,19 +139,19 @@ final class AdvancedColumnResolver implements ColumnResolverInterface, CoreEleme
     ): void {
         $resolverType = $this->resolverTypeGuesser->guessType($fieldConfig->getField(), $element->getClassId());
 
-       $resolver = $this->gridService->getColumnResolvers()[$resolverType];
+        $resolver = $this->gridService->getColumnResolvers()[$resolverType];
 
-       if ($resolver instanceof CoreElementColumnResolverInterface) {
-           $subColumn = new Column(
-               key: $fieldConfig->getField(),
-               locale: $column->getLocale(),
-               type: $resolverType,
-               group: $column->getGroup(),
-               config: $column->getConfig()
-           );
+        if ($resolver instanceof CoreElementColumnResolverInterface) {
+            $subColumn = new Column(
+                key: $fieldConfig->getField(),
+                locale: $column->getLocale(),
+                type: $resolverType,
+                group: $column->getGroup(),
+                config: $column->getConfig()
+            );
 
-           $data = $resolver->resolveForCoreElement($subColumn, $element);
-       }
+            $data = $resolver->resolveForCoreElement($subColumn, $element);
+        }
 
         $this->values[] = new AdvancedValue(
             type: $data->getFieldType(),

--- a/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\DataObject;
 
 use Exception;
-use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
-use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\TransformerException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnResolverInterface;
@@ -137,19 +135,19 @@ final class AdvancedColumnResolver implements ColumnResolverInterface, CoreEleme
     ): void {
         $resolverType = $this->resolverTypeGuesser->guessType($fieldConfig->getField(), $element->getClassId());
 
-       $resolver = $this->gridService->getColumnResolvers()[$resolverType];
+        $resolver = $this->gridService->getColumnResolvers()[$resolverType];
 
-       if ($resolver instanceof CoreElementColumnResolverInterface) {
-           $subColumn = new Column(
-               key: $fieldConfig->getField(),
-               locale: $column->getLocale(),
-               type: $resolverType,
-               group: $column->getGroup(),
-               config: $column->getConfig()
-           );
+        if ($resolver instanceof CoreElementColumnResolverInterface) {
+            $subColumn = new Column(
+                key: $fieldConfig->getField(),
+                locale: $column->getLocale(),
+                type: $resolverType,
+                group: $column->getGroup(),
+                config: $column->getConfig()
+            );
 
-           $data = $resolver->resolveForCoreElement($subColumn, $element);
-       }
+            $data = $resolver->resolveForCoreElement($subColumn, $element);
+        }
 
         $this->values[] = new AdvancedValue(
             type: $data->getFieldType(),

--- a/src/Grid/Column/Resolver/DataObject/ObjectBrickResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/ObjectBrickResolver.php
@@ -28,7 +28,6 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\ObjectBrickKey;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\ColumnDataTrait;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\LocalizedValueTrait;
-use Pimcore\Bundle\StudioBackendBundle\ObjectBrick\Service\ObjectBrickService;
 use Pimcore\Bundle\StudioBackendBundle\ObjectBrick\Service\ObjectBrickServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\DataObject\ClassDefinition;
@@ -79,7 +78,6 @@ final class ObjectBrickResolver implements ColumnResolverInterface, CoreElementC
             $objectBrickKey->getBrickName(),
             $objectBrickKey->getAttribute(),
         )->getFieldType();
-
 
         if ($value === []) {
             return $this->getColumnData(

--- a/src/Grid/Column/Resolver/DataObject/ObjectBrickResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/ObjectBrickResolver.php
@@ -28,6 +28,8 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\ObjectBrickKey;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\ColumnDataTrait;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\LocalizedValueTrait;
+use Pimcore\Bundle\StudioBackendBundle\ObjectBrick\Service\ObjectBrickService;
+use Pimcore\Bundle\StudioBackendBundle\ObjectBrick\Service\ObjectBrickServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
@@ -47,7 +49,8 @@ final class ObjectBrickResolver implements ColumnResolverInterface, CoreElementC
         private readonly ClassDefinitionResolverInterface $classDefinitionResolver,
         private readonly DataServiceInterface $dataService,
         private readonly InheritanceServiceInterface $inheritanceService,
-        private readonly DataObjectServiceResolverInterface $dataObjectServiceResolver
+        private readonly DataObjectServiceResolverInterface $dataObjectServiceResolver,
+        private readonly ObjectBrickServiceInterface $objectBrickService
 
     ) {
     }
@@ -72,10 +75,17 @@ final class ObjectBrickResolver implements ColumnResolverInterface, CoreElementC
             $fieldDefinition
         );
 
+        $objectBrickFieldType = $this->objectBrickService->findObjectBrickField(
+            $objectBrickKey->getBrickName(),
+            $objectBrickKey->getAttribute(),
+        )->getFieldType();
+
+
         if ($value === []) {
             return $this->getColumnData(
                 $column,
                 null,
+                $objectBrickFieldType
             );
         }
 
@@ -97,6 +107,7 @@ final class ObjectBrickResolver implements ColumnResolverInterface, CoreElementC
         return $this->getColumnData(
             $column,
             $value,
+            $objectBrickFieldType,
             $inheritanceData
         );
     }

--- a/src/Grid/Column/Resolver/Metadata/AssetResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/AssetResolver.php
@@ -52,7 +52,7 @@ final class AssetResolver implements ColumnResolverInterface, StudioElementColum
                 false
             );
         } catch (NotFoundException) {
-            return $this->getColumnData($column, null);
+            return $this->getColumnData($column, null, $this->getType());
         }
 
         return $this->getColumnData(

--- a/src/Grid/Column/Resolver/Metadata/AssetResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/AssetResolver.php
@@ -43,7 +43,7 @@ final class AssetResolver implements ColumnResolverInterface, StudioElementColum
         $asset = $this->getLocalizedValue($column, $element);
 
         if (!isset($asset['asset'])) {
-            return $this->getColumnData($column, null);
+            return $this->getColumnData($column, null, $this->getType());
         }
 
         try {

--- a/src/Grid/Column/Resolver/Metadata/AssetResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/AssetResolver.php
@@ -62,7 +62,8 @@ final class AssetResolver implements ColumnResolverInterface, StudioElementColum
                 'subtype' => $relatedAsset->getType(),
                 'type' => 'asset',
                 'fullPath' => $relatedAsset->getFullPath(),
-            ]
+            ],
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/Metadata/CheckboxResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/CheckboxResolver.php
@@ -36,10 +36,10 @@ final class CheckboxResolver implements ColumnResolverInterface, StudioElementCo
         $value = $this->getLocalizedValue($column, $element);
 
         if (!$value) {
-            return $this->getColumnData($column, false);
+            return $this->getColumnData($column, false, $this->getType());
         }
 
-        return $this->getColumnData($column, $value);
+        return $this->getColumnData($column, $value, $this->getType());
     }
 
     public function getType(): string

--- a/src/Grid/Column/Resolver/Metadata/DataObjectResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/DataObjectResolver.php
@@ -52,7 +52,7 @@ final class DataObjectResolver implements ColumnResolverInterface, StudioElement
                 false
             );
         } catch (NotFoundException) {
-            return $this->getColumnData($column, null);
+            return $this->getColumnData($column, null, $this->getType());
         }
 
         return $this->getColumnData(

--- a/src/Grid/Column/Resolver/Metadata/DataObjectResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/DataObjectResolver.php
@@ -43,7 +43,7 @@ final class DataObjectResolver implements ColumnResolverInterface, StudioElement
         $object = $this->getLocalizedValue($column, $element);
 
         if (!isset($object['object'])) {
-            return $this->getColumnData($column, null);
+            return $this->getColumnData($column, null, $this->getType());
         }
 
         try {

--- a/src/Grid/Column/Resolver/Metadata/DataObjectResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/DataObjectResolver.php
@@ -63,7 +63,8 @@ final class DataObjectResolver implements ColumnResolverInterface, StudioElement
                 'type' => 'object',
                 'fullPath' => $relatedObject->getFullPath(),
                 'isPublished' => $relatedObject->isPublished(),
-            ]
+            ],
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/Metadata/DateResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/DateResolver.php
@@ -39,7 +39,7 @@ final class DateResolver implements ColumnResolverInterface, StudioElementColumn
         $value = $this->getLocalizedValue($column, $element);
 
         if (!$value) {
-            return $this->getColumnData($column, null);
+            return $this->getColumnData($column, null, $this->getType());
         }
 
         try {
@@ -48,7 +48,7 @@ final class DateResolver implements ColumnResolverInterface, StudioElementColumn
             throw new InvalidArgumentException('Invalid date format');
         }
 
-        return $this->getColumnData($column, $datetime->getTimestamp());
+        return $this->getColumnData($column, $datetime->getTimestamp(), $this->getType());
     }
 
     public function getType(): string

--- a/src/Grid/Column/Resolver/Metadata/DocumentResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/DocumentResolver.php
@@ -43,7 +43,7 @@ final class DocumentResolver implements ColumnResolverInterface, StudioElementCo
         $document = $this->getLocalizedValue($column, $element);
 
         if (!isset($document['document'])) {
-            return $this->getColumnData($column, null);
+            return $this->getColumnData($column, null, $this->getType());
         }
 
         try {
@@ -52,7 +52,7 @@ final class DocumentResolver implements ColumnResolverInterface, StudioElementCo
                 false
             );
         } catch (NotFoundException) {
-            return $this->getColumnData($column, null);
+            return $this->getColumnData($column, null, $this->getType());
         }
 
         return $this->getColumnData(
@@ -63,7 +63,8 @@ final class DocumentResolver implements ColumnResolverInterface, StudioElementCo
                 'subtype' => $relatedDocument->getType(),
                 'type' => 'document',
                 'isPublished' => $relatedDocument->isPublished(),
-            ]
+            ],
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/Metadata/InputResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/InputResolver.php
@@ -35,7 +35,8 @@ final class InputResolver implements ColumnResolverInterface, StudioElementColum
     {
         return $this->getColumnData(
             $column,
-            $this->getLocalizedValue($column, $element)
+            $this->getLocalizedValue($column, $element),
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/Metadata/SelectResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/SelectResolver.php
@@ -35,7 +35,8 @@ final class SelectResolver implements ColumnResolverInterface, StudioElementColu
     {
         return $this->getColumnData(
             $column,
-            $this->getLocalizedValue($column, $element)
+            $this->getLocalizedValue($column, $element),
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/Metadata/TextareaResolver.php
+++ b/src/Grid/Column/Resolver/Metadata/TextareaResolver.php
@@ -35,7 +35,8 @@ final class TextareaResolver implements ColumnResolverInterface, StudioElementCo
     {
         return $this->getColumnData(
             $column,
-            $this->getLocalizedValue($column, $element)
+            $this->getLocalizedValue($column, $element),
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/System/AssetPreviewResolver.php
+++ b/src/Grid/Column/Resolver/System/AssetPreviewResolver.php
@@ -50,7 +50,8 @@ final class AssetPreviewResolver implements ColumnResolverInterface, StudioEleme
             [
                 'thumbnail' => $thumbnail,
                 'icon' => $element->getIcon(),
-            ]
+            ],
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/System/BooleanResolver.php
+++ b/src/Grid/Column/Resolver/System/BooleanResolver.php
@@ -34,7 +34,8 @@ final class BooleanResolver implements ColumnResolverInterface, CoreElementColum
     {
         return $this->getColumnData(
             $column,
-            $this->getValue($column, $element)
+            $this->getValue($column, $element),
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/System/DatetimeResolver.php
+++ b/src/Grid/Column/Resolver/System/DatetimeResolver.php
@@ -43,7 +43,8 @@ final class DatetimeResolver implements
     {
         return $this->getColumnData(
             $column,
-            $this->getValue($column, $element)
+            $this->getValue($column, $element),
+            $this->getType()
         );
     }
 
@@ -51,7 +52,8 @@ final class DatetimeResolver implements
     {
         return $this->getColumnData(
             $column,
-            $this->getValue($column, $element)
+            $this->getValue($column, $element),
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/System/FileSizeResolver.php
+++ b/src/Grid/Column/Resolver/System/FileSizeResolver.php
@@ -36,7 +36,8 @@ final class FileSizeResolver implements ColumnResolverInterface, StudioElementCo
         /** @var Asset $element */
         return $this->getColumnData(
             $column,
-            formatBytes($element->getFileSize())
+            formatBytes($element->getFileSize()),
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/System/IdResolver.php
+++ b/src/Grid/Column/Resolver/System/IdResolver.php
@@ -44,7 +44,8 @@ final class IdResolver implements
     {
         return $this->getColumnData(
             $column,
-            $this->getValue($column, $element)
+            $this->getValue($column, $element),
+            $this->getType()
         );
     }
 
@@ -52,7 +53,8 @@ final class IdResolver implements
     {
         return $this->getColumnData(
             $column,
-            $this->getValue($column, $element)
+            $this->getValue($column, $element),
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/System/IntegerResolver.php
+++ b/src/Grid/Column/Resolver/System/IntegerResolver.php
@@ -38,7 +38,8 @@ final class IntegerResolver implements ColumnResolverInterface, CoreElementColum
     {
         return $this->getColumnData(
             $column,
-            $this->getValue($column, $element)
+            $this->getValue($column, $element),
+            $this->getType()
         );
     }
 

--- a/src/Grid/Column/Resolver/System/StringResolver.php
+++ b/src/Grid/Column/Resolver/System/StringResolver.php
@@ -56,7 +56,8 @@ final class StringResolver implements
 
         return $this->getColumnData(
             $column,
-            $value
+            $value,
+            $this->getType()
         );
     }
 

--- a/src/Grid/Schema/ColumnData.php
+++ b/src/Grid/Schema/ColumnData.php
@@ -34,6 +34,8 @@ final class ColumnData implements AdditionalAttributesInterface
         private readonly ?string $locale,
         #[Property(description: 'Value', type: 'mixed', example: 73)]
         private readonly mixed $value,
+        #[Property(description: 'Field Type of the column', type: 'string', example: 'input')]
+        private readonly mixed $fieldType,
         #[Property(
             description: 'inheritance',
             type: 'object',
@@ -52,6 +54,11 @@ final class ColumnData implements AdditionalAttributesInterface
     public function getLocale(): ?string
     {
         return $this->locale;
+    }
+
+    public function getFieldType(): mixed
+    {
+        return $this->fieldType;
     }
 
     public function getValue(): mixed

--- a/src/Grid/Util/Trait/ColumnDataTrait.php
+++ b/src/Grid/Util/Trait/ColumnDataTrait.php
@@ -24,8 +24,7 @@ trait ColumnDataTrait
         mixed $value,
         string $fieldType,
         ?InheritanceData $inheritanceData = null
-    ): ColumnData
-    {
+    ): ColumnData {
         return new ColumnData($column->getKey(), $column->getLocale(), $value, $fieldType, $inheritanceData);
     }
 }

--- a/src/Grid/Util/Trait/ColumnDataTrait.php
+++ b/src/Grid/Util/Trait/ColumnDataTrait.php
@@ -19,8 +19,13 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData;
 
 trait ColumnDataTrait
 {
-    private function getColumnData(Column $column, mixed $value, ?InheritanceData $inheritanceData = null): ColumnData
+    private function getColumnData(
+        Column $column,
+        mixed $value,
+        string $fieldType,
+        ?InheritanceData $inheritanceData = null
+    ): ColumnData
     {
-        return new ColumnData($column->getKey(), $column->getLocale(), $value, $inheritanceData);
+        return new ColumnData($column->getKey(), $column->getLocale(), $value, $fieldType, $inheritanceData);
     }
 }

--- a/src/ObjectBrick/Service/ObjectBrickService.php
+++ b/src/ObjectBrick/Service/ObjectBrickService.php
@@ -23,11 +23,9 @@ use Pimcore\Model\DataObject\ClassDefinition\Layout;
  */
 final class ObjectBrickService implements ObjectBrickServiceInterface
 {
-
     public function __construct(
         private readonly DefinitionResolverInterface $objectBrickdefinitionResolver,
-    )
-    {
+    ) {
     }
 
     public function getDataFields(Layout $layout): array
@@ -60,6 +58,4 @@ final class ObjectBrickService implements ObjectBrickServiceInterface
 
         throw new NotFoundException('Object brick', $field, 'field');
     }
-
-
 }

--- a/src/ObjectBrick/Service/ObjectBrickService.php
+++ b/src/ObjectBrick/Service/ObjectBrickService.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\ObjectBrick\Service;
 
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\Objectbrick\DefinitionResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Layout;
 
@@ -21,6 +23,13 @@ use Pimcore\Model\DataObject\ClassDefinition\Layout;
  */
 final class ObjectBrickService implements ObjectBrickServiceInterface
 {
+
+    public function __construct(
+        private readonly DefinitionResolverInterface $objectBrickdefinitionResolver,
+    )
+    {
+    }
+
     public function getDataFields(Layout $layout): array
     {
         $dataFields = [];
@@ -36,4 +45,21 @@ final class ObjectBrickService implements ObjectBrickServiceInterface
 
         return $dataFields;
     }
+
+    public function findObjectBrickField(string $name, string $field): Data
+    {
+        $objectBrickDefinition = $this->objectBrickdefinitionResolver->getByKey($name);
+
+        $fieldDefinition = $this->getDataFields($objectBrickDefinition->getLayoutDefinitions());
+
+        foreach ($fieldDefinition as $dataField) {
+            if ($dataField->getName() === $field) {
+                return $dataField;
+            }
+        }
+
+        throw new NotFoundException('Object brick', $field, 'field');
+    }
+
+
 }

--- a/src/ObjectBrick/Service/ObjectBrickServiceInterface.php
+++ b/src/ObjectBrick/Service/ObjectBrickServiceInterface.php
@@ -25,4 +25,6 @@ interface ObjectBrickServiceInterface
      * @return Data[]
      */
     public function getDataFields(Layout $layout): array;
+
+    public function findObjectBrickField(string $name, string $field): Data;
 }


### PR DESCRIPTION
## Changes in this pull request
Part of #1233 

## Additional info

- Reuse Resolver Logic in the Advanced Resolver
   - So Advanced Resolver calls the right resolver

- Add the field type, to all responses.   

