### PR TITLE
[Elements]: Adjust element folder operations to get all ids

### DIFF
--- a/config/data_index_filters.yaml
+++ b/config/data_index_filters.yaml
@@ -69,6 +69,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\DataObject\ClassNameFilter:
       tags: [ 'pimcore.studio_backend.search_index.data_object.filter' ]
 
+  Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\DataObject\ClassIdFilter:
+      tags: [ 'pimcore.studio_backend.search_index.data_object.filter' ]
+
   Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\DataObject\ClassIdsFilter:
       tags: [ 'pimcore.studio_backend.search_index.data_object.filter' ]
 

--- a/config/pimcore/execution_engine.yaml
+++ b/config/pimcore/execution_engine.yaml
@@ -28,6 +28,7 @@ framework:
       Pimcore\Bundle\StudioBackendBundle\Element\ExecutionEngine\AutomationAction\Messenger\Messages\RecycleBinMessage: pimcore_generic_execution_engine
       Pimcore\Bundle\StudioBackendBundle\Element\ExecutionEngine\AutomationAction\Messenger\Messages\RewriteRefMessage: pimcore_generic_execution_engine
       Pimcore\Bundle\StudioBackendBundle\Export\ExecutionEngine\AutomationAction\Messenger\Messages\CsvCreationMessage: pimcore_generic_execution_engine
+      Pimcore\Bundle\StudioBackendBundle\Export\ExecutionEngine\AutomationAction\Messenger\Messages\XlsxCreationMessage: pimcore_generic_execution_engine
       Pimcore\Bundle\StudioBackendBundle\Tag\ExecutionEngine\AutomationAction\Messenger\Messages\BatchTagOperationMessage: pimcore_generic_execution_engine
       Pimcore\Bundle\StudioBackendBundle\RecycleBin\ExecutionEngine\Messages\DeleteItemsMessage: pimcore_generic_execution_engine
       Pimcore\Bundle\StudioBackendBundle\RecycleBin\ExecutionEngine\Messages\RestoreItemsMessage: pimcore_generic_execution_engine

--- a/src/Asset/Attribute/Request/PatchAssetFolderRequestBody.php
+++ b/src/Asset/Attribute/Request/PatchAssetFolderRequestBody.php
@@ -20,7 +20,7 @@ use OpenApi\Attributes\Property;
 use OpenApi\Attributes\RequestBody;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Attribute\Property\CustomMetadata;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\PatchCustomMetadata;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Filter;
+use Pimcore\Bundle\StudioBackendBundle\Export\Schema\ExportAllFilter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateIntegerProperty;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateStringProperty;
 
@@ -59,7 +59,7 @@ final class PatchAssetFolderRequestBody extends RequestBody
                     ),
                     new Property(
                         property: 'filters',
-                        ref: Filter::class,
+                        ref: ExportAllFilter::class,
                         type: 'object'
                     ),
                 ],

--- a/src/Asset/Attribute/Request/ZipExportFolderRequestBody.php
+++ b/src/Asset/Attribute/Request/ZipExportFolderRequestBody.php
@@ -18,7 +18,7 @@ use OpenApi\Attributes\Items;
 use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\RequestBody;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Filter;
