### PR TITLE
[Grid] Handle Object as folders.

### DIFF
--- a/src/DataIndex/Grid/GridSearch.php
+++ b/src/DataIndex/Grid/GridSearch.php
@@ -167,12 +167,8 @@ final readonly class GridSearch implements GridSearchInterface
             return true;
         }
 
-        // We handle Variants as folders since they can have child items.
-        if (
-            $type === ElementTypes::TYPE_DATA_OBJECT
-            && $element instanceof DataObject
-            && $element->getAllowVariants()
-        ) {
+        // We handle Object as folders since they can have child items.
+        if ($type === ElementTypes::TYPE_DATA_OBJECT && $element instanceof DataObject) {
             return true;
         }
 


### PR DESCRIPTION
## Changes in this pull request
Follow-up #1422

## Additional info
Objects can also have children. and there needs to able to list all those childs in the grid. So we handle all objects as folder. 
