### PR TITLE
 [Reports]: Cannot open configuration editor when data config is incorrect 

### DIFF
--- a/src/Bundle/CustomReport/Hydrator/ColumnHydrator.php
+++ b/src/Bundle/CustomReport/Hydrator/ColumnHydrator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Hydrator;
 
+use Exception;
 use Pimcore\Bundle\CustomReportsBundle\Tool\Config;
 use Pimcore\Bundle\CustomReportsBundle\Tool\Config\ColumnInformation;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportColumnConfiguration;
@@ -61,10 +62,10 @@ final readonly class ColumnHydrator implements ColumnHydratorInterface
                 $column['displayType'] ?? null,
                 $column['filter'] ?? null,
                 $column['filter_drilldown'] ?? null,
-                $metadata?->isDisableOrderBy(),
-                $metadata?->isDisableFilterable(),
-                $metadata?->isDisableDropdownFilterable(),
-                $metadata?->isDisableLabel()
+                $metadata && $metadata->isDisableOrderBy(),
+                $metadata && $metadata->isDisableFilterable(),
+                $metadata && $metadata->isDisableDropdownFilterable(),
+                $metadata && $metadata->isDisableLabel()
             );
         }
 
@@ -74,9 +75,13 @@ final readonly class ColumnHydrator implements ColumnHydratorInterface
     private function getMetadataMap(Config $report): array
     {
         $adapter = $this->adapterService->getAdapter($report);
-        $metadata = $adapter->getColumnsWithMetadata($report->getDataSourceConfig());
-        $columnNames = array_map(static fn ($column) => $column->getName(), $metadata);
+        try {
+            $metadata = $adapter->getColumnsWithMetadata($report->getDataSourceConfig());
+            $columnNames = array_map(static fn ($column) => $column->getName(), $metadata);
 
-        return array_combine($columnNames, $metadata);
+            return array_combine($columnNames, $metadata);
+        } catch (Exception) {
+            return [];
+        }
     }
 }

--- a/src/Bundle/CustomReport/Hydrator/ColumnHydrator.php
+++ b/src/Bundle/CustomReport/Hydrator/ColumnHydrator.php
@@ -75,6 +75,7 @@ final readonly class ColumnHydrator implements ColumnHydratorInterface
     private function getMetadataMap(Config $report): array
     {
         $adapter = $this->adapterService->getAdapter($report);
+
         try {
             $metadata = $adapter->getColumnsWithMetadata($report->getDataSourceConfig());
             $columnNames = array_map(static fn ($column) => $column->getName(), $metadata);


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-backend-bundle/issues/1420

## Additional info
When invalid data configuration is provided, metadata of columns cannot be retrieved as columns are build based on adapter configuration. 
In list endpoint we can catch this error and return default metadata configuration as columns are not valid anyway. Actual metadata values are then filled by another endpoint when data configuration is corrected