+use Pimcore\Bundle\StudioBackendBundle\Export\Schema\ExportAllFilter;
 
 /**
  * @internal
@@ -34,7 +34,7 @@ final class ZipExportFolderRequestBody extends RequestBody
                     new Property(property: 'folders', type: 'array', items: new Items(type: 'integer'), example: [83]),
                     new Property(
                         property: 'filters',
-                        ref: Filter::class,
+                        ref: ExportAllFilter::class,
                         type: 'object'
                     ),
                 ],

--- a/src/Asset/ExecutionEngine/AutomationAction/Messenger/Handler/ExportDataCollectionHandler.php
+++ b/src/Asset/ExecutionEngine/AutomationAction/Messenger/Handler/ExportDataCollectionHandler.php
@@ -96,8 +96,8 @@ final class ExportDataCollectionHandler extends AbstractHandler
             $assetData = [
                 $asset->getId() => $this->gridService->getGridValuesForElement(
                     $columnCollection,
-                    $asset,
                     ElementTypes::TYPE_ASSET,
+                    $asset->getId(),
                     true
                 ),
             ];

--- a/src/Asset/ExecutionEngine/AutomationAction/Messenger/Handler/ExportFolderDataCollectionHandler.php
+++ b/src/Asset/ExecutionEngine/AutomationAction/Messenger/Handler/ExportFolderDataCollectionHandler.php
@@ -76,7 +76,8 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
 
         $filters = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CONFIG_FILTERS->value);
 
-        $assets = $this->gridSearch->searchAssetsForUser(
+        $assets = $this->gridSearch->searchElementIdsForUser(
+            ElementTypes::TYPE_ASSET,
             new GridParameter(
                 $jobFolder['id'],
                 $columns,
@@ -85,7 +86,7 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
             $user
         );
 
-        if (count($assets->getItems()) === 0) {
+        if (count($assets) === 0) {
             $this->updateProgress($this->publishService, $jobRun, $this->getJobStep($message)->getName());
 
             return;
@@ -98,13 +99,13 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
             $columnsDefinitions
         );
 
-        foreach ($assets->getItems() as $asset) {
+        foreach ($assets as $assetId) {
             try {
                 $assetData = [
-                    $asset->getId() => $this->gridService->getGridValuesForElement(
+                    $assetId => $this->gridService->getGridValuesForElement(
                         $columnCollection,
-                        $asset,
                         ElementTypes::TYPE_ASSET,
+                        $assetId,
                         true
                     ),
                 ];
@@ -114,7 +115,7 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
                 $this->abort($this->getAbortData(
                     Config::CSV_DATA_COLLECTION_FAILED_MESSAGE->value,
                     [
-                        'id' => $asset->getId(),
+                        'id' => $assetId,
                         'message' => $e->getMessage(),
                     ]
                 ));

--- a/src/Asset/MappedParameter/ExportFolderFileParameter.php
+++ b/src/Asset/MappedParameter/ExportFolderFileParameter.php
@@ -14,10 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
-use Pimcore\Bundle\StudioBackendBundle\Export\Schema\ExportAllFilter;
 use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Filter;
-use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\SortFilter;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\Element\ElementDescriptor;
 

--- a/src/Asset/MappedParameter/ExportFolderFileParameter.php
+++ b/src/Asset/MappedParameter/ExportFolderFileParameter.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Export\Schema\ExportAllFilter;
 use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Filter;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\SortFilter;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\Element\ElementDescriptor;
 

--- a/src/Asset/Service/ExecutionEngine/ZipService.php
+++ b/src/Asset/Service/ExecutionEngine/ZipService.php
@@ -159,7 +159,8 @@ final readonly class ZipService implements ZipServiceInterface
         $assets = [];
         foreach ($folders as $folder) {
 
-            $result = $this->gridSearch->searchAssetsForUser(
+            $ids = $this->gridSearch->searchElementIdsForUser(
+                ElementTypes::TYPE_ASSET,
                 new GridParameter(
                     $folder->getId(),
                     [],
@@ -167,10 +168,6 @@ final readonly class ZipService implements ZipServiceInterface
                 ),
                 $this->securityService->getCurrentUser()
             );
-
-            $ids = array_map(static function ($item) {
-                return $item->getId();
-            }, $result->getItems());
 
             $assets = [...$assets, ...$ids];
             $this->validateDownloadItems($assets);

--- a/src/DataIndex/Adapter/AssetSearchAdapter.php
+++ b/src/DataIndex/Adapter/AssetSearchAdapter.php
@@ -14,14 +14,16 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Adapter;
 
 use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\UserPermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\AssetSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Asset\AssetSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
+use Pimcore\Bundle\GenericDataIndexBundle\Permission\Workspace\AssetWorkspace;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\Aggregation\FileSizeAggregationServiceInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\AssetSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\Asset\SearchHelper;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchResultIdListServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Asset;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\AssetSearchResult;
@@ -46,6 +48,7 @@ final readonly class AssetSearchAdapter implements AssetSearchAdapterInterface
     public function __construct(
         private AssetSearchServiceInterface $searchService,
         private AssetHydratorServiceInterface $hydratorService,
+        private SearchHelper $searchHelper,
         private SearchResultIdListServiceInterface $searchResultIdListService,
         private FileSizeAggregationServiceInterface $fileSizeAggregationService,
     ) {
@@ -107,8 +110,11 @@ final readonly class AssetSearchAdapter implements AssetSearchAdapterInterface
     public function fetchAssetIds(QueryInterface $assetQuery): array
     {
         try {
-            $search = $assetQuery->getSearch();
-            $search->addModifier(new OrderByFullPath());
+            $search = $this->searchHelper->addSearchRestrictions(
+                search: $assetQuery->getSearch(),
+                userPermission: UserPermissionTypes::ASSETS->value,
+                workspaceType: AssetWorkspace::WORKSPACE_TYPE
+            );
 
             return $this->searchResultIdListService->getAllIds($search);
         } catch (AssetSearchException) {

--- a/src/DataIndex/Adapter/DataObjectSearchAdapter.php
+++ b/src/DataIndex/Adapter/DataObjectSearchAdapter.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Adapter;
 
-use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\UserPermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DataObjectSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearchInterface;

--- a/src/DataIndex/Adapter/DataObjectSearchAdapter.php
+++ b/src/DataIndex/Adapter/DataObjectSearchAdapter.php
@@ -13,13 +13,16 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Adapter;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\PermissionTypes;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\Permission\UserPermissionTypes;
 use Pimcore\Bundle\GenericDataIndexBundle\Exception\DataObjectSearchException;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearchInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\SearchResult\DataObjectSearchResultItem;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
-use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Sort\Tree\OrderByFullPath;
+use Pimcore\Bundle\GenericDataIndexBundle\Permission\Workspace\DataObjectWorkspace;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\DataObjectSearchServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\DataObject\SearchHelper;
 use Pimcore\Bundle\GenericDataIndexBundle\Service\Search\SearchService\SearchResultIdListServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\DataObjectSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
@@ -42,6 +45,7 @@ final readonly class DataObjectSearchAdapter implements DataObjectSearchAdapterI
     public function __construct(
         private DataObjectSearchServiceInterface $searchService,
         private DataObjectHydratorServiceInterface $hydratorService,
+        private SearchHelper $searchHelper,
         private SearchResultIdListServiceInterface $searchResultIdListService,
     ) {
     }
@@ -96,8 +100,11 @@ final readonly class DataObjectSearchAdapter implements DataObjectSearchAdapterI
     public function fetchDataObjectIds(QueryInterface $dataObjectQuery): array
     {
         try {
-            $search = $dataObjectQuery->getSearch();
-            $search->addModifier(new OrderByFullPath());
+            $search = $this->searchHelper->addSearchRestrictions(
+                search: $dataObjectQuery->getSearch(),
+                userPermission: UserPermissionTypes::OBJECTS->value,
+                workspaceType: DataObjectWorkspace::WORKSPACE_TYPE,
+            );
 
             return $this->searchResultIdListService->getAllIds($search);
         } catch (DataObjectSearchException) {

--- a/src/DataIndex/Filter/DataObject/ClassIdFilter.php
+++ b/src/DataIndex/Filter/DataObject/ClassIdFilter.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\DataObject;
+
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\FilterInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\DataObjectQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Request\ClassIdParametersInterface;
+
+/**
+ * @internal
+ */
+final class ClassIdFilter implements FilterInterface
+{
+    /**
+     * @throws Exception
+     */
+    public function apply(mixed $parameters, QueryInterface $query): QueryInterface
+    {
+        if (
+            !$parameters instanceof ClassIdParametersInterface ||
+            !$query instanceof DataObjectQueryInterface ||
+            !$parameters->getClassId()
+        ) {
+            return $query;
+        }
+
+        return $query->setClassDefinition($parameters->getClassId());
+    }
+}

