### PR TITLE
Add support of Mercure running on a subdomain

### DIFF
--- a/config/mercure.yaml
+++ b/config/mercure.yaml
@@ -20,7 +20,7 @@ services:
         arguments:
             $tokenProvider: '@Pimcore\Bundle\StudioBackendBundle\Mercure\Service\ClientTokenService'
             $cookieLifetime: '%pimcore_studio_backend.mercure_settings.cookie_lifetime%'
-            $jwt_cookie_strictness: '%pimcore_studio_backend.mercure_settings.jwt_cookie_strictness%'
+            $jwtCookieStrictness: '%pimcore_studio_backend.mercure_settings.jwt_cookie_strictness%'
             $jwtCookieHost: '%pimcore_studio_backend.mercure_settings.jwt_cookie_host%'
 
     Pimcore\Bundle\StudioBackendBundle\Mercure\Service\Loader\TopicLoaderInterface:

--- a/config/mercure.yaml
+++ b/config/mercure.yaml
@@ -20,7 +20,8 @@ services:
         arguments:
             $tokenProvider: '@Pimcore\Bundle\StudioBackendBundle\Mercure\Service\ClientTokenService'
             $cookieLifetime: '%pimcore_studio_backend.mercure_settings.cookie_lifetime%'
-            $cookieSameSite: '%pimcore_studio_backend.mercure_settings.cookie_same_site%'
+            $jwt_cookie_strictness: '%pimcore_studio_backend.mercure_settings.jwt_cookie_strictness%'
+            $jwtCookieHost: '%pimcore_studio_backend.mercure_settings.jwt_cookie_host%'
 
     Pimcore\Bundle\StudioBackendBundle\Mercure\Service\Loader\TopicLoaderInterface:
         class: Pimcore\Bundle\StudioBackendBundle\Mercure\Service\Loader\TaggedIteratorAdapter

--- a/src/Asset/Schema/Type/Video.php
+++ b/src/Asset/Schema/Type/Video.php
@@ -37,7 +37,7 @@ class Video extends Asset implements ThumbnailPathInterface
             type: 'string',
             example: '/path/to/video/imagethumbnail.jpg'
         )]
-        private readonly?string $imageThumbnailPath,
+        private readonly ?string $imageThumbnailPath,
         bool $hasChildren,
         string $type,
         string $filename,

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -48,12 +48,6 @@ class Configuration implements ConfigurationInterface
 
     private const string PERMISSION_ARRAY_VALUE_ERROR = 'Each permission value must be a boolean.';
 
-    private const array ALLOWED_COOKIE_SAME_SITE_VALUES = [
-        Cookie::SAMESITE_LAX,
-        Cookie::SAMESITE_NONE,
-        Cookie::SAMESITE_STRICT,
-    ];
-
     /**
      * {@inheritdoc}
      */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -297,14 +297,13 @@ class Configuration implements ConfigurationInterface
                         ->info('Lifetime of the mercure cookie in seconds. Default is one hour.')
                         ->defaultValue(3600)
                     ->end()
-                     ->enumNode('cookie_same_site')
-                        ->info('Same site setting for the mercure cookie. Default is "' .
-                            Cookie::SAMESITE_STRICT .'". ' .
-                            'Possible values are: ' .
-                            implode(',', self::ALLOWED_COOKIE_SAME_SITE_VALUES) .'".'
-                        )
-                        ->values(self::ALLOWED_COOKIE_SAME_SITE_VALUES)
-                        ->defaultValue(Cookie::SAMESITE_STRICT)
+                     ->scalarNode('jwt_cookie_host')
+                        ->info('Domain where to set the Mercure auth cookie, e.g. ".example.com".')
+                        ->defaultNull()
+                    ->end()
+                     ->booleanNode('jwt_cookie_strictness')
+                        ->info('If true, use SameSite=Strict; if false, use SameSite=None.')
+                        ->defaultTrue()
                     ->end()
                 ->end()
             ->end();

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,7 +24,6 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\HttpFoundation\Cookie;
 use function is_array;
 use function is_int;
 use function is_null;

--- a/src/Mercure/Service/HubService.php
+++ b/src/Mercure/Service/HubService.php
@@ -26,7 +26,7 @@ final readonly class HubService implements HubServiceInterface
         private TokenProviderInterface $tokenProvider,
         private UrlServiceInterface $urlService,
         private int $cookieLifetime = 3600,
