### PR TITLE
Symfony 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "nesbot/carbon": "^3.8.4",
     "pimcore/static-resolver-bundle": "^3.2.0",
     "pimcore/generic-data-index-bundle": "^2.2.0",
-    "pimcore/pimcore": "^12.0",
+    "pimcore/pimcore": "^12.3",
     "zircote/swagger-php": "^4.8 || ^5.0",
     "ext-zip": "*",
     "symfony/mercure": "^0.6.5",

--- a/src/Security/Voter/UserPasswordVoter.php
+++ b/src/Security/Voter/UserPasswordVoter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Security\Voter;
 
+use Pimcore\Helper\ParameterBagHelper;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\AccessDeniedException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
@@ -63,6 +64,6 @@ final class UserPasswordVoter extends Voter
     {
         $request = $this->getCurrentRequest($this->requestStack);
 
-        return $request->attributes->getInt('id');
+        return ParameterBagHelper::getInt($request->attributes, 'id');
     }
 }

--- a/src/Security/Voter/UserPasswordVoter.php
+++ b/src/Security/Voter/UserPasswordVoter.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Security\Voter;
 
-use Pimcore\Helper\ParameterBagHelper;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\AccessDeniedException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\RequestTrait;
+use Pimcore\Helper\ParameterBagHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;


### PR DESCRIPTION
This pull request introduces a minor update to the way user IDs are retrieved from request attributes in the `UserPasswordVoter` class. The change improves robustness by using a helper method for extracting integer values.

* Updated `getUserIdFromRequest()` to use `ParameterBagHelper::getInt()` instead of directly calling `$request->attributes->getInt()`, which provides safer and more consistent parameter extraction. (`src/Security/Voter/UserPasswordVoter.php`)
* Added the import for `Pimcore\Helper\ParameterBagHelper` to support the new helper usage. (`src/Security/Voter/UserPasswordVoter.php`)