--- a/src/DataIndex/Grid/GridSearch.php
+++ b/src/DataIndex/Grid/GridSearch.php
@@ -139,8 +139,7 @@ final readonly class GridSearch implements GridSearchInterface
         string $type,
         int $folderId,
         ?UserInterface $user
-    ): FilterParameter
-    {
+    ): FilterParameter {
         $folder = match($type) {
             ElementTypes::TYPE_ASSET => $this->assetSearchService->getAssetById($folderId, $user),
             ElementTypes::TYPE_DATA_OBJECT => $this->dataObjectSearchService->getDataObjectById($folderId, $user),

--- a/src/DataIndex/Grid/GridSearch.php
+++ b/src/DataIndex/Grid/GridSearch.php
@@ -29,6 +29,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
+use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\Filter\Service\FilterServiceProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
 use Pimcore\Bundle\StudioBackendBundle\Response\StudioElementInterface;
@@ -99,35 +100,10 @@ final readonly class GridSearch implements GridSearchInterface
     ): AssetSearchResult|DataObjectSearchResult|DocumentSearchResult {
         $filter = $gridParameter->getFilters();
         $type = $this->getStudioElementType($type);
-
-        $folder = match($type) {
-            ElementTypes::TYPE_ASSET => $this->assetSearchService->getAssetById(
-                $gridParameter->getFolderId(),
-                $user
-            ),
-            ElementTypes::TYPE_DATA_OBJECT => $this->dataObjectSearchService->getDataObjectById(
-                $gridParameter->getFolderId(),
-                $user
-            ),
-            ElementTypes::TYPE_DOCUMENT => $this->documentSearchService->getDocumentById(
-                $gridParameter->getFolderId(),
-                $user
-            ),
-            default => throw new InvalidElementTypeException($type)
-        };
-
-        if (!$this->isFolderOfType($type, $folder)) {
-            throw new NotFoundException($type . ' Folder', $gridParameter->getFolderId());
-        }
-
-        $filter->setPath($folder->getFullPath());
+        $filter = $this->setFilterPath($filter, $type, $gridParameter->getFolderId(), $user);
 
         /** @var AssetQueryInterface|DataObjectQueryInterface|DocumentQueryInterface $query */
-        $query = $this->filterService->applyFilters(
-            $filter,
-            $type
-        );
-
+        $query = $this->filterService->applyFilters($filter, $type);
         $query->setUser($user);
 
         return match($type) {
@@ -136,6 +112,49 @@ final readonly class GridSearch implements GridSearchInterface
             ElementTypes::TYPE_DOCUMENT => $this->documentSearchService->searchDocuments($query),
             default => throw new InvalidElementTypeException($type)
         };
+    }
+
+    public function searchElementIdsForUser(
+        string $type,
+        GridParameter $gridParameter,
+        UserInterface $user
+    ): array {
+        $filter = $gridParameter->getFilters();
+        $type = $this->getStudioElementType($type);
+        $filter = $this->setFilterPath($filter, $type, $gridParameter->getFolderId(), $user);
+
+        /** @var AssetQueryInterface|DataObjectQueryInterface $query */
+        $query = $this->filterService->applyFilters($filter, $type);
+        $query->setUser($user);
+
+        return match($type) {
+            ElementTypes::TYPE_ASSET => $this->assetSearchService->fetchAssetIds($query),
+            ElementTypes::TYPE_DATA_OBJECT => $this->dataObjectSearchService->fetchDataObjectIds($query),
+            default => throw new InvalidElementTypeException($type)
+        };
+    }
+
+    private function setFilterPath(
+        FilterParameter $filter,
+        string $type,
+        int $folderId,
+        ?UserInterface $user
+    ): FilterParameter
+    {
+        $folder = match($type) {
+            ElementTypes::TYPE_ASSET => $this->assetSearchService->getAssetById($folderId, $user),
+            ElementTypes::TYPE_DATA_OBJECT => $this->dataObjectSearchService->getDataObjectById($folderId, $user),
+            ElementTypes::TYPE_DOCUMENT => $this->documentSearchService->getDocumentById($folderId, $user),
+            default => throw new InvalidElementTypeException($type)
+        };
+
+        if (!$this->isFolderOfType($type, $folder)) {
+            throw new NotFoundException($type . ' Folder', $folderId);
+        }
+
+        $filter->setPath($folder->getFullPath());
+
+        return $filter;
     }
 
     private function isFolderOfType(string $type, StudioElementInterface $element): bool

--- a/src/DataIndex/Grid/GridSearchInterface.php
+++ b/src/DataIndex/Grid/GridSearchInterface.php
@@ -42,4 +42,10 @@ interface GridSearchInterface
         GridParameter $gridParameter,
         UserInterface $user
     ): AssetSearchResult|DataObjectSearchResult|DocumentSearchResult;
