### PR TITLE
[Data Object Editor] Check size of layout JSON

### DIFF
--- a/src/Controller/AbstractApiController.php
+++ b/src/Controller/AbstractApiController.php
@@ -33,9 +33,15 @@ abstract class AbstractApiController extends AbstractController
     protected function jsonResponse(
         mixed $data,
         int $status = HttpResponseCodes::SUCCESS->value,
-        array $headers = []
+        array $headers = [],
+        array $context = []
     ): JsonResponse {
-        return new JsonResponse($this->serializer->serialize($data, 'json'), $status, $headers, true);
+        return new JsonResponse(
+            $this->serializer->serialize($data, 'json', $context),
+            $status,
+            $headers,
+            true
+        );
     }
 
     protected function patchResponse(array $errors = [], array $headers = []): Response

--- a/src/DataObject/Controller/LayoutController.php
+++ b/src/DataObject/Controller/LayoutController.php
@@ -34,6 +34,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -80,6 +81,10 @@ final class LayoutController extends AbstractApiController
         int $id,
         #[MapQueryString] GetLayoutIdParameter $layoutIdParameter = new GetLayoutIdParameter()
     ): JsonResponse {
-        return $this->jsonResponse($this->layoutService->getDataObjectLayout($id, $layoutIdParameter->getLayoutId()));
+
+        return $this->jsonResponse(
+            data: $this->layoutService->getDataObjectLayout($id, $layoutIdParameter->getLayoutId()),
+            context: [AbstractNormalizer::IGNORED_ATTRIBUTES => ['childrenByRef']]
+        );
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Resolves #1036 

## Additional info
Symfony Serializer was adding by default `childrenByRef` property of all children objects. In this case we dont need those and they should be skipped. This significantly reduces the response size