### PR TITLE
[Data Object Editor]: Add enrichLayoutDefinition() and ignore childrenByRef for responses

### DIFF
--- a/src/Class/Controller/FieldCollection/LayoutController.php
+++ b/src/Class/Controller/FieldCollection/LayoutController.php
@@ -66,7 +66,7 @@ final class LayoutController extends AbstractApiController
     )]
     #[DefaultResponses([
         HttpResponseCodes::NOT_FOUND,
-        HttpResponseCodes::UNPROCESSABLE_CONTENT
+        HttpResponseCodes::UNPROCESSABLE_CONTENT,
     ])]
     public function getFieldCollectionLayoutForObject(int $objectId): JsonResponse
     {

--- a/src/Class/Controller/FieldCollection/LayoutController.php
+++ b/src/Class/Controller/FieldCollection/LayoutController.php
@@ -18,6 +18,7 @@ use OpenApi\Attributes\Get;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\FieldCollection\LayoutDefinition;
 use Pimcore\Bundle\StudioBackendBundle\Class\Service\FieldCollection\LayoutDefinitionServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\GenericCollection;
@@ -44,7 +45,7 @@ final class LayoutController extends AbstractApiController
     }
 
     /**
-     * @throws Exception|NotFoundException
+     * @throws InvalidElementTypeException|Exception|NotFoundException
      */
     #[Route(
         '/class/field-collection/{objectId}/object/layout',
@@ -65,6 +66,7 @@ final class LayoutController extends AbstractApiController
     )]
     #[DefaultResponses([
         HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::UNPROCESSABLE_CONTENT
     ])]
     public function getFieldCollectionLayoutForObject(int $objectId): JsonResponse
     {

--- a/src/Class/Controller/ObjectBrick/LayoutController.php
+++ b/src/Class/Controller/ObjectBrick/LayoutController.php
@@ -18,6 +18,7 @@ use OpenApi\Attributes\Get;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ObjectBrick\LayoutDefinition;
 use Pimcore\Bundle\StudioBackendBundle\Class\Service\ObjectBrick\LayoutDefinitionServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\GenericCollection;
@@ -44,7 +45,7 @@ final class LayoutController extends AbstractApiController
     }
 
     /**
-     * @throws Exception|NotFoundException
+     * @throws Exception|InvalidElementTypeException|NotFoundException
      */
     #[Route(
         '/class/object-brick/{objectId}/object/layout',