+
+    public function searchElementIdsForUser(
+        string $type,
+        GridParameter $gridParameter,
+        UserInterface $user
+    ): array;
 }

--- a/src/DataIndex/Query/DataObjectQuery.php
+++ b/src/DataIndex/Query/DataObjectQuery.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Query;
 
 use Carbon\Carbon;
-use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\Search\SortDirection;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\DataObject\DataObjectSearch;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Modifier\Filter\Basic\BooleanFilter;
@@ -100,11 +99,25 @@ final class DataObjectQuery implements DataObjectQueryInterface
     }
 
     /**
-     * @throws Exception
+     * {@inheritdoc}
      */
     public function setClassDefinitionName(string $classDefinitionId): self
     {
         $classDefinition = $this->classDefinitionResolver->getByName($classDefinitionId);
+        if ($classDefinition === null) {
+            throw new NotFoundException('Class definition', $classDefinitionId);
+        }
+        $this->search->setClassDefinition($classDefinition);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setClassDefinition(string $classDefinitionId): self
+    {
+        $classDefinition = $this->classDefinitionResolver->getById($classDefinitionId);
         if ($classDefinition === null) {
             throw new NotFoundException('Class definition', $classDefinitionId);
         }

--- a/src/DataIndex/Query/DataObjectQueryInterface.php
+++ b/src/DataIndex/Query/DataObjectQueryInterface.php
@@ -32,6 +32,11 @@ interface DataObjectQueryInterface extends QueryInterface
      */
     public function setClassDefinitionName(string $classDefinitionId): self;
 
+    /**
+     * @throws Exception
+     */
+    public function setClassDefinition(string $classDefinitionId): self;
+
     public function setClassDefinitionIds(array $classDefinitionIds): self;
 
     public function booleanFilter(string $fieldName, null|bool $value): self;

--- a/src/DataIndex/Request/ClassIdParametersInterface.php
+++ b/src/DataIndex/Request/ClassIdParametersInterface.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Request;
+
+/**
+ * @internal
+ */
+interface ClassIdParametersInterface
+{
+    public function getClassId(): ?string;
+}

--- a/src/DataObject/Attribute/Request/PatchDataObjectFolderRequestBody.php
+++ b/src/DataObject/Attribute/Request/PatchDataObjectFolderRequestBody.php
@@ -19,7 +19,6 @@ use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\RequestBody;
 use Pimcore\Bundle\StudioBackendBundle\Export\Schema\ExportAllFilter;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Filter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateBooleanProperty;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateIntegerProperty;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateObjectProperty;

--- a/src/DataObject/Attribute/Request/PatchDataObjectFolderRequestBody.php
+++ b/src/DataObject/Attribute/Request/PatchDataObjectFolderRequestBody.php
@@ -18,6 +18,7 @@ use OpenApi\Attributes\Items;
 use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\RequestBody;
+use Pimcore\Bundle\StudioBackendBundle\Export\Schema\ExportAllFilter;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Filter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateBooleanProperty;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\UpdateIntegerProperty;
@@ -63,8 +64,13 @@ final class PatchDataObjectFolderRequestBody extends RequestBody
                     ),
                     new Property(
                         property: 'filters',
-                        ref: Filter::class,
+                        ref: ExportAllFilter::class,
                         type: 'object'
+                    ),
+                    new Property(
+                        property: 'classId',
+                        type: 'string',
+                        example: 'CAR',
                     ),
                 ],
                 type: 'object',

