### PR TITLE
Update phpspreadsheet version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "symfony/mercure-bundle": "^0.3.9",
     "lcobucci/jwt": "^5.3",
     "phpdocumentor/reflection-docblock": "^5.6",
-    "phpoffice/phpspreadsheet": "^3.3",
+    "phpoffice/phpspreadsheet": "^3.3|^4.0|^5.0",
     "ext-intl": "*",
     "ext-filter": "*"
   },


### PR DESCRIPTION
Not affected by breaking changes of https://github.com/PHPOffice/PhpSpreadsheet/blob/master/CHANGELOG.md#2025-02-08---400

Right now this blocks others from installing this bundle. 4.x was released February 2025.

## Changes in this pull request
Resolves #

## Additional info