@@ -65,6 +66,7 @@ final class LayoutController extends AbstractApiController
     )]
     #[DefaultResponses([
         HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::UNPROCESSABLE_CONTENT,
     ])]
     public function getObjectBrickLayoutForObject(int $objectId): JsonResponse
     {

--- a/src/Class/Service/FieldCollection/LayoutDefinitionService.php
+++ b/src/Class/Service/FieldCollection/LayoutDefinitionService.php
@@ -27,6 +27,8 @@ use Pimcore\Model\DataObject\ClassDefinition\Data\Fieldcollections;
 use Pimcore\Model\DataObject\ClassDefinitionInterface;
 use Pimcore\Model\DataObject\Concrete;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function get_class;
+use function sprintf;
 
 /**
  * @internal

--- a/src/Class/Service/FieldCollection/LayoutDefinitionService.php
+++ b/src/Class/Service/FieldCollection/LayoutDefinitionService.php
@@ -16,13 +16,16 @@ namespace Pimcore\Bundle\StudioBackendBundle\Class\Service\FieldCollection;
 use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\FieldCollection\DefinitionResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Event\FieldCollection\LayoutDefinitionEvent;
 use Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\FieldCollection\LayoutDefinitionHydratorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\FieldCollection\LayoutDefinition;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Fieldcollections;
 use Pimcore\Model\DataObject\ClassDefinitionInterface;
+use Pimcore\Model\DataObject\Concrete;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -32,6 +35,7 @@ final class LayoutDefinitionService implements LayoutDefinitionServiceInterface
 {
     public function __construct(
         private readonly DataObjectResolverInterface $dataObjectResolver,
+        private readonly DataObjectServiceResolverInterface $dataObjectServiceResolver,
         private readonly ClassDefinitionResolverInterface $classDefinitionResolver,
         private readonly DefinitionResolverInterface $definitionResolver,
         private readonly LayoutDefinitionHydratorInterface $layoutDefinitionHydrator,
@@ -48,8 +52,10 @@ final class LayoutDefinitionService implements LayoutDefinitionServiceInterface
     {
         $dataObject = $this->dataObjectResolver->getById($dataObjectId);
 
-        if (!$dataObject) {
-            throw new NotFoundException('data Object', $dataObjectId);
+        if (!$dataObject instanceof Concrete) {
+            throw new InvalidElementTypeException(
+                sprintf('DataObject class (%s) is not a concrete object', get_class($dataObject))
+            );
         }
 
         $this->collectFieldCollectionTypes(
@@ -58,7 +64,7 @@ final class LayoutDefinitionService implements LayoutDefinitionServiceInterface
 
         $layoutDefinitions = [];
         foreach ($this->fieldCollectionTypes as $fieldCollectionType) {
-            $layoutDefinitions[] = $this->getLayoutDefinitionByType($fieldCollectionType);
+            $layoutDefinitions[] = $this->getLayoutDefinitionByType($fieldCollectionType, $dataObject);
         }
 
         return $layoutDefinitions;
@@ -67,14 +73,15 @@ final class LayoutDefinitionService implements LayoutDefinitionServiceInterface
     /**
      * @throws Exception
      */
-    private function getLayoutDefinitionByType(string $name): LayoutDefinition
+    private function getLayoutDefinitionByType(string $name, Concrete $dataObject): LayoutDefinition
     {
         $definition = $this->definitionResolver->getByKey($name);
 
         if (!$definition) {
             throw new NotFoundException('Field Collection Definition', $name);
         }
-
+        $layoutDefinitions = $definition->getLayoutDefinitions();
+        $this->dataObjectServiceResolver->enrichLayoutDefinition($layoutDefinitions, $dataObject);
         $layoutDefinition = $this->layoutDefinitionHydrator->hydrate($definition);
 
         $this->eventDispatcher->dispatch(

--- a/src/Class/Service/FieldCollection/LayoutDefinitionServiceInterface.php
+++ b/src/Class/Service/FieldCollection/LayoutDefinitionServiceInterface.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Class\Service\FieldCollection;
 
 use Exception;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\FieldCollection\LayoutDefinition;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 
 /**
@@ -23,7 +24,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 interface LayoutDefinitionServiceInterface
 {
     /**
-     * @throws NotFoundException|Exception
+     * @throws InvalidElementTypeException|NotFoundException|Exception
      *
      * @return LayoutDefinition[]
      */

--- a/src/Class/Service/ObjectBrick/LayoutDefinitionService.php
+++ b/src/Class/Service/ObjectBrick/LayoutDefinitionService.php
@@ -16,13 +16,16 @@ namespace Pimcore\Bundle\StudioBackendBundle\Class\Service\ObjectBrick;
 use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectResolverInterface;
-use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\Objectbrick\DefinitionResolverInterface as ObjectBrickDefinitionResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\Objectbrick\DefinitionResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Event\ObjectBrick\LayoutDefinitionEvent;
 use Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\ObjectBrick\LayoutDefinitionHydratorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ObjectBrick\LayoutDefinition;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks;
 use Pimcore\Model\DataObject\ClassDefinitionInterface;
+use Pimcore\Model\DataObject\Concrete;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -32,14 +35,13 @@ final class LayoutDefinitionService implements LayoutDefinitionServiceInterface
 {
     public function __construct(
         private readonly DataObjectResolverInterface $dataObjectResolver,
+        private readonly DataObjectServiceResolverInterface $dataObjectServiceResolver,
         private readonly ClassDefinitionResolverInterface $classDefinitionResolver,
-        private readonly ObjectBrickDefinitionResolverInterface $definitionResolver,
+        private readonly DefinitionResolverInterface $definitionResolver,
         private readonly LayoutDefinitionHydratorInterface $layoutDefinitionHydrator,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
-
-    private array $objectBrickTypes = [];
 
     /**
      * {@inheritdoc}
@@ -47,14 +49,24 @@ final class LayoutDefinitionService implements LayoutDefinitionServiceInterface
     public function getLayoutDefinitionsForObject(int $dataObjectId): array
     {
         $dataObject = $this->dataObjectResolver->getById($dataObjectId);
+        if (!$dataObject instanceof Concrete) {
+            throw new InvalidElementTypeException(
+                sprintf('DataObject class (%s) is not a concrete object', get_class($dataObject))
+            );
+        }
 
         $classDef = $this->classDefinitionResolver->getById($dataObject->getClassId());
+        if (!$classDef instanceof ClassDefinitionInterface) {
+            throw new NotFoundException(type: 'class for data object', id: $dataObjectId);
+        }
 
         $this->collectFieldCollectionTypes($classDef);
 
         $layoutDefinitions = [];
-        foreach ($this->objectBrickTypes as $type) {
-            $layoutDefinitions[] = $this->getLayoutDefinitionByType($type);
+        foreach ($this->collectFieldCollectionTypes($classDef) as $field => $types) {
+            foreach ($types as $type) {
+                $layoutDefinitions[] = $this->getLayoutDefinitionByType($type, $field, $dataObject);
+            }
         }
 
         return $layoutDefinitions;
@@ -64,7 +76,7 @@ final class LayoutDefinitionService implements LayoutDefinitionServiceInterface
     /**
      * @throws Exception
      */
-    private function getLayoutDefinitionByType(string $name): LayoutDefinition
+    private function getLayoutDefinitionByType(string $name, string $field, Concrete $dataObject): LayoutDefinition
     {
         $definition = $this->definitionResolver->getByKey($name);
 
@@ -72,6 +84,16 @@ final class LayoutDefinitionService implements LayoutDefinitionServiceInterface
             throw new NotFoundException('Object Brick Definition', $name);
         }
 
+        $layoutDefinitions = $definition->getLayoutDefinitions();
+        $this->dataObjectServiceResolver->enrichLayoutDefinition(
+            $layoutDefinitions,
+            $dataObject,
+            [
+                'containerType' => 'objectbrick',
+                'containerKey' => $name,
+                'outerFieldname' => $field,
+            ]
+        );
         $layoutDefinition = $this->layoutDefinitionHydrator->hydrate($definition);
 
         $this->eventDispatcher->dispatch(
@@ -82,12 +104,15 @@ final class LayoutDefinitionService implements LayoutDefinitionServiceInterface
         return $layoutDefinition;
     }
 
-    private function collectFieldCollectionTypes(ClassDefinitionInterface $classDefinition): void
+    private function collectFieldCollectionTypes(ClassDefinitionInterface $classDefinition): array
     {
+        $objectBrickTypes = [];
         foreach ($classDefinition->getFieldDefinitions() as $fieldDefinition) {
             if ($fieldDefinition instanceof Objectbricks) {
-                $this->objectBrickTypes = [...$this->objectBrickTypes, ...$fieldDefinition->getAllowedTypes()];
+                $objectBrickTypes[$fieldDefinition->getName()] = $fieldDefinition->getAllowedTypes();
             }
         }
+
+        return $objectBrickTypes;
     }
 }

--- a/src/Class/Service/ObjectBrick/LayoutDefinitionService.php
+++ b/src/Class/Service/ObjectBrick/LayoutDefinitionService.php
@@ -27,6 +27,8 @@ use Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks;
 use Pimcore\Model\DataObject\ClassDefinitionInterface;
 use Pimcore\Model\DataObject\Concrete;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function get_class;
+use function sprintf;
 
 /**
  * @internal

--- a/src/Class/Service/ObjectBrick/LayoutDefinitionServiceInterface.php
+++ b/src/Class/Service/ObjectBrick/LayoutDefinitionServiceInterface.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Class\Service\ObjectBrick;
 
 use Exception;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ObjectBrick\LayoutDefinition;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 
 /**
@@ -23,7 +24,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 interface LayoutDefinitionServiceInterface
 {
     /**
-     * @throws NotFoundException|Exception
+     * @throws InvalidElementTypeException|NotFoundException|Exception
      *
      * @return LayoutDefinition[]
      */

--- a/src/Controller/AbstractApiController.php
+++ b/src/Controller/AbstractApiController.php
@@ -14,16 +14,20 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Controller;
 
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\SerializerContextTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 
 abstract class AbstractApiController extends AbstractController
 {
-    public const VOTER_PUBLIC_STUDIO_API = 'PUBLIC_STUDIO_API';
+    use SerializerContextTrait;
 
-    public const PREFIX = '{prefix}';
+    public const string VOTER_PUBLIC_STUDIO_API = 'PUBLIC_STUDIO_API';
+
+    public const string PREFIX = '{prefix}';
 
     public function __construct(
         protected readonly SerializerInterface $serializer,
@@ -37,18 +41,18 @@ abstract class AbstractApiController extends AbstractController
         array $context = []
     ): JsonResponse {
         return new JsonResponse(
-            $this->serializer->serialize($data, 'json', $context),
+            $this->serializer->serialize($data, 'json', $this->getSerializerContext($context)),
             $status,
             $headers,
             true
         );
     }
 
-    protected function patchResponse(array $errors = [], array $headers = []): Response
+    protected function patchResponse(array $errors = [], array $headers = [], array $context = []): Response
     {
         if (!empty($errors)) {
             return new JsonResponse(
-                $this->serializer->serialize($errors, 'json'),
+                $this->serializer->serialize($errors, 'json', $this->getSerializerContext($context)),
                 HttpResponseCodes::MULTI_STATUS->value,
                 $headers,
                 true

--- a/src/Controller/AbstractApiController.php
+++ b/src/Controller/AbstractApiController.php
@@ -18,7 +18,6 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\SerializerContextTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 
 abstract class AbstractApiController extends AbstractController

--- a/src/DataObject/Controller/LayoutController.php
+++ b/src/DataObject/Controller/LayoutController.php
@@ -83,8 +83,7 @@ final class LayoutController extends AbstractApiController
     ): JsonResponse {
 
         return $this->jsonResponse(
-            data: $this->layoutService->getDataObjectLayout($id, $layoutIdParameter->getLayoutId()),
-            context: [AbstractNormalizer::IGNORED_ATTRIBUTES => ['childrenByRef']]
+            $this->layoutService->getDataObjectLayout($id, $layoutIdParameter->getLayoutId())
         );
     }
 }

--- a/src/DataObject/Controller/LayoutController.php
+++ b/src/DataObject/Controller/LayoutController.php
@@ -34,7 +34,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**

--- a/src/Util/Trait/PaginatedResponseTrait.php
+++ b/src/Util/Trait/PaginatedResponseTrait.php
@@ -22,14 +22,21 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 trait PaginatedResponseTrait
 {
+    use SerializerContextTrait;
+
     private const HEADER_TOTAL_ITEMS = 'X-Pimcore-Total-Items';
 
     protected function getPaginatedCollection(
         SerializerInterface $serializer,
         array $items,
-        int $totalItems = 0
+        int $totalItems = 0,
+        array $context = []
     ): JsonResponse {
-        $serialized = $serializer->serialize(new Collection($totalItems, $items), 'json');
+        $serialized = $serializer->serialize(
+            new Collection($totalItems, $items),
+            'json',
+            $this->getSerializerContext($context)
+        );
 
         return new JsonResponse($serialized, 200, [self::HEADER_TOTAL_ITEMS => $totalItems], true);
     }

--- a/src/Util/Trait/SerializerContextTrait.php
+++ b/src/Util/Trait/SerializerContextTrait.php
@@ -29,8 +29,8 @@ trait SerializerContextTrait
         $ignored = $context[AbstractNormalizer::IGNORED_ATTRIBUTES] ?? [];
         $ignored = is_array($ignored) ? $ignored : [$ignored];
 
-        if (!in_array('childrenByRef', $ignored, true)) {
-            $ignored[] = 'childrenByRef';
+        if (!in_array(self::DEFAULT_IGNORE_ATTRIBUTE, $ignored, true)) {
+            $ignored[] = self::DEFAULT_IGNORE_ATTRIBUTE;
         }
 
         $context[AbstractNormalizer::IGNORED_ATTRIBUTES] = $ignored;

--- a/src/Util/Trait/SerializerContextTrait.php
+++ b/src/Util/Trait/SerializerContextTrait.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Util\Trait;
+
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+
+/**
+ * @internal
+ */
+trait SerializerContextTrait
+{
+    private const string DEFAULT_IGNORE_ATTRIBUTE = 'childrenByRef';
+
+    private function getSerializerContext(array $context = []): array
+    {
+        $ignored = $context[AbstractNormalizer::IGNORED_ATTRIBUTES] ?? [];
+        $ignored = is_array($ignored) ? $ignored : [$ignored];
+
+        if (!in_array('childrenByRef', $ignored, true)) {
+            $ignored[] = 'childrenByRef';
+        }
+
+        $context[AbstractNormalizer::IGNORED_ATTRIBUTES] = $ignored;
+
+        return $context;
+    }
+}

--- a/src/Util/Trait/SerializerContextTrait.php
+++ b/src/Util/Trait/SerializerContextTrait.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Util\Trait;
 
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use function in_array;
+use function is_array;
 
 /**
  * @internal

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -1317,6 +1317,9 @@ pimcore_studio_api_class_custom_layout_import_summary: Import custom layout
 pimcore_studio_api_class_custom_layout_import_success_response: Http status code
 pimcore_studio_api_class_custom_layout_import_layout_id: Id of custom layout
 pimcore_studio_api_classes_folder_collection: Get list of all data object classes in a folder
+ping_action_description: Ping action to check if the API is reachable
+ping_action_summary: Ping action
+ping_action_success_response: API is reachable
 class_definition_folder_collection: Get list of all data object classes in a folder
 class_definition_folder_collection_description: Get list of all data object classes in a folder
 class_definition_folder_collection_summary: Get list of all data object classes in a folder

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -1317,9 +1317,6 @@ pimcore_studio_api_class_custom_layout_import_summary: Import custom layout
 pimcore_studio_api_class_custom_layout_import_success_response: Http status code
 pimcore_studio_api_class_custom_layout_import_layout_id: Id of custom layout
 pimcore_studio_api_classes_folder_collection: Get list of all data object classes in a folder
-ping_action_description: Ping action to check if the API is reachable
-ping_action_summary: Ping action
-ping_action_success_response: API is reachable
 class_definition_folder_collection: Get list of all data object classes in a folder
 class_definition_folder_collection_description: Get list of all data object classes in a folder
 class_definition_folder_collection_summary: Get list of all data object classes in a folder


### PR DESCRIPTION
## Changes in this pull request
Resolves #1457 
Resolves #1436

## Additional info
- Added missing `enrichLayoutDefinition` method for object bricks and field collections
- Ignore `childrenByRef` in all serializer responses by default