--- a/src/DataObject/Attribute/Request/PatchDataObjectFolderRequestBody.php
+++ b/src/DataObject/Attribute/Request/PatchDataObjectFolderRequestBody.php
@@ -35,7 +35,7 @@ final class PatchDataObjectFolderRequestBody extends RequestBody
         parent::__construct(
             required: true,
             content: new JsonContent(
-                required: ['data'],
+                required: ['data', 'classId'],
                 properties: [
                     new Property(
                         property: 'data',
@@ -70,6 +70,7 @@ final class PatchDataObjectFolderRequestBody extends RequestBody
                         property: 'classId',
                         type: 'string',
                         example: 'CAR',
+                        nullable: false
                     ),
                 ],
                 type: 'object',

--- a/src/DataObject/Controller/PatchFolderController.php
+++ b/src/DataObject/Controller/PatchFolderController.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Controller;
 use OpenApi\Attributes\Patch;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Attribute\Request\PatchDataObjectFolderRequestBody;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\PatchFolderParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\IdJson;
@@ -47,7 +48,7 @@ final class PatchFolderController extends AbstractApiController
     }
 
     /**
-     * @throws UserNotFoundException
+     * @throws InvalidArgumentException|UserNotFoundException
      */
     #[Route('/data-objects/folder', name: 'pimcore_studio_api_patch_data_object_folder', methods: ['PATCH'])]
     #[IsGranted(UserPermissions::DATA_OBJECTS->value)]

--- a/src/DataObject/ExecutionEngine/AutomationAction/Messenger/Handler/ExportDataCollectionHandler.php
+++ b/src/DataObject/ExecutionEngine/AutomationAction/Messenger/Handler/ExportDataCollectionHandler.php
@@ -98,8 +98,8 @@ final class ExportDataCollectionHandler extends AbstractHandler
             $dataObjectData = [
                 $dataObject->getId() => $this->gridService->getGridValuesForElement(
                     $columnCollection,
-                    $dataObject,
                     ElementTypes::TYPE_OBJECT,
+                    $dataObject->getId(),
                     true
                 ),
             ];

--- a/src/DataObject/ExecutionEngine/AutomationAction/Messenger/Handler/ExportFolderDataCollectionHandler.php
+++ b/src/DataObject/ExecutionEngine/AutomationAction/Messenger/Handler/ExportFolderDataCollectionHandler.php
@@ -17,6 +17,7 @@ use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\User\UserResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Grid\GridSearchInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\ExecutionEngine\AutomationAction\Messenger\Messages\ExportFolderDataCollectionMessage;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataObjectServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\AutomationAction\AbstractHandler;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Config;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
@@ -40,6 +41,7 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
 
     public function __construct(
         private readonly ColumnConfigurationServiceInterface $columnConfigurationService,
+        private readonly DataObjectServiceInterface $dataObjectService,
         private readonly FilterParameterMapperInterface $filterParameterMapper,
         private readonly PublishServiceInterface $publishService,
         private readonly UserResolverInterface $userResolver,
@@ -76,27 +78,24 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
 
         $filters = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CONFIG_FILTERS->value);
 
-        $dataObjects = $this->gridSearch->searchElementsForUser(
-            'object',
-            new GridParameter(
-                $jobFolder['id'],
-                $columns,
-                $this->filterParameterMapper->fromArray($filters)
-            ),
+        $classId = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::ELEMENT_CLASS_ID->value);
+        $filters = $this->filterParameterMapper->fromArray($filters);
+        $filters->setClassId($classId);
+
+        $dataObjects = $this->gridSearch->searchElementIdsForUser(
+            ElementTypes::TYPE_OBJECT,
+            new GridParameter($jobFolder['id'], $columns, $filters),
             $user
         );
 
-        if (count($dataObjects->getItems()) === 0) {
+        if (count($dataObjects) === 0) {
             $this->updateProgress($this->publishService, $jobRun, $this->getJobStep($message)->getName());
 
             return;
         }
 
-        $dataObject = $dataObjects->getItems()[0];
-
-        $className = $dataObject->getClassName();
         $columnsDefinitions = $this->columnConfigurationService->getAvailableDataObjectColumnConfiguration(
-            $className,
+            $classId,
             $jobFolder['id'],
             $user
         );
@@ -106,13 +105,13 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
             $columnsDefinitions
         );
 
-        foreach ($dataObjects->getItems() as $dataObject) {
+        foreach ($dataObjects as $dataObjectId) {
             try {
                 $dataObjectData = [
-                    $dataObject->getId() => $this->gridService->getGridValuesForElement(
+                    $dataObjectId => $this->gridService->getGridValuesForElement(
                         $columnCollection,
-                        $dataObject,
                         ElementTypes::TYPE_OBJECT,
+                        $dataObjectId,
                         true
                     ),
                 ];
@@ -122,7 +121,7 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
                 $this->abort($this->getAbortData(
                     Config::CSV_DATA_COLLECTION_FAILED_MESSAGE->value,
                     [
-                        'id' => $dataObject->getId(),
+                        'id' => $dataObjectId,
                         'message' => $e->getMessage(),
                     ]
                 ));
@@ -137,7 +136,7 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
                 StepConfig::GRID_EXPORT_DATA_INFO->value,
                 [
                     'type' => ElementTypes::TYPE_OBJECT,
-                    'className' => $className,
+                    'classId' => $classId,
                 ]
             );
         }
@@ -161,6 +160,11 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
         $this->stepConfiguration->setAllowedTypes(
             StepConfig::CONFIG_FILTERS->value,
             StepConfig::CONFIG_TYPE_ARRAY->value
+        );
+        $this->stepConfiguration->setRequired(StepConfig::ELEMENT_CLASS_ID->value);
+        $this->stepConfiguration->setAllowedTypes(
+            StepConfig::ELEMENT_CLASS_ID->value,
+            StepConfig::CONFIG_TYPE_STRING->value
         );
     }
 }

--- a/src/DataObject/ExecutionEngine/AutomationAction/Messenger/Handler/ExportFolderDataCollectionHandler.php
+++ b/src/DataObject/ExecutionEngine/AutomationAction/Messenger/Handler/ExportFolderDataCollectionHandler.php
@@ -17,7 +17,6 @@ use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\User\UserResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Grid\GridSearchInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\ExecutionEngine\AutomationAction\Messenger\Messages\ExportFolderDataCollectionMessage;
-use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataObjectServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\AutomationAction\AbstractHandler;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Config;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
@@ -41,7 +40,6 @@ final class ExportFolderDataCollectionHandler extends AbstractHandler
 
     public function __construct(
         private readonly ColumnConfigurationServiceInterface $columnConfigurationService,
-        private readonly DataObjectServiceInterface $dataObjectService,
         private readonly FilterParameterMapperInterface $filterParameterMapper,
         private readonly PublishServiceInterface $publishService,
         private readonly UserResolverInterface $userResolver,

--- a/src/Element/ExecutionEngine/AutomationAction/Messenger/Handler/PatchFolderHandler.php
+++ b/src/Element/ExecutionEngine/AutomationAction/Messenger/Handler/PatchFolderHandler.php
@@ -79,7 +79,6 @@ final class PatchFolderHandler extends AbstractHandler
             $filters->setClassId($classId);
         }
 
-
         $elementIds = $this->gridSearch->searchElementIdsForUser(
             $elementType,
             new GridParameter($folderId, [], $filters),

--- a/src/Element/ExecutionEngine/AutomationAction/Messenger/Handler/PatchFolderHandler.php
+++ b/src/Element/ExecutionEngine/AutomationAction/Messenger/Handler/PatchFolderHandler.php
@@ -71,20 +71,22 @@ final class PatchFolderHandler extends AbstractHandler
         }
 
         $folderId = $validatedParameters->getSubject()->getId();
-        $elementType =  $validatedParameters->getSubject()->getType();
+        $elementType = $validatedParameters->getSubject()->getType();
         $filters = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CONFIG_FILTERS->value);
