### PR TITLE
[Widget] Add `elementType` to widget collection

### DIFF
--- a/src/Perspective/Hydrator/WidgetConfigListHydrator.php
+++ b/src/Perspective/Hydrator/WidgetConfigListHydrator.php
@@ -28,12 +28,12 @@ final readonly class WidgetConfigListHydrator implements WidgetConfigListHydrato
 
     public function hydrate(array $widgetData): WidgetConfig
     {
-
         return new WidgetConfig(
             $widgetData['id'],
             $widgetData['name'],
             $widgetData['widgetType'],
             $this->iconService->getIconForValue($widgetData['icon']),
+            $widgetData['elementType']
         );
     }
 }

--- a/src/Perspective/Schema/WidgetConfig.php
+++ b/src/Perspective/Schema/WidgetConfig.php
@@ -26,6 +26,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
         'name',
         'widgetType',
         'icon',
+        'elementType'
     ],
     type: 'object'
 )]
@@ -42,6 +43,8 @@ class WidgetConfig implements AdditionalAttributesInterface
         private readonly string $widgetType,
         #[Property(description: 'Icon', type: ElementIcon::class)]
         private readonly ElementIcon $icon,
+        #[Property(description: 'Element Type', type: 'string', example: ElementTypes::TYPE_DATA_OBJECT)]
+        private readonly string $elementType = ElementTypes::TYPE_DATA_OBJECT,
     ) {
     }
 
@@ -63,5 +66,10 @@ class WidgetConfig implements AdditionalAttributesInterface
     public function getIcon(): ElementIcon
     {
         return $this->icon;
+    }
+
+    public function getElementType(): string
+    {
+        return $this->elementType;
     }
 }

--- a/src/Perspective/Schema/WidgetConfig.php
+++ b/src/Perspective/Schema/WidgetConfig.php
@@ -26,7 +26,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
         'name',
         'widgetType',
         'icon',
-        'elementType'
+        'elementType',
     ],
     type: 'object'
 )]

--- a/src/Perspective/Schema/WidgetConfig.php
+++ b/src/Perspective/Schema/WidgetConfig.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Perspective\Schema;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\Response\ElementIcon;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
 


### PR DESCRIPTION
## Changes in this pull request
Related to: https://github.com/pimcore/studio-ui-bundle/issues/307

## Additional info
This pull request updates the `WidgetConfig` schema and its hydration logic to support a new `elementType` property. This enhancement allows widgets to specify their element type, improving flexibility and integration with other parts of the system.

Schema and data model updates:

* Added the `elementType` property to the `WidgetConfig` schema, including its OpenAPI documentation and a default value of `ElementTypes::TYPE_DATA_OBJECT`. (`src/Perspective/Schema/WidgetConfig.php`) [[1]](diffhunk://#diff-378d2e5e3c9aa0a08aeff5a51785497fa9d473d6b30efd3decbebcb814c28da8R30) [[2]](diffhunk://#diff-378d2e5e3c9aa0a08aeff5a51785497fa9d473d6b30efd3decbebcb814c28da8R47-R48)
* Imported `ElementTypes` to support the new property in the schema. (`src/Perspective/Schema/WidgetConfig.php`)
* Added a getter method `getElementType()` to expose the new property. (`src/Perspective/Schema/WidgetConfig.php`)

Hydration logic update:

* Modified the hydrator to pass `elementType` when creating a new `WidgetConfig`, ensuring the property is set from widget data. (`src/Perspective/Hydrator/WidgetConfigListHydrator.php`)