### PR TITLE
[keybindings]: Add missing default keybindings

### DIFF
--- a/config/pimcore/user_key_binding.yaml
+++ b/config/pimcore/user_key_binding.yaml
@@ -126,3 +126,49 @@ pimcore_studio_backend:
         action: clearDataCache
         ctrl: false
         alt: true
+      application_logger:
+        key: 'L'
+        action: applicationLogger
+        ctrl: true
+        alt: true
+      reports:
+        key: 'M'
+        action: reports
+        ctrl: true
+        alt: true
+      custom_reports:
+        key: 'C'
+        action: customReports
+        ctrl: true
+        alt: true
+        shift: false
+      glossary:
+        key: 'G'
+        action: glossary
+        ctrl: false
+        alt: true
+        shift: true
+      http_error_log:
+        key: 'O'
+        action: httpErrorLog
+        ctrl: true
+        alt: true
+        shift: false
+      seo_document_editor:
+        key: 'S'
+        action: seoDocumentEditor
+        ctrl: true
+        alt: true
+        shift: false
+      robots:
+        key: 'J'
+        action: robots
+        ctrl: true
+        alt: true
+        shift: false
+      quick_search:
+        key: 'F'
+        action: quickSearch
+        ctrl: true
+        alt: false
+        shift: true


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-ui-bundle/issues/2125#issuecomment-3379943777

## Additional info
I added the following default keybindings:

> Application Logger: Ctrl + Alt + L
> Reports: Ctrl + Alt + M
> Custom Reports: Ctrl + Alt + C
> Glossary: Alt + Shift + G
> HTTP Error Log: Ctrl + Alt + O
> SEO Document Editor: Ctrl + Alt + S
> Robots: Ctrl + Alt + J
> Quick Search: Ctrl + Shift + F