### PR TITLE
Update Node.js workflows to version 22

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -38,9 +38,9 @@ jobs:
                   token: ${{ secrets.DOCS_GENERATOR_ACCESS_TOKEN }}
 
             - name: "Install Node"
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: 19.x
+                  node-version: 22.x
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Prepare Docs


### PR DESCRIPTION
## 🚀 Node.js Version Update

This PR updates all GitHub Actions workflows to use Node.js version 22 (latest LTS) instead of older versions.

### Changes:
- ✅ Updated `node-version` from 20 and below to 22
- ✅ Updated `actions/setup-node` to v4
- ✅ Ensures compatibility with latest Node.js features and security updates

### Testing:
Please verify that all workflows continue to work as expected with the new Node.js version.

### References:
- [Node.js Release Schedule](https://nodejs.org/en/about/releases/)
- [actions/setup-node v4](https://github.com/actions/setup-node)