### PR TITLE
[Grid][Transformer] Translator for Grid Columns

### DIFF
--- a/config/grid.yaml
+++ b/config/grid.yaml
@@ -414,3 +414,6 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\Grid\Column\Transformer\Anonymizer:
     tags: [ 'pimcore.studio_backend.grid_transformer' ]
+
+  Pimcore\Bundle\StudioBackendBundle\Grid\Column\Transformer\Translate:
+    tags: [ 'pimcore.studio_backend.grid_transformer' ]

--- a/doc/03_Grid.md
+++ b/doc/03_Grid.md
@@ -491,7 +491,6 @@ The `Translate` transformer translates a given value using Symfony’s Translato
 **Available Configurations:**
 
 -   `prefix`: Adds a prefix to the value before translation.
--   `locale`: Specifies the locale to use for translation. Example: "de" → translates the value into German. If not set, the current application locale will be used.
 
 ---
 

--- a/doc/03_Grid.md
+++ b/doc/03_Grid.md
@@ -500,7 +500,7 @@ The `Translate` transformer translates a given value using Symfony’s Translato
 ```json
 {
   "key": "translatedName",
-  "locale": "de",
+  "locale": "en",
   "type": "dataobject.advanced",
   "config": {
     "title": "Translated Name",
@@ -517,7 +517,6 @@ The `Translate` transformer translates a given value using Symfony’s Translato
         "key": "translate",
         "config": {
           "prefix": "attribute.",
-          "locale": "de"
         }
       }
     ]

--- a/doc/03_Grid.md
+++ b/doc/03_Grid.md
@@ -480,3 +480,48 @@ The `anonymizer` transformer allows you to irreversibly obfuscate sensitive stri
 }
 ...
 ```
+
+
+#### Translate Transformer
+
+The `Translate` transformer translates a given value using Symfony’s Translator component. You can optionally add a prefix to the translation key and specify a locale to control the translation context. This is useful for dynamically translating field values in grids or data objects according to the configured locale and translation keys.
+
+---
+
+**Available Configurations:**
+
+-   `prefix`: Adds a prefix to the value before translation.
+-   `locale`: Specifies the locale to use for translation. Example: "de" → translates the value into German. If not set, the current application locale will be used.
+
+---
+
+**Example Configuration:**
+
+```json
+{
+  "key": "translatedName",
+  "locale": "de",
+  "type": "dataobject.advanced",
+  "config": {
+    "title": "Translated Name",
+    "advancedColumns": [
+      {
+        "key": "simpleField",
+        "config": {
+          "field": "name"
+        }
+      }
+    ],
+    "transformers": [
+      {
+        "key": "translate",
+        "config": {
+          "prefix": "attribute.",
+          "locale": "de"
+        }
+      }
+    ]
+  }
+}
+...
+```

--- a/src/Grid/Column/Transformer/Anonymizer.php
+++ b/src/Grid/Column/Transformer/Anonymizer.php
@@ -94,9 +94,8 @@ final class Anonymizer implements TransformerInterface
                 'options' => [
                     ['value' => 'md5', 'label' => 'MD5 Hash'],
                     ['value' => 'bcrypt', 'label' => 'Bcrypt'],
-                    ['value' => 'default', 'label' => 'Default Placeholder'],
                 ],
-                'default' => 'default',
+                'default' => 'md5',
             ],
         ];
     }