-        private bool $jwt_cookie_strictness = true,
+        private bool $jwtCookieStrictness = true,
         private ?string $jwtCookieHost = null,
     ) {
     }
@@ -53,7 +53,7 @@ final readonly class HubService implements HubServiceInterface
             $urlParts[Mercure::URL_SCHEME->value] === Mercure::URL_SCHEME_HTTPS->value,
             true,
             false,
-            $this->jwt_cookie_strictness ? Cookie::SAMESITE_STRICT : Cookie::SAMESITE_NONE
+            $this->jwtCookieStrictness ? Cookie::SAMESITE_STRICT : Cookie::SAMESITE_NONE
         );
     }
 }

--- a/src/Mercure/Service/HubService.php
+++ b/src/Mercure/Service/HubService.php
@@ -26,7 +26,8 @@ final readonly class HubService implements HubServiceInterface
         private TokenProviderInterface $tokenProvider,
         private UrlServiceInterface $urlService,
         private int $cookieLifetime = 3600,
-        private string $cookieSameSite = Cookie::SAMESITE_STRICT,
+        private bool $jwt_cookie_strictness = true,
+        private ?string $jwtCookieHost = null,
     ) {
     }
 
@@ -34,16 +35,25 @@ final readonly class HubService implements HubServiceInterface
     {
         $urlParts = parse_url($this->urlService->getClientSideUrl());
 
+        if (!empty($this->jwtCookieHost)) {
+            $host = $this->jwtCookieHost;
+        }
+        elseif (isset($urlParts[Mercure::URL_HOST->value])) {
+            $host = $urlParts[Mercure::URL_HOST->value];
+        } else {
+            $host = '';
+        }
+
         return new Cookie(
             Mercure::AUTHORIZATION_COOKIE_NAME->value,
             $this->tokenProvider->getJwt(),
             time() + $this->cookieLifetime,
             $urlParts[Mercure::URL_PATH->value] ?? '/',
-            $urlParts[Mercure::URL_HOST->value] ?? '',
+            $host,
             $urlParts[Mercure::URL_SCHEME->value] === Mercure::URL_SCHEME_HTTPS->value,
             true,
             false,
-            $this->cookieSameSite
+            $this->jwt_cookie_strictness ? Cookie::SAMESITE_STRICT : Cookie::SAMESITE_NONE
         );
     }
 }

--- a/src/Mercure/Service/HubService.php
+++ b/src/Mercure/Service/HubService.php
@@ -39,7 +39,7 @@ final readonly class HubService implements HubServiceInterface
         if (!empty($this->jwtCookieHost)) {
             $host = $this->jwtCookieHost;
         }
-        
+
         if ($host === '' && isset($urlParts[Mercure::URL_HOST->value])) {
             $host = $urlParts[Mercure::URL_HOST->value];
         }

--- a/src/Mercure/Service/HubService.php
+++ b/src/Mercure/Service/HubService.php
@@ -37,8 +37,7 @@ final readonly class HubService implements HubServiceInterface
 
         if (!empty($this->jwtCookieHost)) {
             $host = $this->jwtCookieHost;
-        }
-        elseif (isset($urlParts[Mercure::URL_HOST->value])) {
+        } elseif (isset($urlParts[Mercure::URL_HOST->value])) {
             $host = $urlParts[Mercure::URL_HOST->value];
         } else {
             $host = '';

--- a/src/Mercure/Service/HubService.php
+++ b/src/Mercure/Service/HubService.php
@@ -35,12 +35,13 @@ final readonly class HubService implements HubServiceInterface
     {
         $urlParts = parse_url($this->urlService->getClientSideUrl());
 
+        $host = '';
         if (!empty($this->jwtCookieHost)) {
             $host = $this->jwtCookieHost;
-        } elseif (isset($urlParts[Mercure::URL_HOST->value])) {
+        }
+        
+        if ($host === '' && isset($urlParts[Mercure::URL_HOST->value])) {
             $host = $urlParts[Mercure::URL_HOST->value];
-        } else {
-            $host = '';
         }
 
         return new Cookie(


### PR DESCRIPTION
On Pimcore PaaS, we'd like to switch from running Mercure in a side app to running Mercure as a Service.
But running Mercure as a Service implies that we run it on a subdomain.
Those modifications are required for the authentication layer.

There are also changes required in studio-ui-bundle, see https://github.com/pimcore/studio-ui-bundle/pull/2095.