### PR TITLE
[Export]: Require grid group only when when group should be present

### DIFF
--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -265,7 +265,7 @@ final class GridService implements GridServiceInterface
     {
         return array_map(
             static function (Column $column) use ($withGroup) {
-                if (!$column->getGroup()) {
+                if ($withGroup === true && !$column->getGroup()) {
                     throw new InvalidArgumentException('Group must be set when withGroup is true');
                 }
 


### PR DESCRIPTION
## Changes in this pull request
Related https://github.com/pimcore/studio-ui-bundle/issues/1854

## Additional info
- group seems to be required also when `withGroup` is false, which currently breaks the export