--- a/src/Grid/Column/Transformer/Translate.php
+++ b/src/Grid/Column/Transformer/Translate.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Transformer;
+
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\TransformerException;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\TransformerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Util\AdvancedValue;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+use function is_string;
+use function sprintf;
+
+/**
+ * @internal
+ */
+final readonly class Translate implements TransformerInterface
+{
+
+    public function __construct(private TranslatorInterface $translator)
+    {
+    }
+
+    public function transform(array $value, array $config): array
+    {
+        if (isset($config['prefix']) && !is_string($config['prefix'])) {
+                    throw new TransformerException(
+                        $this->getName(),
+                        sprintf(
+                            'Invalid "prefix" configuration (must be a string) for %s transformer.',
+                            $this->getKey()
+                        )
+                    );
+                }
+
+        if (isset($config['locale']) && !is_string($config['locale'])) {
+                    throw new TransformerException(
+                        $this->getName(),
+                        sprintf(
+                            'Invalid "locale" configuration (must be a string) for %s transformer.',
+                            $this->getKey()
+                        )
+                    );
+                }
+        
+        $prefix = $config['prefix'] ?? '';
+        $locale = $config['locale'] ?? null;
+
+        $translatedValues = [];
+
+        foreach ($value as $item) {
+            if (!$item instanceof AdvancedValue) {
+                continue;
+            }
+
+            $originalValue = (string) $item->getValue();
+            if ($originalValue === '') {
+                $translatedValues[] = $item;
+                continue;
+            }
+
+
+            $translated = $this->translator->trans(
+                $prefix . $originalValue,
+                [],
+                null,
+                $locale
+            );
+
+            $translatedValues[] = new AdvancedValue('string', $translated, $item->getFieldName());
+        }
+
+        return $translatedValues;
+    }
+
+    public function getName(): string
+    {
+        return 'Translate';
+    }
+
+    public function getKey(): string
+    {
+        return 'translate';
+    }
+    
+    public function getDescription(): string
+    {
+        return 'Translates the value using Symfony Translator. You can optionally add a prefix and set a locale.';
+    }
+
+    public function getConfigOptions(): array
+    {
+        return [
+            'prefix' => [
+                'type' => 'text',
+                'default' => '',
+                'label' => 'Translation Prefix',
+                'description' => 'Prefix added before the value for translation. Example: "label_" → "label_myValue".',
+            ],
+            'locale' => [
+                'type' => 'text',
+                'default' => '',
+                'label' => 'Locale',
+                'description' => 'translateOptional locale to use for translation. If not set, current locale is used.',
+            ],
+        ];
+    }
+
+}

--- a/src/Grid/Column/Transformer/Translate.php
+++ b/src/Grid/Column/Transformer/Translate.php
@@ -27,7 +27,6 @@ use function sprintf;
  */
 final readonly class Translate implements TransformerInterface
 {
-
     public function __construct(private TranslatorInterface $translator)
     {
     }
@@ -35,25 +34,25 @@ final readonly class Translate implements TransformerInterface
     public function transform(array $value, array $config): array
     {
         if (isset($config['prefix']) && !is_string($config['prefix'])) {
-                    throw new TransformerException(
-                        $this->getName(),
-                        sprintf(
-                            'Invalid "prefix" configuration (must be a string) for %s transformer.',
-                            $this->getKey()
-                        )
-                    );
-                }
+            throw new TransformerException(
+                $this->getName(),
+                sprintf(
+                    'Invalid "prefix" configuration (must be a string) for %s transformer.',
+                    $this->getKey()
+                )
+            );
+        }
 
         if (isset($config['locale']) && !is_string($config['locale'])) {
-                    throw new TransformerException(
-                        $this->getName(),
-                        sprintf(
-                            'Invalid "locale" configuration (must be a string) for %s transformer.',
-                            $this->getKey()
-                        )
-                    );
-                }
-        
+            throw new TransformerException(
+                $this->getName(),
+                sprintf(
+                    'Invalid "locale" configuration (must be a string) for %s transformer.',
+                    $this->getKey()
+                )
+            );
+        }
+
         $prefix = $config['prefix'] ?? '';
         $locale = $config['locale'] ?? null;
 
@@ -67,9 +66,9 @@ final readonly class Translate implements TransformerInterface
             $originalValue = (string) $item->getValue();
             if ($originalValue === '') {
                 $translatedValues[] = $item;
+
                 continue;
             }
-
 
             $translated = $this->translator->trans(
                 $prefix . $originalValue,
@@ -93,7 +92,7 @@ final readonly class Translate implements TransformerInterface
     {
         return 'translate';
     }
-    
+
     public function getDescription(): string
     {
         return 'Translates the value using Symfony Translator. You can optionally add a prefix and set a locale.';
@@ -116,5 +115,4 @@ final readonly class Translate implements TransformerInterface
             ],
         ];
     }
-
 }

--- a/src/Grid/Column/Transformer/Translate.php
+++ b/src/Grid/Column/Transformer/Translate.php
@@ -106,13 +106,13 @@ final readonly class Translate implements TransformerInterface
                 'type' => 'text',
                 'default' => '',
                 'label' => 'Translation Prefix',
