### PR TITLE
Add translations for forgot password form

### DIFF
--- a/src/Util/Constant/PublicTranslations.php
+++ b/src/Util/Constant/PublicTranslations.php
@@ -30,6 +30,6 @@ final readonly class PublicTranslations
         'forgot-password-form.success-message',
         'forgot-password-form.username',
         'forgot-password-form.reset-password',
-        'forgot-password-form.back'
+        'forgot-password-form.back',
     ];
 }

--- a/src/Util/Constant/PublicTranslations.php
+++ b/src/Util/Constant/PublicTranslations.php
@@ -27,5 +27,9 @@ final readonly class PublicTranslations
         'aria.login-form-additional-logins.additional-login-provider',
         'login-form.username',
         'login-form.password',
+        'forgot-password-form.success-message',
+        'forgot-password-form.username',
+        'forgot-password-form.reset-password',
+        'forgot-password-form.back'
     ];
 }


### PR DESCRIPTION
## Changes in this pull request
Related to: https://github.com/pimcore/studio-ui-bundle/pull/2331

## Additional info
This pull request adds new translation keys related to the forgot password form to the list of public translations in `PublicTranslations.php`.

* Added the following translation keys for the forgot password form: `forgot-password-form.success-message`, `forgot-password-form.username`, `forgot-password-form.reset-password`, and `forgot-password-form.back` (`src/Util/Constant/PublicTranslations.php`).