### PR TITLE
Add placeholder translation for username field

### DIFF
--- a/src/Util/Constant/PublicTranslations.php
+++ b/src/Util/Constant/PublicTranslations.php
@@ -31,5 +31,6 @@ final readonly class PublicTranslations
         'forgot-password-form.username',
         'forgot-password-form.reset-password',
         'forgot-password-form.back',
+        'forgot-password-form.username.placeholder'
     ];
 }

--- a/src/Util/Constant/PublicTranslations.php
+++ b/src/Util/Constant/PublicTranslations.php
@@ -31,6 +31,6 @@ final readonly class PublicTranslations
         'forgot-password-form.username',
         'forgot-password-form.reset-password',
         'forgot-password-form.back',
-        'forgot-password-form.username.placeholder'
+        'forgot-password-form.username.placeholder',
     ];
 }


### PR DESCRIPTION
## Changes in this pull request
Belongs to: https://github.com/pimcore/studio-ui-bundle/pull/2331

## Additional info
This pull request makes a minor update to the `PublicTranslations.php` file by adding a new translation key for the forgot password form username placeholder. This helps ensure that the placeholder text can be localized properly.