### PR TITLE
[Authentication][Token]:  User is not in the session

### DIFF
--- a/src/Security/Authenticator/AdminTokenAuthenticator.php
+++ b/src/Security/Authenticator/AdminTokenAuthenticator.php
@@ -90,10 +90,6 @@ class AdminTokenAuthenticator extends AbstractAuthenticator
             );
         }
 
-        if (session_status() === PHP_SESSION_ACTIVE) {
-            session_write_close();
-        }
-
         return null;
     }
 


### PR DESCRIPTION
## Changes in this pull request
See title

## Additional info
onAuthenticationSuccess() runs before Symfony writes the security token into the session, therefore closing the session here:

- cancels authentication state persistence
- causes user to "lose session after reload"