### PR TITLE
[Classification Store] maintaining a user in the grid leads to an error

### DIFF
--- a/src/DataObject/Data/Adapter/UserAdapter.php
+++ b/src/DataObject/Data/Adapter/UserAdapter.php
@@ -25,6 +25,7 @@ use Pimcore\Normalizer\NormalizerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use function array_key_exists;
 use function is_int;
+use function is_string;
 
 /**
  * @internal

--- a/src/DataObject/Data/Adapter/UserAdapter.php
+++ b/src/DataObject/Data/Adapter/UserAdapter.php
@@ -40,16 +40,21 @@ final readonly class UserAdapter implements SetterDataInterface, DataNormalizerI
         UserInterface $user,
         ?FieldContextData $contextData = null,
         bool $isPatch = false
-    ): ?int {
-
-        if (!array_key_exists($key, $data) ||
-            !$fieldDefinition instanceof NormalizerInterface ||
-            !is_int($data[$key])
+    ): ?string {
+        if (
+            !$fieldDefinition instanceof NormalizerInterface
+            || !array_key_exists($key, $data)
         ) {
             return null;
         }
 
-        return $data[$key];
+        $value = $data[$key];
+
+        if (!is_int($value) && !is_string($value)) {
+            return null;
+        }
+
+        return (string) $value;
     }
 
     public function normalize(mixed $value, Data $fieldDefinition): ?int

--- a/src/Grid/Column/Collector/DataObject/ObjectBrickCollector.php
+++ b/src/Grid/Column/Collector/DataObject/ObjectBrickCollector.php
@@ -199,7 +199,7 @@ final class ObjectBrickCollector implements
     {
         foreach ($layout->getChildren() as $child) {
             if ($child instanceof Layout) {
-                $found = $this->getBaseLayoutName($fieldname, $child, $child->getTitle());
+                $found = $this->getBaseLayoutName($fieldname, $child, $child->getTitle() ?: $child->getName());
 
                 if ($found !== null) {
                     return $found;


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-backend-bundle/issues/1504
Resolves https://github.com/pimcore/studio-backend-bundle/issues/1511

## Additional info
- If title of parent layout for object brick is empty fallback to the name
- User is set in the core with ID as a string. As we have our custom adapter, this was not causing issue for user field itself but when having user field within classification store, we have to stick to a string for now

More info about issue see here: https://github.com/pimcore/pimcore/issues/18851