-                'description' => 'Prefix added before the value for translation. Example: "label_" → "label_myValue".',
+                'description' => 'Prefix added before the value for translation. Example: "attribute." → "attribute.myValue".',
             ],
             'locale' => [
                 'type' => 'text',
                 'default' => '',
                 'label' => 'Locale',
-                'description' => 'translateOptional locale to use for translation. If not set, current locale is used.',
+                'description' => 'Optional locale to use for translation (e.g., "de"). If not set, the current locale is used.',
             ],
         ];
     }

--- a/src/Grid/Column/Transformer/Translate.php
+++ b/src/Grid/Column/Transformer/Translate.php
@@ -108,13 +108,6 @@ final readonly class Translate implements TransformerInterface
                'description' => 'Prefix added before the value for translation. '
                . 'Example: "attribute." → "attribute.myValue".',
             ],
-            'locale' => [
-                'type' => 'text',
-                'default' => '',
-                'label' => 'Locale',
-                'description' => 'Optional locale to use for translation (e.g., "de"). '
-               . 'If not set, the current locale is used.',
-            ],
         ];
     }
 }

--- a/src/Grid/Column/Transformer/Translate.php
+++ b/src/Grid/Column/Transformer/Translate.php
@@ -105,13 +105,15 @@ final readonly class Translate implements TransformerInterface
                 'type' => 'text',
                 'default' => '',
                 'label' => 'Translation Prefix',
-                'description' => 'Prefix added before the value for translation. Example: "attribute." → "attribute.myValue".',
+               'description' => 'Prefix added before the value for translation. '
+               . 'Example: "attribute." → "attribute.myValue".',
             ],
             'locale' => [
                 'type' => 'text',
                 'default' => '',
                 'label' => 'Locale',
-                'description' => 'Optional locale to use for translation (e.g., "de"). If not set, the current locale is used.',
+                'description' => 'Optional locale to use for translation (e.g., "de"). '
+               . 'If not set, the current locale is used.',
             ],
         ];
     }

--- a/src/Grid/Schema/Column.php
+++ b/src/Grid/Schema/Column.php
@@ -131,10 +131,10 @@ final readonly class Column
             foreach ($this->config['transformers'] as $transformer) {
                 if (isset($transformer['key'])) {
 
-                // Inject locale into original config array if not set
-                if ($this->getLocale() !== null) {
-                    $transformer['config']['locale'] = $this->getLocale();
-                }
+                    // Inject locale into original config array if not set
+                    if ($this->getLocale() !== null) {
+                        $transformer['config']['locale'] = $this->getLocale();
+                    }
 
                     $transformers[] = new Transformer(
                         key: $transformer['key'],

--- a/src/Grid/Schema/Column.php
+++ b/src/Grid/Schema/Column.php
@@ -131,13 +131,10 @@ final readonly class Column
             foreach ($this->config['transformers'] as $transformer) {
                 if (isset($transformer['key'])) {
 
-                    // Inject locale into original config array if not set
-                    if (
-                        !isset($transformer['config']['locale']) &&
-                        $this->getLocale() !== null
-                    ) {
-                        $transformer['config']['locale'] = $this->getLocale();
-                    }
+                // Inject locale into original config array if not set
+                if ($this->getLocale() !== null) {
+                    $transformer['config']['locale'] = $this->getLocale();
+                }
 
                     $transformers[] = new Transformer(
                         key: $transformer['key'],

--- a/src/Grid/Schema/Column.php
+++ b/src/Grid/Schema/Column.php
@@ -130,6 +130,15 @@ final readonly class Column
         if (isset($this->config['transformers'])) {
             foreach ($this->config['transformers'] as $transformer) {
                 if (isset($transformer['key'])) {
+
+                    // Inject locale into original config array if not set
+                    if (
+                        !isset($transformer['config']['locale']) &&
+                        $this->getLocale() !== null
+                    ) {
+                        $transformer['config']['locale'] = $this->getLocale();
+                    }
+
                     $transformers[] = new Transformer(
                         key: $transformer['key'],
                         config: $transformer['config'] ?? []
@@ -138,7 +147,7 @@ final readonly class Column
             }
         }
 
-        return  $transformers;
+        return $transformers;
     }
 
     public function toArray(): array


### PR DESCRIPTION
Added a new Translate Transformer for grids to easily translate field values with optional prefix and locale support. This makes grid data more flexible and localized.