### PR TITLE
Unify linkType for link document type

### DIFF
--- a/src/Document/Data/Adapter/LinkAdapter.php
+++ b/src/Document/Data/Adapter/LinkAdapter.php
@@ -35,7 +35,7 @@ final readonly class LinkAdapter implements SetterDataInterface, SettingsNormali
 {
     private const string PATH_KEY = 'path';
 
-    private const string LINK_TYPE_KEY = 'linktype';
+    private const string LINK_TYPE_KEY = 'linkType';
 
     private const string INTERNAL_TYPE_KEY = 'internalType';
 


### PR DESCRIPTION
We also receive `linkType` via the GET endpoint, therefore it's easier to use the same syntax also for updates.