+        $classId = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::ELEMENT_CLASS_ID->value);
+        $filters = $this->filterParameterMapper->fromArray($filters);
+        if ($classId !== '') {
+            $filters->setClassId($classId);
+        }
 
-        $result = $this->gridSearch->searchElementsForUser(
+
+        $elementIds = $this->gridSearch->searchElementIdsForUser(
             $elementType,
-            new GridParameter(
-                $folderId,
-                [],
-                $this->filterParameterMapper->fromArray($filters)
-            ),
+            new GridParameter($folderId, [], $filters),
             $validatedParameters->getUser()
         );
 
-        if (empty($result->getItems())) {
+        if (empty($elementIds)) {
             $this->updateProgress($this->publishService, $jobRun, $this->getJobStep($message)->getName());
 
             return;
@@ -92,10 +94,10 @@ final class PatchFolderHandler extends AbstractHandler
 
         $jobEnvironmentData = $jobRun->getJob()?->getEnvironmentData();
 
-        foreach ($result->getItems() as $item) {
+        foreach ($elementIds as $elementId) {
             $element = $this->elementService->getAllowedElementById(
                 $elementType,
-                $item->getId(),
+                $elementId,
                 $validatedParameters->getUser()
             );
 
@@ -127,6 +129,11 @@ final class PatchFolderHandler extends AbstractHandler
         $this->stepConfiguration->setAllowedTypes(
             StepConfig::CONFIG_FILTERS->value,
             StepConfig::CONFIG_TYPE_ARRAY->value
+        );
+        $this->stepConfiguration->setRequired(StepConfig::ELEMENT_CLASS_ID->value);
+        $this->stepConfiguration->setAllowedTypes(
+            StepConfig::ELEMENT_CLASS_ID->value,
+            StepConfig::CONFIG_TYPE_STRING->value
         );
     }
 }

--- a/src/Element/ExecutionEngine/AutomationAction/Messenger/Handler/PatchFolderHandler.php
+++ b/src/Element/ExecutionEngine/AutomationAction/Messenger/Handler/PatchFolderHandler.php
@@ -29,6 +29,7 @@ use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\PublishServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Patcher\Service\PatchServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use function count;
 
 /**
  * @internal

--- a/src/Element/ExecutionEngine/AutomationAction/Messenger/Handler/PatchFolderHandler.php
+++ b/src/Element/ExecutionEngine/AutomationAction/Messenger/Handler/PatchFolderHandler.php
@@ -93,6 +93,7 @@ final class PatchFolderHandler extends AbstractHandler
 
         $jobEnvironmentData = $jobRun->getJob()?->getEnvironmentData();
 
+        $elementCount = count($elementIds);
         foreach ($elementIds as $elementId) {
             $element = $this->elementService->getAllowedElementById(
                 $elementType,
@@ -118,7 +119,12 @@ final class PatchFolderHandler extends AbstractHandler
                 ));
             }
 
-            $this->updateProgress($this->publishService, $jobRun, $this->getJobStep($message)->getName());
+            $this->updateProgress(
+                $this->publishService,
+                $jobRun,
+                $this->getJobStep($message)->getName(),
+                $elementCount
+            );
         }
     }
 

--- a/src/ExecutionEngine/Util/StepConfig.php
+++ b/src/ExecutionEngine/Util/StepConfig.php
@@ -22,6 +22,7 @@ enum StepConfig: string
     case ID = 'id';
     case CUSTOM_REPORT_CONFIG = 'custom_report_config';
     case CUSTOM_REPORT_TO_EXPORT = 'custom_report_to_export';
+    case ELEMENT_CLASS_ID = 'element_class_id';
     case ELEMENT_TO_EXPORT = 'element_to_export';
     case ELEMENT_TYPE = 'element_type';
     case FOLDER_TO_EXPORT = 'folder_to_export';

--- a/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
+++ b/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
@@ -21,7 +21,6 @@ use OpenApi\Attributes\RequestBody;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
 use Pimcore\Bundle\StudioBackendBundle\Export\Schema\ExportAllFilter;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
-use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Filter;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 
 /**

--- a/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
+++ b/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
@@ -19,6 +19,7 @@ use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\RequestBody;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
+use Pimcore\Bundle\StudioBackendBundle\Export\Schema\ExportAllFilter;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Filter;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
@@ -58,7 +59,7 @@ final class ExportFolderDataRequestBody extends RequestBody
                     ),
                     new Property(
                         property: 'filters',
-                        ref: Filter::class,
+                        ref: ExportAllFilter::class,
                         type: 'object'
                     ),
                     new Property(property: 'config', properties: $configProperties, type: 'object'),
@@ -67,6 +68,12 @@ final class ExportFolderDataRequestBody extends RequestBody
                         type: 'string',
                         enum: ElementTypes::ALLOWED_TYPES,
                         example: ElementTypes::TYPE_ASSET
+                    ),
+                    new Property(
+                        property: 'classId',
+                        type: 'string',
+                        example: 'CAR',
+                        nullable: true
                     ),
                 ],
                 type: 'object'

--- a/src/Export/MappedParameter/ExportFolderParameter.php
+++ b/src/Export/MappedParameter/ExportFolderParameter.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Export\MappedParameter;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Export\Util\Trait\ExportConfigValidationTrait;
 use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\Element\ElementDescriptor;
 
 /**
@@ -33,10 +34,15 @@ final readonly class ExportFolderParameter
         private ?FilterParameter $filters,
         private array $config,
         private array $folders,
-        private string $elementType
+        private string $elementType,
+        private ?string $classId = null
     ) {
         if (empty($this->getFolders())) {
             throw new InvalidArgumentException('No folders provided');
+        }
+
+        if ($this->classId === null && $this->getValidElementType($this->elementType) === ElementTypes::TYPE_OBJECT) {
+            throw new InvalidArgumentException('Class ID must be provided for data object exports');
         }
 
         $this->validateConfig();
@@ -71,5 +77,10 @@ final readonly class ExportFolderParameter
     public function getElementType(): string
     {
         return $this->getValidElementType($this->elementType);
+    }
+
+    public function getClassId(): ?string
+    {
+        return $this->classId;
     }
 }

--- a/src/Export/Schema/ExportAllFilter.php
+++ b/src/Export/Schema/ExportAllFilter.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Export\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+
+/**
+ * Contains all data that is needed to get all the data for the column.
+ *
+ * @internal
+ */
+#[Schema(
+    schema: 'ExportAllFilter',
+    title: 'Export All Filter',
+    required: ['columnFilters', 'sortFilter'],
+    type: 'object'
+)]
+final readonly class ExportAllFilter
+{
+    public function __construct(
+        #[Property(
+            description: 'Column Filter',
+            type: 'object',
+            example: '[{"key":"name","type": "metadata.object","filterValue": 1, "locale":"de"}]'
+        )]
+        private array $columnFilters = [],
+        #[Property(
+            description: 'Sort Filter',
+            type: 'object',
+            example: '{"key":"id","direction": "ASC"}'
+        )]
+        private array $sortFilter = []
+
+    ) {
+    }
+
+    public function getColumnFilters(): array
+    {
+        return $this->columnFilters;
+    }
+
+    public function getSortFilter(): array
+    {
+        return $this->sortFilter;
+    }
+}

