### PR TITLE
[Tree]: update custom index of siblings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "ext-filter": "*"
   },
   "require-dev": {
-    "codeception/codeception": "^5.0.10",
+    "codeception/codeception": "^5.3.2",
     "roave/security-advisories": "dev-latest",
     "codeception/phpunit-wrapper": "^9",
     "codeception/module-asserts": "^2",

--- a/config/elements.yaml
+++ b/config/elements.yaml
@@ -39,6 +39,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementSaveServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementSaveService
 
+  Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementIndexServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementIndexService
+
   Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementLocationServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementLocationService
 

--- a/src/Element/Service/ElementIndexService.php
+++ b/src/Element/Service/ElementIndexService.php
@@ -1,0 +1,254 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
+
+use Exception;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DbalException;
+use Pimcore\Bundle\StaticResolverBundle\Db\DbResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ConcreteObjectResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\Document;
+use Pimcore\Model\Document\Listing;
+use Pimcore\Model\Document\PageSnippet;
+use Pimcore\Model\Element\ElementInterface;
+use Psr\Log\LoggerInterface;
+use Random\RandomException;
+
+/**
+ * @internal
+ */
+final readonly class ElementIndexService implements ElementIndexServiceInterface
+{
+    private const string DATA_OBJET_TABLE = 'objects';
+
+    public function __construct(
+        private ConcreteObjectResolverInterface $concreteResolver,
+        private DbResolverInterface $dbResolver,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function indexRelatedElements(ElementInterface $element, int $newIndex): void
+    {
+        if ($element instanceof DataObject) {
+            $this->indexRelatedObjects($element, $newIndex);
+            return;
+        }
+
+        if ($element instanceof Document) {
+            $this->indexRelatedDocuments($element, $newIndex);
+        }
+    }
+
+    private function indexRelatedObjects(DataObject $updatedObject, int $newIndex): void
+    {
+        $parent = $updatedObject->getParent();
+        if ($parent === null) {
+            return;
+        }
+
+        $this->executeInsideTransaction(
+            fn() => $this->reindexSiblingObjects($updatedObject, $newIndex, $parent)
+        );
+    }
+
+
+    private function indexRelatedDocuments(Document $updatedDocument, int $newIndex): void
+    {
+        $parentId = $updatedDocument->getParentId();
+        if ($parentId === null) {
+            return;
+        }
+
+        // if changed the index change also all documents on the same level
+        $updatedDocument->saveIndex($newIndex);
+
+        $list = new Listing();
+        $list->setCondition('parentId = ? AND id != ?', [$parentId, $updatedDocument->getId()]);
+        $list->setOrderKey('index');
+        $list->setOrder('asc');
+        $childrenList = $list->load();
+
+        $count = 0;
+        foreach ($childrenList as $child) {
+            if ($count === $newIndex) {
+                $count++;
+            }
+            $child->saveIndex($count);
+            if ($child instanceof PageSnippet) {
+                $this->updateLatestVersionIndex($child, $count);
+            }
+            $count++;
+        }
+    }
+
+    /**
+     * @throws DbalException
+     */
+    private function reindexSiblingObjects(
+        DataObject $updatedObject,
+        int $newIndex,
+        AbstractObject $parent
+    ): void {
+        $updatedObject->saveIndex($newIndex);
+
+        $this->updateSiblingIndexes($updatedObject, $newIndex, $parent);
+        $this->updateSiblingVersions($updatedObject, $newIndex);
+    }
+
+    /**
+     * @throws DbalException
+     */
+    private function updateSiblingIndexes(
+        DataObject $updatedObject,
+        int $newIndex,
+        AbstractObject $parent
+    ): void {
+        $db = $this->dbResolver->get();
+        $db->executeStatement(
+            'UPDATE '. self::DATA_OBJET_TABLE .' o,
+            (
+                SELECT newIndex, id
+                FROM (
+                    With cte As (SELECT `index`, id FROM ' . self::DATA_OBJET_TABLE .
+            ' WHERE parentId = ? AND id != ? ORDER BY `index` LIMIT '.
+            $parent->getChildAmount() .')
+                    SELECT @n := IF(@n = ? - 1,@n + 2,@n + 1) AS newIndex, id
+                    FROM cte,
+                    (SELECT @n := -1) variable
+                ) tmp
+            ) order_table
+            SET o.index = order_table.newIndex
+            WHERE o.id=order_table.id',
+            [
+                $updatedObject->getParentId(),
+                $updatedObject->getId(),
+                $newIndex,
+            ]
+        );
+    }
+
+    /**
+     * @throws Exception|DbalException
+     * @throws \Exception
+     */
+    private function updateSiblingVersions(
+        DataObject $updatedObject,
+        int $newIndex
+    ): void {
+        $db = $this->dbResolver->get();
+        $siblings = $db->fetchAllAssociative(
+            'SELECT id, modificationDate, versionCount, `key`, `index` FROM ' . self::DATA_OBJET_TABLE .
+            ' WHERE parentId = ? AND id != ? ORDER BY `index` ASC',
+            [$updatedObject->getParentId(), $updatedObject->getId()]
+        );
+
+        $index = 0;
+        foreach ($siblings as $sibling) {
+            if ($index === $newIndex) {
+                $index++;
+            }
+
+            $element = $this->concreteResolver->getById($sibling['id']);
+            if ($element === null) {
+                continue;
+            }
+
+            $this->updateLatestVersionIndex($element, $index);
+            $index++;
+
+            $element->clearDependentCache();
+        }
+    }
+
+    private function updateLatestVersionIndex(Concrete|PageSnippet $element, int $newIndex): void
+    {
+        $latestVersion = $element->getLatestVersion();
+        if ($latestVersion === null) {
+            return;
+        }
+
+        // don't renew references (which means loading the target elements)
+        // Not needed as we just save a new version with the updated index
+        $version = $latestVersion->loadData(false);
+        if ($newIndex !== $version->getIndex()) {
+            $version->setIndex($newIndex);
+        }
+
+        $latestVersion->save();
+    }
+
+    private function executeInsideTransaction(callable $fn): void
+    {
+        $db = $this->dbResolver->get();
+        $maxRetries = 5;
+        for ($retries = 0; $retries < $maxRetries; $retries++) {
+            try {
+                $db->beginTransaction();
+
+                $fn();
+
+                $db->commit();
+
+                break;
+            } catch (Exception $e) {
+                $this->rollBackTransaction($db, $retries, $e);
+            } catch (DbalException $e) {
+                throw new DatabaseException('Database error occurred: ' . $e->getMessage(), previous: $e);
+            }
+        }
+    }
+
+    private function rollBackTransaction(Connection $db, int $retries, Exception $exception): void
+    {
+        $maxRetries = 5;
+        try {
+            $db->rollBack();
+
+            // we try to start the transaction $maxRetries times again (deadlocks, ...)
+            if ($retries < ($maxRetries - 1)) {
+                $run = $retries + 1;
+                $waitTime = random_int(1, 5) * 100000; // microseconds
+                $this->logger->warning(
+                    'Unable to finish transaction (' . $run . ". run) because of the following reason '" .
+                    $exception->getMessage() . "'. --> Retrying in " . $waitTime .
+                    ' microseconds ... (' . ($run + 1) . ' of ' . $maxRetries . ')'
+                );
+
+                usleep($waitTime); // wait a specified time until we restart the transaction
+            } else {
+                // if the transaction still fails after $maxRetries retries, we throw out the exception
+                $this->logger->error(
+                    'Finally giving up restarting the same transaction again and again, last message: ' .
+                    $exception->getMessage()
+                );
+
+                throw new DatabaseException(
+                    message: sprintf('Error while updating indexes: %s', $exception->getMessage()),
+                    previous: $exception
+                );
+            }
+
+        } catch (DbalException $e) {
+            throw new DatabaseException('Database error occurred: ' . $e->getMessage(), previous: $e);
+        } catch (RandomException $e) {
+            throw new EnvironmentException($e->getMessage(), previous: $e);
+        }
+    }
+}

--- a/src/Element/Service/ElementIndexService.php
+++ b/src/Element/Service/ElementIndexService.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DbalException;
 use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Db\DbResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Lib\CacheResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ConcreteObjectResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
@@ -36,9 +37,10 @@ use function sprintf;
  */
 final readonly class ElementIndexService implements ElementIndexServiceInterface
 {
-    private const string DATA_OBJET_TABLE = 'objects';
+    private const string DATA_OBJECT_TABLE = 'objects';
 
     public function __construct(
+        private CacheResolverInterface $cacheResolver,
         private ConcreteObjectResolverInterface $concreteResolver,
         private DbResolverInterface $dbResolver,
         private LoggerInterface $logger,
@@ -55,6 +57,52 @@ final readonly class ElementIndexService implements ElementIndexServiceInterface
 
         if ($element instanceof Document) {
             $this->indexRelatedDocuments($element, $newIndex);
+        }
+    }
+    
+    public function reindexBasedOnSortBy(AbstractObject $parentObject, string $currentSortOrder): void
+    {
+        $this->executeInsideTransaction(fn () => $this->reindexByIndex($parentObject, $currentSortOrder));
+    }
+
+    /**
+     * @throws DbalException
+     */
+    private function reindexByIndex(AbstractObject $dataObject, string $currentSortOrder): void
+    {
+        $db = $this->dbResolver->get();
+        $db->executeStatement(
+            'UPDATE '. self::DATA_OBJECT_TABLE .' o,
+                    (
+                    SELECT newIndex, id FROM (
+                        SELECT @n := @n +1 AS newIndex, id
+                        FROM '. self::DATA_OBJECT_TABLE .',
+                                (SELECT @n := -1) variable
+                                 WHERE parentId = ? ORDER BY `key` ' . $currentSortOrder
+            .') tmp
+                    ) order_table
+                    SET o.index = order_table.newIndex
+                    WHERE o.id=order_table.id',
+            [
+                $dataObject->getId(),
+            ]
+        );
+
+        $children = $db->fetchAllAssociative(
+            'SELECT id, modificationDate, versionCount FROM ' . self::DATA_OBJECT_TABLE .
+            ' WHERE parentId = ? ORDER BY `index` ASC',
+            [$dataObject->getId()]
+        );
+
+        foreach ($children as $child) {
+            $element = $this->concreteResolver->getById($child['id']);
+            if ($element === null) {
+                continue;
+            }
+            $this->updateLatestVersionIndex($element, $child['modificationDate']);
+            $this->cacheResolver->clearTags(
+                [sprintf('object_%s', $child['id']), 'object_properties', 'output']
+            );
         }
     }
 
@@ -123,11 +171,11 @@ final readonly class ElementIndexService implements ElementIndexServiceInterface
     ): void {
         $db = $this->dbResolver->get();
         $db->executeStatement(
-            'UPDATE '. self::DATA_OBJET_TABLE .' o,
+            'UPDATE '. self::DATA_OBJECT_TABLE .' o,
             (
                 SELECT newIndex, id
                 FROM (
-                    With cte As (SELECT `index`, id FROM ' . self::DATA_OBJET_TABLE .
+                    With cte As (SELECT `index`, id FROM ' . self::DATA_OBJECT_TABLE .
             ' WHERE parentId = ? AND id != ? ORDER BY `index` LIMIT '.
             $parent->getChildAmount() .')
                     SELECT @n := IF(@n = ? - 1,@n + 2,@n + 1) AS newIndex, id
@@ -155,7 +203,7 @@ final readonly class ElementIndexService implements ElementIndexServiceInterface
     ): void {
         $db = $this->dbResolver->get();
         $siblings = $db->fetchAllAssociative(
-            'SELECT id, modificationDate, versionCount, `key`, `index` FROM ' . self::DATA_OBJET_TABLE .
+            'SELECT id, modificationDate, versionCount, `key`, `index` FROM ' . self::DATA_OBJECT_TABLE .
             ' WHERE parentId = ? AND id != ? ORDER BY `index` ASC',
             [$updatedObject->getParentId(), $updatedObject->getId()]
         );
@@ -216,6 +264,9 @@ final readonly class ElementIndexService implements ElementIndexServiceInterface
         }
     }
 
+    /**
+     * @throws DatabaseException|EnvironmentException
+     */
     private function rollBackTransaction(Connection $db, int $retries, Exception $exception): void
     {
         $maxRetries = 5;

--- a/src/Element/Service/ElementIndexService.php
+++ b/src/Element/Service/ElementIndexService.php
@@ -59,7 +59,7 @@ final readonly class ElementIndexService implements ElementIndexServiceInterface
             $this->indexRelatedDocuments($element, $newIndex);
         }
     }
-    
+
     public function reindexBasedOnSortBy(AbstractObject $parentObject, string $currentSortOrder): void
     {
         $this->executeInsideTransaction(fn () => $this->reindexByIndex($parentObject, $currentSortOrder));

--- a/src/Element/Service/ElementIndexService.php
+++ b/src/Element/Service/ElementIndexService.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
 
-use Exception;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DbalException;
+use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Db\DbResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ConcreteObjectResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
@@ -29,6 +29,7 @@ use Pimcore\Model\Document\PageSnippet;
 use Pimcore\Model\Element\ElementInterface;
 use Psr\Log\LoggerInterface;
 use Random\RandomException;
+use function sprintf;
 
 /**
  * @internal
@@ -48,6 +49,7 @@ final readonly class ElementIndexService implements ElementIndexServiceInterface
     {
         if ($element instanceof DataObject) {
             $this->indexRelatedObjects($element, $newIndex);
+
             return;
         }
 
@@ -64,10 +66,9 @@ final readonly class ElementIndexService implements ElementIndexServiceInterface
         }
 
         $this->executeInsideTransaction(
-            fn() => $this->reindexSiblingObjects($updatedObject, $newIndex, $parent)
+            fn () => $this->reindexSiblingObjects($updatedObject, $newIndex, $parent)
         );
     }
-
 
     private function indexRelatedDocuments(Document $updatedDocument, int $newIndex): void
     {
@@ -146,7 +147,7 @@ final readonly class ElementIndexService implements ElementIndexServiceInterface
 
     /**
      * @throws Exception|DbalException
-     * @throws \Exception
+     * @throws Exception
      */
     private function updateSiblingVersions(
         DataObject $updatedObject,
@@ -218,6 +219,7 @@ final readonly class ElementIndexService implements ElementIndexServiceInterface
     private function rollBackTransaction(Connection $db, int $retries, Exception $exception): void
     {
         $maxRetries = 5;
+
         try {
             $db->rollBack();
 

--- a/src/Element/Service/ElementIndexServiceInterface.php
+++ b/src/Element/Service/ElementIndexServiceInterface.php
@@ -13,9 +13,21 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
 
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
+use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\Element\ElementInterface;
 
 interface ElementIndexServiceInterface
 {
+
+    /**
+     * @throws DatabaseException|EnvironmentException
+     */
     public function indexRelatedElements(ElementInterface $element, int $newIndex): void;
+
+    /**
+     * @throws DatabaseException|EnvironmentException
+     */
+    public function reindexBasedOnSortBy(AbstractObject $parentObject, string $currentSortOrder): void;
 }

--- a/src/Element/Service/ElementIndexServiceInterface.php
+++ b/src/Element/Service/ElementIndexServiceInterface.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
+
+use Pimcore\Model\Element\ElementInterface;
+
+interface ElementIndexServiceInterface
+{
+    public function indexRelatedElements(ElementInterface $element, int $newIndex): void;
+}

--- a/src/Element/Service/ElementIndexServiceInterface.php
+++ b/src/Element/Service/ElementIndexServiceInterface.php
@@ -20,7 +20,6 @@ use Pimcore\Model\Element\ElementInterface;
 
 interface ElementIndexServiceInterface
 {
-
     /**
      * @throws DatabaseException|EnvironmentException
      */

--- a/src/Patcher/Adapter/ChildrenSortByAdapter.php
+++ b/src/Patcher/Adapter/ChildrenSortByAdapter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Patcher\Adapter;
 
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementIndexServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementSavingFailedException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Patcher\Service\Loader\TaggedIteratorAdapter;
@@ -32,7 +33,12 @@ use function sprintf;
 #[AutoconfigureTag(TaggedIteratorAdapter::ADAPTER_TAG)]
 final readonly class ChildrenSortByAdapter implements PatchAdapterInterface
 {
-    private const INDEX_KEY = 'childrenSortBy';
+    private const string INDEX_KEY = 'childrenSortBy';
+
+    public function __construct(
+        private ElementIndexServiceInterface $indexService
+    ) {
+    }
 
     /**
      * @throws ElementSavingFailedException|ForbiddenException
@@ -57,6 +63,9 @@ final readonly class ChildrenSortByAdapter implements PatchAdapterInterface
         }
 
         $element->setChildrenSortBy($data[$this->getIndexKey()]);
+        if ($value === AbstractObject::OBJECT_CHILDREN_SORT_BY_INDEX) {
+            $this->indexService->reindexBasedOnSortBy($element, $this->getDefaultSortOrder($data));
+        }
     }
 
     public function getIndexKey(): string
@@ -69,5 +78,18 @@ final readonly class ChildrenSortByAdapter implements PatchAdapterInterface
         return [
             ElementTypes::TYPE_OBJECT,
         ];
+    }
+
+    private function getDefaultSortOrder(array $data): string
+    {
+        if (!in_array(
+            $data[ChildrenSortOrderAdapter::INDEX_KEY] ?? '',
+            ['ASC', 'DESC'],
+            true
+        )) {
+            return AbstractObject::OBJECT_CHILDREN_SORT_ORDER_DEFAULT;
+        }
+
+        return $data[ChildrenSortOrderAdapter::INDEX_KEY];
     }
 }

--- a/src/Patcher/Adapter/ChildrenSortOrderAdapter.php
+++ b/src/Patcher/Adapter/ChildrenSortOrderAdapter.php
@@ -30,7 +30,7 @@ use function sprintf;
 #[AutoconfigureTag(TaggedIteratorAdapter::ADAPTER_TAG)]
 final readonly class ChildrenSortOrderAdapter implements PatchAdapterInterface
 {
-    private const INDEX_KEY = 'childrenSortOrder';
+    public const string INDEX_KEY = 'childrenSortOrder';
 
     /**
      * @throws ElementSavingFailedException

--- a/src/Patcher/Service/PatchService.php
+++ b/src/Patcher/Service/PatchService.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\StudioBackendBundle\DataObject\Util\Trait\ValidateObjectDataT
 use Pimcore\Bundle\StudioBackendBundle\Element\ExecutionEngine\AutomationAction\Messenger\Messages\PatchFolderMessage;
 use Pimcore\Bundle\StudioBackendBundle\Element\ExecutionEngine\AutomationAction\Messenger\Messages\PatchMessage;
 use Pimcore\Bundle\StudioBackendBundle\Element\ExecutionEngine\Util\JobSteps;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementIndexServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementSaveServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementExistsException;
@@ -59,6 +60,7 @@ final readonly class PatchService implements PatchServiceInterface
         private DataAdapterServiceInterface $dataAdapterService,
         private ElementServiceInterface $elementService,
         private JobExecutionAgentInterface $jobExecutionAgent,
+        private ElementIndexServiceInterface $indexService,
         private ElementSaveServiceInterface $elementSaveService
     ) {
     }
@@ -156,6 +158,10 @@ final readonly class PatchService implements PatchServiceInterface
                 $user,
                 $elementPatchData[ElementSaveServiceInterface::INDEX_TASK] ?? null
             );
+
+            if (isset($elementPatchData['index'])) {
+                $this->indexService->indexRelatedElements($element, $elementPatchData['index']);
+            }
         } catch (DuplicateFullPathException) {
             throw new ElementExistsException(
                 message: sprintf('Element with full path [%s] already exists', $element->getRealFullPath())

--- a/src/Updater/Adapter/ChildrenSortByAdapter.php
+++ b/src/Updater/Adapter/ChildrenSortByAdapter.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Updater\Adapter;
 
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementIndexServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementSavingFailedException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Patcher\Adapter\ChildrenSortOrderAdapter;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
@@ -31,9 +33,10 @@ use function sprintf;
 #[AutoconfigureTag('pimcore.studio_backend.update_adapter')]
 final readonly class ChildrenSortByAdapter implements UpdateAdapterInterface
 {
-    private const INDEX_KEY = 'childrenSortBy';
+    private const string INDEX_KEY = 'childrenSortBy';
 
     public function __construct(
+        private ElementIndexServiceInterface $indexService,
         private SecurityServiceInterface $securityService
     ) {
     }
@@ -61,7 +64,10 @@ final readonly class ChildrenSortByAdapter implements UpdateAdapterInterface
             throw new ElementSavingFailedException(null, sprintf('Invalid sort method "%s"', $value));
         }
 
-        $element->setChildrenSortBy($data[$this->getIndexKey()]);
+        $element->setChildrenSortBy($value);
+        if ($value === AbstractObject::OBJECT_CHILDREN_SORT_BY_INDEX) {
+            $this->indexService->reindexBasedOnSortBy($element, $this->getDefaultSortOrder($data));
+        }
     }
 
     public function getIndexKey(): string
@@ -74,5 +80,18 @@ final readonly class ChildrenSortByAdapter implements UpdateAdapterInterface
         return [
             ElementTypes::TYPE_OBJECT,
         ];
+    }
+
+    private function getDefaultSortOrder(array $data): string
+    {
+        if (!in_array(
+            $data[ChildrenSortOrderAdapter::INDEX_KEY] ?? '',
+            ['ASC', 'DESC'],
+            true
+        )) {
+            return AbstractObject::OBJECT_CHILDREN_SORT_ORDER_DEFAULT;
+        }
+
+        return $data[ChildrenSortOrderAdapter::INDEX_KEY];
     }
 }

--- a/src/Updater/Adapter/ChildrenSortOrderAdapter.php
+++ b/src/Updater/Adapter/ChildrenSortOrderAdapter.php
@@ -28,7 +28,7 @@ use function sprintf;
 #[AutoconfigureTag('pimcore.studio_backend.update_adapter')]
 final readonly class ChildrenSortOrderAdapter implements UpdateAdapterInterface
 {
-    private const INDEX_KEY = 'childrenSortOrder';
+    public const string INDEX_KEY = 'childrenSortOrder';
 
     /**
      * @throws ElementSavingFailedException

--- a/src/Updater/Service/UpdateService.php
+++ b/src/Updater/Service/UpdateService.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataServiceInterface as DataObjectDataService;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Util\Trait\ValidateObjectDataTrait;
 use Pimcore\Bundle\StudioBackendBundle\Document\Service\DataServiceInterface as DocumentDataService;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementIndexServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementSaveServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementExistsException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementSavingFailedException;
@@ -49,6 +50,7 @@ final readonly class UpdateService implements UpdateServiceInterface
         private DocumentDataService $documentDataService,
         private SecurityServiceInterface $securityService,
         private ServiceResolverInterface $serviceResolver,
+        private ElementIndexServiceInterface $indexService,
         private ElementSaveServiceInterface $elementSaveService,
     ) {
     }
@@ -78,6 +80,10 @@ final readonly class UpdateService implements UpdateServiceInterface
 
         try {
             $this->elementSaveService->save($element, $user, $task);
+
+            if (isset($data['index'])) {
+                $this->indexService->indexRelatedElements($element, $data['index']);
+            }
         } catch (DuplicateFullPathException) {
             throw new ElementExistsException(
                 message: sprintf('Element with full path [%s] already exists', $element->getRealFullPath())


### PR DESCRIPTION
## Changes in this pull request
Resolves #1469

## Additional info
Siblings of element need to have index updated when element index was updated same as in the classic UI