### PR TITLE
[User Management] missing properties

### DIFF
--- a/src/OpenApi/Schema/UserInformation.php
+++ b/src/OpenApi/Schema/UserInformation.php
@@ -31,9 +31,9 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
     description: 'Information about the user',
     required: [
         'id', 'username', 'email', 'firstname', 'lastname', 'permissions', 'isAdmin', 'classes', 'docTypes',
-        'language', 'dateTimeLocale', 'welcomeScreen', 'memorizeTabs', 'hasImage', 'contentLanguages',
-        'keyBindings', 'activePerspective', 'perspectives', 'allowedLanguagesForEditingWebsiteTranslations',
-        'allowedLanguagesForViewingWebsiteTranslations',
+        'language', 'dateTimeLocale', 'welcomeScreen', 'memorizeTabs', 'allowDirtyClose', 'hasImage',
+        'contentLanguages', 'keyBindings', 'activePerspective', 'perspectives',
+        'allowedLanguagesForEditingWebsiteTranslations', 'allowedLanguagesForViewingWebsiteTranslations',
     ],
     type: 'object'
 )]
@@ -80,6 +80,8 @@ final class UserInformation implements AdditionalAttributesInterface
         private readonly bool $welcomeScreen,
         #[Property(description: 'Memorize Tabs', type: 'boolean', example: true)]
         private readonly bool $memorizeTabs,
+        #[Property(description: 'Allow Dirty Close', type: 'boolean', example: true)]
+        private readonly bool $allowDirtyClose,
         #[Property(description: 'Has Image', type: 'boolean', example: true)]
         private readonly bool $hasImage,
         #[Property(
@@ -188,6 +190,11 @@ final class UserInformation implements AdditionalAttributesInterface
     public function isMemorizeTabs(): bool
     {
         return $this->memorizeTabs;
+    }
+
+    public function isAllowDirtyClose(): bool
+    {
+        return $this->allowDirtyClose;
     }
 
     public function isHasImage(): bool

--- a/src/User/Hydrator/UserInformationHydrator.php
+++ b/src/User/Hydrator/UserInformationHydrator.php
@@ -48,6 +48,7 @@ final readonly class UserInformationHydrator implements UserInformationHydratorI
             dateTimeLocale: $user instanceof User ? $user->getDateTimeLocale() : '',
             welcomeScreen: $user->getWelcomeScreen(),
             memorizeTabs: $user->getMemorizeTabs(),
+            allowDirtyClose: $user->getAllowDirtyClose(),
             hasImage: $user->hasImage(),
             contentLanguages: $this->contentLanguagesHydrator->hydrate($user),
             allowedLanguagesForEditingWebsiteTranslations:

--- a/src/User/MappedParameter/UpdateUserParameter.php
+++ b/src/User/MappedParameter/UpdateUserParameter.php
@@ -42,7 +42,7 @@ final readonly class UpdateUserParameter
         private int $parentId,
         private array $permissions,
         private array $roles,
-        private bool $twoFactorAuthenticationEnabled,
+        private bool $twoFactorAuthenticationRequired,
         private array $websiteTranslationLanguagesEdit,
         private array $websiteTranslationLanguagesView,
         private bool $welcomeScreen,
@@ -131,9 +131,9 @@ final readonly class UpdateUserParameter
         return $this->roles;
     }
 
-    public function isTwoFactorAuthenticationEnabled(): bool
+    public function isTwoFactorAuthenticationRequired(): bool
     {
-        return $this->twoFactorAuthenticationEnabled;
+        return $this->twoFactorAuthenticationRequired;
     }
 
     public function getWebsiteTranslationLanguagesEdit(): array

--- a/src/User/Schema/UpdateUser.php
+++ b/src/User/Schema/UpdateUser.php
@@ -26,7 +26,7 @@ use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
     description: 'User Schema to update a User.',
     required: [
         'active', 'classes', 'closeWarning', 'allowDirtyClose', 'contentLanguages', 'keyBindings',
-        'language', 'memorizeTabs', 'parentId', 'permissions', 'roles', 'twoFactorAuthenticationEnabled',
+        'language', 'memorizeTabs', 'parentId', 'permissions', 'roles', 'twoFactorAuthenticationRequired',
         'websiteTranslationLanguagesEdit', 'websiteTranslationLanguagesView', 'welcomeScreen',
         'assetWorkspaces', 'dataObjectWorkspaces', 'documentWorkspaces', 'perspectives',
     ],
@@ -70,7 +70,7 @@ final readonly class UpdateUser
         #[Property(description: 'ID List of roles the user is assigned', type: 'object', example: [12, 14])]
         private array $roles,
         #[Property(description: 'Two Factor Authentication Enabled', type: 'boolean', example: false)]
-        private bool $twoFactorAuthenticationEnabled,
+        private bool $twoFactorAuthenticationRequired,
         #[Property(description: 'Website Translation Languages Edit', type: 'object', example: ['de', 'en'])]
         private array $websiteTranslationLanguagesEdit,
         #[Property(description: 'Website Translation Languages View', type: 'object', example: ['de'])]
@@ -170,9 +170,9 @@ final readonly class UpdateUser
         return $this->allowDirtyClose;
     }
 
-    public function isTwoFactorAuthenticationEnabled(): bool
+    public function isTwoFactorAuthenticationRequired(): bool
     {
-        return $this->twoFactorAuthenticationEnabled;
+        return $this->twoFactorAuthenticationRequired;
     }
 
     public function getWebsiteTranslationLanguagesEdit(): array

--- a/src/User/Service/UserUpdateService.php
+++ b/src/User/Service/UserUpdateService.php
@@ -74,7 +74,7 @@ final readonly class UserUpdateService implements UserUpdateServiceInterface
         $user->setMemorizeTabs($updateUserParameter->isMemorizeTabs());
         $user->setParentId($updateUserParameter->getParentId());
         $user->setAllowDirtyClose($updateUserParameter->isAllowDirtyClose());
-        $user->setTwoFactorAuthentication('required', $updateUserParameter->isTwoFactorAuthenticationEnabled());
+        $user->setTwoFactorAuthentication('required', $updateUserParameter->isTwoFactorAuthenticationRequired());
         $user->setWelcomescreen($updateUserParameter->isWelcomescreen());
         $user->setContentLanguages($updateUserParameter->getContentLanguages());
         $user->setWebsiteTranslationLanguagesEdit($updateUserParameter->getWebsiteTranslationLanguagesEdit());


### PR DESCRIPTION
## Changes in this pull request
Resolves #1255

## Additional info
- added missing `allowDirtyClose` to UserInformation property
- renamed  UserUpdate parameter to `isTwoFactorAuthenticationRequired` for more clarity