--- a/src/Export/Service/CsvExportService.php
+++ b/src/Export/Service/CsvExportService.php
@@ -42,7 +42,7 @@ final readonly class CsvExportService extends AbstractExportService
         $data = [];
 
         if (!empty($headers)) {
-            $data[]  = $headers;
+            $data[] = $headers;
         }
 
         $data = array_merge($data, $exportData);

--- a/src/Export/Service/ExecutionEngine/ExportService.php
+++ b/src/Export/Service/ExecutionEngine/ExportService.php
@@ -73,6 +73,10 @@ final readonly class ExportService implements ExportServiceInterface
             StepConfig::CONFIG_FILTERS->value => $exportParameter->getFilters(),
         ];
 
+        if ($exportParameter->getElementType() === ElementTypes::TYPE_OBJECT) {
+            $collectionSettings[StepConfig::ELEMENT_CLASS_ID->value] = $exportParameter->getClassId();
+        }
+
         $creationSettings = [
             StepConfig::CONFIG_COLUMNS->value => $exportParameter->getColumns(),
             StepConfig::CONFIG_CONFIGURATION->value => $exportParameter->getConfig(),

--- a/src/Filter/MappedParameter/FilterParameter.php
+++ b/src/Filter/MappedParameter/FilterParameter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter;
 
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Request\ClassIdParametersInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Request\ClassNameParametersInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\CollectionParametersInterface;
@@ -37,11 +38,14 @@ final class FilterParameter implements
     ColumnFiltersParameterInterface,
     SimpleColumnFiltersParameterInterface,
     SortFilterParameterInterface,
-    ClassNameParametersInterface
+    ClassNameParametersInterface,
+    ClassIdParametersInterface
 {
     private ?string $path = null;
 
     private ?string $className = null;
+
+    private ?string $classId = null;
 
     private bool $excludeFolders = true;
 
@@ -161,5 +165,15 @@ final class FilterParameter implements
     public function setClassName(?string $className): void
     {
         $this->className = $className;
+    }
+
+    public function getClassId(): ?string
+    {
+        return $this->classId;
+    }
+
+    public function setClassId(?string $classId): void
+    {
+        $this->classId = $classId;
     }
 }

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -167,15 +167,16 @@ final class GridService implements GridServiceInterface
      */
     public function getGridDataForElement(
         ColumnCollection $columnCollection,
-        StudioElementInterface $element,
+        ?StudioElementInterface $element,
         string $elementType,
+        int $elementId,
         bool $isExport = false
     ): array {
         $data = [];
 
         $databaseElement = null;
-        if ($elementType === ElementTypes::TYPE_OBJECT) {
-            $databaseElement = $this->getElement($this->serviceResolver, $elementType, $element->getId());
+        if ($isExport || $elementType === ElementTypes::TYPE_OBJECT) {
+            $databaseElement = $this->getElement($this->serviceResolver, $elementType, $elementId);
         }
 
         foreach ($columnCollection->getColumns() as $column) {
@@ -191,7 +192,7 @@ final class GridService implements GridServiceInterface
                     $resolver->resolveForExport($column, $databaseElement),
                 $databaseElement && $resolver instanceof CoreElementColumnResolverInterface =>
                     $resolver->resolveForCoreElement($column, $databaseElement),
-                $resolver instanceof StudioElementColumnResolverInterface =>
+                $element !== null && $resolver instanceof StudioElementColumnResolverInterface =>
                     $resolver->resolveForStudioElement($column, $element),
                 default =>
                     throw new InvalidArgumentException(
@@ -205,10 +206,10 @@ final class GridService implements GridServiceInterface
                 GridColumnDataEvent::EVENT_NAME
             );
 
-            $data['id'] = $element->getId();
+            $data['id'] = $elementId;
             $data['columns'][] = $columnData;
-            $data['isLocked'] = $element->getIsLocked();
-            $data['permissions'] = $element->getPermissions();
+            $data['isLocked'] = $element?->getIsLocked();
+            $data['permissions'] = $element?->getPermissions();
         }
 
         return $data;
@@ -219,11 +220,12 @@ final class GridService implements GridServiceInterface
      */
     public function getGridValuesForElement(
         ColumnCollection $columnCollection,
-        StudioElementInterface $element,
         string $elementType,
+        int $elementId,
         bool $isExport = false
     ): array {
-        $data = $this->getGridDataForElement($columnCollection, $element, $elementType, $isExport);
+
+        $data = $this->getGridDataForElement($columnCollection, null, $elementType, $elementId, $isExport);
 
         return array_map(
             static fn (ColumnData $columnData) => $columnData->getValue(),
@@ -372,7 +374,8 @@ final class GridService implements GridServiceInterface
             $data[] = $this->getGridDataForElement(
                 $this->getConfigurationFromArray($gridParameter->getColumns()),
                 $item,
-                $elementType
+                $elementType,
+                $item->getId()
             );
         }
 

--- a/src/Grid/Service/GridServiceInterface.php
+++ b/src/Grid/Service/GridServiceInterface.php
@@ -41,8 +41,9 @@ interface GridServiceInterface
      */
     public function getGridDataForElement(
         ColumnCollection $columnCollection,
-        StudioElementInterface $element,
+        ?StudioElementInterface $element,
         string $elementType,
+        int $elementId,
         bool $isExport = false
     ): array;
 
@@ -51,8 +52,8 @@ interface GridServiceInterface
      */
     public function getGridValuesForElement(
         ColumnCollection $columnCollection,
-        StudioElementInterface $element,
         string $elementType,
+        int $elementId,
         bool $isExport = false
     ): array;
 

--- a/src/MappedParameter/PatchFolderParameter.php
+++ b/src/MappedParameter/PatchFolderParameter.php
@@ -23,6 +23,7 @@ final readonly class PatchFolderParameter extends DataParameter
     public function __construct(
         array $data,
         private ?FilterParameter $filters,
+        private ?string $classId = null
     ) {
         parent::__construct($data);
     }
@@ -30,5 +31,10 @@ final readonly class PatchFolderParameter extends DataParameter
     public function getFilters(): FilterParameter
     {
         return $this->filters ?? new FilterParameter();
+    }
+
+    public function getClassId(): ?string
+    {
+        return $this->classId;
     }
 }

--- a/src/Patcher/Service/PatchService.php
+++ b/src/Patcher/Service/PatchService.php
@@ -31,9 +31,11 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Config;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Jobs;
+use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\PatchFolderParameter;
 use Pimcore\Bundle\StudioBackendBundle\Updater\Service\UpdateServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\DataObject\FieldKeys;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\PatchDataKeys;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\PatcherActions;
 use Pimcore\Model\DataObject\Concrete;
@@ -79,11 +81,19 @@ final readonly class PatchService implements PatchServiceInterface
         return null;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function patchFolder(
         string $elementType,
         PatchFolderParameter $patchFolderParameter,
         UserInterface $user,
     ): ?int {
+        $classId = $patchFolderParameter->getClassId();
+        if ($elementType === ElementTypes::TYPE_OBJECT && $classId === null) {
+            throw new InvalidArgumentException('Class ID must be provided for object folder patching');
+        }
+
         $job = new Job(
             name: Jobs::PATCH_ELEMENTS->value,
             steps: [
@@ -91,7 +101,10 @@ final readonly class PatchService implements PatchServiceInterface
                     JobSteps::ELEMENT_FOLDER_PATCHING->value,
                     PatchFolderMessage::class,
                     '',
-                    ['filters' => $patchFolderParameter->getFilters()]
+                    [
+                        StepConfig::CONFIG_FILTERS->value => $patchFolderParameter->getFilters(),
+                        StepConfig::ELEMENT_CLASS_ID->value => $classId ?? '',
+                    ]
                 ),
             ],
             selectedElements: array_map(

--- a/src/Patcher/Service/PatchServiceInterface.php
+++ b/src/Patcher/Service/PatchServiceInterface.php
@@ -35,6 +35,9 @@ interface PatchServiceInterface
         UserInterface $user,
     ): ?int;
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function patchFolder(
         string $elementType,
         PatchFolderParameter $patchFolderParameter,


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-backend-bundle/issues/1079
Resolves https://github.com/pimcore/studio-ui-bundle/issues/1750
Part of https://github.com/pimcore/studio-ui-bundle/issues/1854

## Additional info
- remove pagination for folder exports (zip, csv, xlsx) and batch patch as this should always apply for all elements within folder
- add mandatory classId param for object folder operations
- use getAllIds which uztilizes searchAfter instead of element search