### PR TITLE
[Class Definitions][Config Detail]: Add endpoints for field deifinitions part 2

### DIFF
--- a/config/class.yaml
+++ b/config/class.yaml
@@ -14,6 +14,9 @@ services:
   #
   # Services
   #
+  Pimcore\Bundle\StudioBackendBundle\Class\Service\FieldCollection\FieldCollectionServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Class\Service\FieldCollection\FieldCollectionService
+
   Pimcore\Bundle\StudioBackendBundle\Class\Service\FieldCollection\LayoutDefinitionServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Class\Service\FieldCollection\LayoutDefinitionService
 
@@ -22,6 +25,9 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\Class\Service\ClassDefinitionServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Class\Service\ClassDefinitionService
+
+  Pimcore\Bundle\StudioBackendBundle\Class\Service\ClassServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Class\Service\ClassService
 
   Pimcore\Bundle\StudioBackendBundle\Class\Service\IdentifierServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Class\Service\IdentifierService
@@ -42,6 +48,9 @@ services:
   # Repositories
   #
 
+  Pimcore\Bundle\StudioBackendBundle\Class\Repository\FieldCollectionRepositoryInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Class\Repository\FieldCollectionRepository
+
   Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepository
 
@@ -51,6 +60,12 @@ services:
   #
   # Hydrators
   #
+  Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\AvailableVisibleFieldHydratorInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\AvailableVisibleFieldHydrator
+
+  Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\FieldCollectionConfigHydratorInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\FieldCollectionConfigHydrator
+
   Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\FieldCollection\LayoutDefinitionHydratorInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\FieldCollection\LayoutDefinitionHydrator
 

--- a/config/classification_store.yaml
+++ b/config/classification_store.yaml
@@ -31,6 +31,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Service\SearchHelperServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Service\SearchHelperService
 
+  Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Service\StoreServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Service\StoreService
+
 
   #
   # Repositories
@@ -48,6 +51,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository\KeyGroupRelationRepositoryInterface:
     class: Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository\KeyGroupRelationRepository
 
+  Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository\StoreRepositoryInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository\StoreRepository
+
 
   #
   # Hydrators
@@ -64,3 +70,6 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Hydrator\GroupLayoutHydratorInterface:
     class: Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Hydrator\GroupLayoutHydrator
+
+  Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Hydrator\StoreConfigHydratorInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Hydrator\StoreConfigHydrator

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -35,6 +35,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Setting\Hydrator\ActiveBundleHydratorInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Setting\Hydrator\ActiveBundleHydrator
 
+  Pimcore\Bundle\StudioBackendBundle\Setting\Hydrator\CountryHydratorInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Setting\Hydrator\CountryHydrator
+
   #
   # Providers
   #

--- a/doc/05_Additional_Custom_Attributes.md
+++ b/doc/05_Additional_Custom_Attributes.md
@@ -82,12 +82,14 @@ final class AssetEvent extends AbstractPreResponseEvent
 - `pre_response.bundle_seo.redirect.list`
 - `pre_response.bundle_seo.redirect.status`
 - `pre_response.class_definition`
+- `pre_response.class_definition.visible_field`
 - `pre_response.class_definition.collection`
 - `pre_response.class_definition.folder.collection`
 - `pre_response.class_definition.identifier_data`
 - `pre_response.class_definition.object_brick_data`
 - `pre_response.class_definition.tree`
 - `pre_response.classification_store.collection`
+- `pre_response.classification_store.config_collection`
 - `pre_response.classification_store.group`
 - `pre_response.classification_store.group_layout`
 - `pre_response.classification_store.key_group_relation`
@@ -127,6 +129,7 @@ final class AssetEvent extends AbstractPreResponseEvent
 - `pre_response.element_property`
 - `pre_response.element_subtype`
 - `pre_response.execution_engine.list_running_job_runs`
+- `pre_response.field_collection.config`
 - `pre_response.field_collection.layout_definition`
 - `pre_response.grid_column_configuration`
 - `pre_response.grid_column_data`
@@ -149,6 +152,7 @@ final class AssetEvent extends AbstractPreResponseEvent
 - `pre_response.schedule`
 - `pre_response.select_option.tree`
 - `pre_response.settings.active_bundle`
+- `pre_response.settings.available_country`
 - `pre_response.simple_search.preview`
 - `pre_response.simple_search.result`
 - `pre_response.simple_user`

--- a/src/Class/Controller/AvailableVisibleFieldsController.php
+++ b/src/Class/Controller/AvailableVisibleFieldsController.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Controller;
+
+use OpenApi\Attributes\Get;
+use Pimcore\Bundle\StudioBackendBundle\Class\MappedParameter\AvailableVisibleFieldsParameters;
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\AvailableVisibleField;
+use Pimcore\Bundle\StudioBackendBundle\Class\Service\ClassServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\ClassNamesParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\GenericCollection;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\CollectionJson;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\PaginatedResponseTrait;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapQueryString;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+use function count;
+
+/**
+ * @internal
+ */
+final class AvailableVisibleFieldsController extends AbstractApiController
+{
+    use PaginatedResponseTrait;
+
+    private const string ROUTE = '/class/definition/available-visible-fields';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly ClassServiceInterface $classService
+    ) {
+        parent::__construct($serializer);
+    }
+
+    /**
+     * @throws NotFoundException
+     */
+    #[Route(
+        self::ROUTE,
+        name: 'pimcore_studio_api_class_available_visible_fields',
+        methods: ['GET']
+    )]
+    #[IsGranted(UserPermissions::CLASS_DEFINITION->value)]
+    #[Get(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'class_get_available_visible_fields',
+        description: 'class_get_available_visible_fields_description',
+        summary: 'class_get_available_visible_fields_summary',
+        tags: [Tags::ClassDefinition->value],
+    )]
+    #[ClassNamesParameter]
+    #[SuccessResponse(
+        description: 'class_get_available_visible_fields_success_response',
+        content: new CollectionJson(new GenericCollection(AvailableVisibleField::class))
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::NOT_FOUND,
+    ])]
+    public function getAvailableVisibleFields(
+        #[MapQueryString] AvailableVisibleFieldsParameters $parameters
+    ): JsonResponse {
+        $availableFields = $this->classService->getAvailableVisibleFields($parameters);
+
+        return $this->getPaginatedCollection(
+            $this->serializer,
+            $availableFields,
+            count($availableFields)
+        );
+    }
+}
+

--- a/src/Class/Controller/AvailableVisibleFieldsController.php
+++ b/src/Class/Controller/AvailableVisibleFieldsController.php
@@ -88,4 +88,3 @@ final class AvailableVisibleFieldsController extends AbstractApiController
         );
     }
 }
-

--- a/src/Class/Controller/DefinitionConfiguration/SelectedVisibleFieldsController.php
+++ b/src/Class/Controller/DefinitionConfiguration/SelectedVisibleFieldsController.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Controller\DefinitionConfiguration;
+
+use OpenApi\Attributes\Get;
+use OpenApi\Attributes\Items;
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Property;
+use Pimcore\Bundle\StudioBackendBundle\Class\MappedParameter\RelationParameter;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnConfigurationForRelationServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\StringParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\StringParameter as QueryStringParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapQueryString;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class SelectedVisibleFieldsController extends AbstractApiController
+{
+    private const string ROUTE = '/class/definition/configuration-view/detail/{id}/selected-visible-fields';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly ColumnConfigurationForRelationServiceInterface $columnConfigurationService,
+        private readonly SecurityServiceInterface $securityService,
+    ) {
+        parent::__construct($serializer);
+    }
+
+    /**
+     * @throws NotFoundException|SearchException
+     */
+    #[Route(
+        self::ROUTE,
+        name: 'pimcore_studio_api_class_relation_selected_visible_fields',
+        methods: ['GET']
+    )]
+    #[IsGranted(UserPermissions::CLASS_DEFINITION->value)]
+    #[Get(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'class_get_selected_visible_fields',
+        description: 'class_get_selected_visible_fields_description',
+        summary: 'class_get_selected_visible_fields_summary',
+        tags: [Tags::ClassDefinition->value]
+    )]
+    #[StringParameter(
+        name: 'id',
+        example: 'CAR',
+        description: 'Class definition unique identifier',
+        required: true
+    )]
+    #[QueryStringParameter(
+        name: 'relationField',
+        example: 'myRelationField',
+        description: 'Relation field name for which the selected fields should be retrieved.',
+        required: false,
+    )]
+    #[SuccessResponse(
+        description: 'class_get_selected_visible_fields_success_response',
+        content: new JsonContent(
+            properties: [
+                new Property(
+                    property: 'columns',
+                    type: 'array',
+                    items: new Items(ref: ColumnConfiguration::class),
+                )],
+        )
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::INTERNAL_SERVER_ERROR,
+        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::NOT_FOUND,
+    ])]
+    public function getSelectedVisibleFields(
+        string $id,
+        #[MapQueryString] RelationParameter $parameter
+    ): JsonResponse {
+        $columns = $this->columnConfigurationService->getAvailableDataObjectColumnConfigurationForRelation(
+            $id,
+            $parameter->getRelationField(),
+            $this->securityService->getCurrentUser()
+        );
+
+        return $this->jsonResponse([
+            'columns' => $columns,
+        ]);
+    }
+}

--- a/src/Class/Controller/FieldCollection/CollectionController.php
+++ b/src/Class/Controller/FieldCollection/CollectionController.php
@@ -77,4 +77,3 @@ final class CollectionController extends AbstractApiController
         );
     }
 }
-

--- a/src/Class/Controller/FieldCollection/CollectionController.php
+++ b/src/Class/Controller/FieldCollection/CollectionController.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Controller\FieldCollection;
+
+use OpenApi\Attributes\Get;
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\FieldCollection\FieldCollectionConfig;
+use Pimcore\Bundle\StudioBackendBundle\Class\Service\FieldCollection\FieldCollectionServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\GenericCollection;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\CollectionJson;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\PaginatedResponseTrait;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class CollectionController extends AbstractApiController
+{
+    use PaginatedResponseTrait;
+
+    private const string ROUTE = '/class/field-collection/collection';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly FieldCollectionServiceInterface $fieldCollectionService
+    ) {
+        parent::__construct($serializer);
+    }
+
+    #[Route(
+        self::ROUTE,
+        name: 'pimcore_studio_api_class_field_collection_collection',
+        methods: ['GET']
+    )]
+    #[IsGranted(UserPermissions::CLASS_DEFINITION->value)]
+    #[Get(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'class_field_collection_collection',
+        description: 'class_field_collection_collection_description',
+        summary: 'class_field_collection_collection_summary',
+        tags: [Tags::ClassDefinition->value],
+    )]
+    #[SuccessResponse(
+        description: 'class_field_collection_collection_success_response',
+        content: new CollectionJson(new GenericCollection(FieldCollectionConfig::class))
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+    ])]
+    public function getFieldCollectionCollection(): JsonResponse
+    {
+        $collection = $this->fieldCollectionService->listFieldCollections();
+
+        return $this->getPaginatedCollection(
+            $this->serializer,
+            $collection->getItems(),
+            $collection->getTotalItems()
+        );
+    }
+}
+

--- a/src/Class/Event/AvailableVisibleFieldEvent.php
+++ b/src/Class/Event/AvailableVisibleFieldEvent.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Event;
+
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\AvailableVisibleField;
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+
+final class AvailableVisibleFieldEvent extends AbstractPreResponseEvent
+{
+    public const string EVENT_NAME = 'pre_response.class_definition.visible_field';
+
+    public function __construct(
+        private readonly AvailableVisibleField $availableVisibleField
+    ) {
+        parent::__construct($availableVisibleField);
+    }
+
+    /**
+     * Use this to get additional info out of the response object
+     */
+    public function getAvailableVisibleField(): AvailableVisibleField
+    {
+        return $this->availableVisibleField;
+    }
+}
+

--- a/src/Class/Event/AvailableVisibleFieldEvent.php
+++ b/src/Class/Event/AvailableVisibleFieldEvent.php
@@ -34,4 +34,3 @@ final class AvailableVisibleFieldEvent extends AbstractPreResponseEvent
         return $this->availableVisibleField;
     }
 }
-

--- a/src/Class/Event/FieldCollection/ConfigEvent.php
+++ b/src/Class/Event/FieldCollection/ConfigEvent.php
@@ -34,4 +34,3 @@ final class ConfigEvent extends AbstractPreResponseEvent
         return $this->fieldCollectionConfig;
     }
 }
-

--- a/src/Class/Event/FieldCollection/ConfigEvent.php
+++ b/src/Class/Event/FieldCollection/ConfigEvent.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Event\FieldCollection;
+
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\FieldCollection\FieldCollectionConfig;
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+
+final class ConfigEvent extends AbstractPreResponseEvent
+{
+    public const string EVENT_NAME = 'pre_response.field_collection.config';
+
+    public function __construct(
+        private readonly FieldCollectionConfig $fieldCollectionConfig
+    ) {
+        parent::__construct($fieldCollectionConfig);
+    }
+
+    /**
+     * Use this to get additional info out of the response object
+     */
+    public function getFieldCollectionConfig(): FieldCollectionConfig
+    {
+        return $this->fieldCollectionConfig;
+    }
+}
+

--- a/src/Class/Hydrator/AvailableVisibleFieldHydrator.php
+++ b/src/Class/Hydrator/AvailableVisibleFieldHydrator.php
@@ -25,4 +25,3 @@ final readonly class AvailableVisibleFieldHydrator implements AvailableVisibleFi
         return new AvailableVisibleField($fieldKey);
     }
 }
-

--- a/src/Class/Hydrator/AvailableVisibleFieldHydrator.php
+++ b/src/Class/Hydrator/AvailableVisibleFieldHydrator.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\AvailableVisibleField;
+
+/**
+ * @internal
+ */
+final readonly class AvailableVisibleFieldHydrator implements AvailableVisibleFieldHydratorInterface
+{
+    public function hydrate(string $fieldKey): AvailableVisibleField
+    {
+        return new AvailableVisibleField($fieldKey);
+    }
+}
+

--- a/src/Class/Hydrator/AvailableVisibleFieldHydratorInterface.php
+++ b/src/Class/Hydrator/AvailableVisibleFieldHydratorInterface.php
@@ -22,4 +22,3 @@ interface AvailableVisibleFieldHydratorInterface
 {
     public function hydrate(string $fieldKey): AvailableVisibleField;
 }
-

--- a/src/Class/Hydrator/AvailableVisibleFieldHydratorInterface.php
+++ b/src/Class/Hydrator/AvailableVisibleFieldHydratorInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\AvailableVisibleField;
+
+/**
+ * @internal
+ */
+interface AvailableVisibleFieldHydratorInterface
+{
+    public function hydrate(string $fieldKey): AvailableVisibleField;
+}
+

--- a/src/Class/Hydrator/FieldCollectionConfigHydrator.php
+++ b/src/Class/Hydrator/FieldCollectionConfigHydrator.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\FieldCollection\FieldCollectionConfig;
+use Pimcore\Model\DataObject\Fieldcollection\Definition;
+
+/**
+ * @internal
+ */
+final readonly class FieldCollectionConfigHydrator implements FieldCollectionConfigHydratorInterface
+{
+    public function hydrate(Definition $definition): FieldCollectionConfig
+    {
+        return new FieldCollectionConfig(
+            $definition->getKey(),
+            $definition->getTitle()
+        );
+    }
+}
+

--- a/src/Class/Hydrator/FieldCollectionConfigHydrator.php
+++ b/src/Class/Hydrator/FieldCollectionConfigHydrator.php
@@ -29,4 +29,3 @@ final readonly class FieldCollectionConfigHydrator implements FieldCollectionCon
         );
     }
 }
-

--- a/src/Class/Hydrator/FieldCollectionConfigHydratorInterface.php
+++ b/src/Class/Hydrator/FieldCollectionConfigHydratorInterface.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\FieldCollection\FieldCollectionConfig;
+use Pimcore\Model\DataObject\Fieldcollection\Definition;
+
+/**
+ * @internal
+ */
+interface FieldCollectionConfigHydratorInterface
+{
+    public function hydrate(Definition $definition): FieldCollectionConfig;
+}
+

--- a/src/Class/Hydrator/FieldCollectionConfigHydratorInterface.php
+++ b/src/Class/Hydrator/FieldCollectionConfigHydratorInterface.php
@@ -23,4 +23,3 @@ interface FieldCollectionConfigHydratorInterface
 {
     public function hydrate(Definition $definition): FieldCollectionConfig;
 }
-

--- a/src/Class/MappedParameter/AvailableVisibleFieldsParameters.php
+++ b/src/Class/MappedParameter/AvailableVisibleFieldsParameters.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\MappedParameter;
+
+/**
+ * @internal
+ */
+final readonly class AvailableVisibleFieldsParameters
+{
+    public function __construct(
+        private string $classNames = ''
+    ) {
+    }
+
+    public function getClassNames(): string
+    {
+        return $this->classNames;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getClassNamesArray(): array
+    {
+        if (empty($this->classNames)) {
+            return [];
+        }
+
+        return array_filter(
+            array_map('trim', explode(',', $this->classNames)),
+            static fn(string $className): bool => !empty($className)
+        );
+    }
+}
+

--- a/src/Class/MappedParameter/AvailableVisibleFieldsParameters.php
+++ b/src/Class/MappedParameter/AvailableVisibleFieldsParameters.php
@@ -39,8 +39,7 @@ final readonly class AvailableVisibleFieldsParameters
 
         return array_filter(
             array_map('trim', explode(',', $this->classNames)),
-            static fn(string $className): bool => !empty($className)
+            static fn (string $className): bool => !empty($className)
         );
     }
 }
-

--- a/src/Class/MappedParameter/RelationParameter.php
+++ b/src/Class/MappedParameter/RelationParameter.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\MappedParameter;
+
+/**
+ * @internal
+ */
+final readonly class RelationParameter
+{
+    public function __construct(
+        private string $relationField
+    ) {
+
+    }
+
+    public function getRelationField(): string
+    {
+        return $this->relationField;
+    }
+}

--- a/src/Class/Repository/FieldCollectionRepository.php
+++ b/src/Class/Repository/FieldCollectionRepository.php
@@ -25,4 +25,3 @@ final readonly class FieldCollectionRepository implements FieldCollectionReposit
         return (new Definition\Listing())->load();
     }
 }
-

--- a/src/Class/Repository/FieldCollectionRepository.php
+++ b/src/Class/Repository/FieldCollectionRepository.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Repository;
+
+use Pimcore\Model\DataObject\Fieldcollection\Definition;
+
+/**
+ * @internal
+ */
+final readonly class FieldCollectionRepository implements FieldCollectionRepositoryInterface
+{
+    public function listFieldCollections(): array
+    {
+        return (new Definition\Listing())->load();
+    }
+}
+

--- a/src/Class/Repository/FieldCollectionRepositoryInterface.php
+++ b/src/Class/Repository/FieldCollectionRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Repository;
+
+use Pimcore\Model\DataObject\Fieldcollection\Definition;
+
+/**
+ * @internal
+ */
+interface FieldCollectionRepositoryInterface
+{
+    /**
+     * @return Definition[]
+     */
+    public function listFieldCollections(): array;
+}
+

--- a/src/Class/Repository/FieldCollectionRepositoryInterface.php
+++ b/src/Class/Repository/FieldCollectionRepositoryInterface.php
@@ -25,4 +25,3 @@ interface FieldCollectionRepositoryInterface
      */
     public function listFieldCollections(): array;
 }
-

--- a/src/Class/Schema/AvailableVisibleField.php
+++ b/src/Class/Schema/AvailableVisibleField.php
@@ -39,4 +39,3 @@ final class AvailableVisibleField implements AdditionalAttributesInterface
         return $this->key;
     }
 }
-

--- a/src/Class/Schema/AvailableVisibleField.php
+++ b/src/Class/Schema/AvailableVisibleField.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+#[Schema(
+    schema: 'AvailableVisibleField',
+    title: 'Class definition Visible Field',
+    required: ['key'],
+    type: 'object'
+)]
+final class AvailableVisibleField implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(description: 'Field key', type: 'string', example: 'id')]
+        private readonly string $key
+    ) {
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+}
+

--- a/src/Class/Schema/FieldCollection/FieldCollectionConfig.php
+++ b/src/Class/Schema/FieldCollection/FieldCollectionConfig.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Schema\FieldCollection;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+#[Schema(
+    schema: 'FieldCollectionConfig',
+    title: 'Field Collection Configuration',
+    required: [
+        'key',
+        'title',
+    ],
+    type: 'object'
+)]
+final class FieldCollectionConfig implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(description: 'Key', type: 'string', example: 'MyFieldCollection')]
+        private readonly string $key,
+        #[Property(description: 'Title', type: 'string', example: 'My Field Collection')]
+        private readonly string $title,
+    ) {
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}
+

--- a/src/Class/Schema/FieldCollection/FieldCollectionConfig.php
+++ b/src/Class/Schema/FieldCollection/FieldCollectionConfig.php
@@ -49,4 +49,3 @@ final class FieldCollectionConfig implements AdditionalAttributesInterface
         return $this->title;
     }
 }
-

--- a/src/Class/Service/ClassService.php
+++ b/src/Class/Service/ClassService.php
@@ -1,0 +1,181 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Class\Event\AvailableVisibleFieldEvent;
+use Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\AvailableVisibleFieldHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\Class\MappedParameter\AvailableVisibleFieldsParameters;
+use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\AvailableVisibleField;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Block;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Fieldcollections;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+final readonly class ClassService implements ClassServiceInterface
+{
+    private const array SYSTEM_COLUMNS = [
+        'id',
+        'fullpath',
+        'key',
+        'published',
+        'creationDate',
+        'modificationDate',
+        'filename',
+        'classname',
+    ];
+
+    public function __construct(
+        private AvailableVisibleFieldHydratorInterface $availableVisibleFieldHydrator,
+        private ClassDefinitionRepositoryInterface $classDefinitionRepository,
+        private EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAvailableVisibleFields(AvailableVisibleFieldsParameters $parameters): array
+    {
+        $classNames = $parameters->getClassNamesArray();
+
+        if (empty($classNames)) {
+            return [];
+        }
+
+        $availableFields = $this->buildSystemFields();
+        $commonFields = $this->getCommonFieldDefinitions($classNames);
+
+        foreach (array_keys($commonFields) as $fieldKey) {
+            $availableFields[] = $this->hydrateAvailableField($fieldKey);
+        }
+
+        return $availableFields;
+    }
+
+    /**
+     * @return AvailableVisibleField[]
+     */
+    private function buildSystemFields(): array
+    {
+        return array_map(
+            function (string $fieldKey): AvailableVisibleField {
+                return $this->hydrateAvailableField($fieldKey);
+            },
+            self::SYSTEM_COLUMNS
+        );
+    }
+
+    /**
+     * @throws NotFoundException
+     */
+    private function getCommonFieldDefinitions(array $classNames): array
+    {
+        $commonFields = [];
+        $firstIteration = true;
+
+        foreach ($classNames as $className) {
+            $class = $this->classDefinitionRepository->getClassDefinition($className);
+
+            $fieldDefinitions = $class->getFieldDefinitions();
+            $allFieldNames = $this->collectAllFieldNames($class, $fieldDefinitions);
+
+            if (!$firstIteration) {
+                $commonFields = $this->filterCommonFields($commonFields, $allFieldNames);
+            }
+
+            $commonFields = $this->processAvailableFieldDefinitions(
+                $fieldDefinitions,
+                $firstIteration,
+                $commonFields
+            );
+
+            $firstIteration = false;
+        }
+
+        return $commonFields;
+    }
+
+    private function processAvailableFieldDefinitions(
+        array $fieldDefinitions,
+        bool $firstIteration,
+        array $commonFields
+    ): array {
+        foreach ($fieldDefinitions as $fieldDefinition) {
+
+            if ($fieldDefinition instanceof Fieldcollections
+                || $fieldDefinition instanceof Objectbricks
+                || $fieldDefinition instanceof Block
+            ) {
+                continue;
+            }
+
+            // Recursively process localized fields
+            if ($fieldDefinition instanceof Localizedfields) {
+                $localizedFieldDefinitions = $fieldDefinition->getFieldDefinitions();
+                $commonFields = $this->processAvailableFieldDefinitions(
+                    $localizedFieldDefinitions,
+                    $firstIteration,
+                    $commonFields
+                );
+                continue;
+            }
+
+            $fieldName = $fieldDefinition->getName();
+            if (
+                $firstIteration ||
+                (
+                    isset($commonFields[$fieldName]) &&
+                    $commonFields[$fieldName]->getFieldtype() === $fieldDefinition->getFieldtype()
+                )
+            ) {
+                $commonFields[$fieldName] = $fieldDefinition;
+            }
+        }
+
+        return $commonFields;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function collectAllFieldNames(ClassDefinition $class, array $fieldDefinitions): array
+    {
+        $fieldNames = array_keys($fieldDefinitions);
+
+        $localizedFields = $class->getFieldDefinition('localizedfields');
+        if ($localizedFields instanceof Localizedfields) {
+            $localizedFieldNames = array_keys($localizedFields->getFieldDefinitions());
+            $fieldNames = array_merge($fieldNames, $localizedFieldNames);
+        }
+
+        return $fieldNames;
+    }
+
+    private function filterCommonFields(array $commonFields, array $currentFieldNames): array
+    {
+        return array_filter(
+            $commonFields,
+            static fn(string $fieldKey): bool => in_array($fieldKey, $currentFieldNames, true),
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    private function hydrateAvailableField(string $fieldKey): AvailableVisibleField
+    {
+        $field = $this->availableVisibleFieldHydrator->hydrate($fieldKey);
+        $this->eventDispatcher->dispatch(
+            new AvailableVisibleFieldEvent($field),
+            AvailableVisibleFieldEvent::EVENT_NAME
+        );
+
+        return $field;
+    }
+}

--- a/src/Class/Service/ClassService.php
+++ b/src/Class/Service/ClassService.php
@@ -1,6 +1,16 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
 namespace Pimcore\Bundle\StudioBackendBundle\Class\Service;
 
 use Pimcore\Bundle\StudioBackendBundle\Class\Event\AvailableVisibleFieldEvent;
@@ -15,6 +25,7 @@ use Pimcore\Model\DataObject\ClassDefinition\Data\Fieldcollections;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function in_array;
 
 /**
  * @internal
@@ -125,6 +136,7 @@ final readonly class ClassService implements ClassServiceInterface
                     $firstIteration,
                     $commonFields
                 );
+
                 continue;
             }
 
@@ -163,7 +175,7 @@ final readonly class ClassService implements ClassServiceInterface
     {
         return array_filter(
             $commonFields,
-            static fn(string $fieldKey): bool => in_array($fieldKey, $currentFieldNames, true),
+            static fn (string $fieldKey): bool => in_array($fieldKey, $currentFieldNames, true),
             ARRAY_FILTER_USE_KEY
         );
     }

--- a/src/Class/Service/ClassServiceInterface.php
+++ b/src/Class/Service/ClassServiceInterface.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Class\MappedParameter\AvailableVisibleFieldsParameters;
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\AvailableVisibleField;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+
+/**
+ * @internal
+ */
+interface ClassServiceInterface
+{
+    /**
+     * @throws NotFoundException
+     *
+     * @return AvailableVisibleField[]
+     */
+    public function getAvailableVisibleFields(AvailableVisibleFieldsParameters $parameters): array;
+}

--- a/src/Class/Service/FieldCollection/FieldCollectionService.php
+++ b/src/Class/Service/FieldCollection/FieldCollectionService.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Service\FieldCollection;
+
+use Pimcore\Bundle\StudioBackendBundle\Class\Event\FieldCollection\ConfigEvent;
+use Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\FieldCollectionConfigHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\Class\Repository\FieldCollectionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function count;
+
+/**
+ * @internal
+ */
+final readonly class FieldCollectionService implements FieldCollectionServiceInterface
+{
+    public function __construct(
+        private FieldCollectionRepositoryInterface $fieldCollectionRepository,
+        private FieldCollectionConfigHydratorInterface $fieldCollectionConfigHydrator,
+        private EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function listFieldCollections(): Collection
+    {
+        $definitions = $this->fieldCollectionRepository->listFieldCollections();
+        $fieldCollections = [];
+
+        foreach ($definitions as $definition) {
+            $fieldCollection = $this->fieldCollectionConfigHydrator->hydrate($definition);
+            $this->eventDispatcher->dispatch(new ConfigEvent($fieldCollection), ConfigEvent::EVENT_NAME);
+            $fieldCollections[] = $fieldCollection;
+        }
+
+        return new Collection(count($fieldCollections), $fieldCollections);
+    }
+}
+

--- a/src/Class/Service/FieldCollection/FieldCollectionService.php
+++ b/src/Class/Service/FieldCollection/FieldCollectionService.php
@@ -46,4 +46,3 @@ final readonly class FieldCollectionService implements FieldCollectionServiceInt
         return new Collection(count($fieldCollections), $fieldCollections);
     }
 }
-

--- a/src/Class/Service/FieldCollection/FieldCollectionServiceInterface.php
+++ b/src/Class/Service/FieldCollection/FieldCollectionServiceInterface.php
@@ -22,4 +22,3 @@ interface FieldCollectionServiceInterface
 {
     public function listFieldCollections(): Collection;
 }
-

--- a/src/Class/Service/FieldCollection/FieldCollectionServiceInterface.php
+++ b/src/Class/Service/FieldCollection/FieldCollectionServiceInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Service\FieldCollection;
+
+use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
+
+/**
+ * @internal
+ */
+interface FieldCollectionServiceInterface
+{
+    public function listFieldCollections(): Collection;
+}
+

--- a/src/ClassificationStore/Controller/StoreCollectionController.php
+++ b/src/ClassificationStore/Controller/StoreCollectionController.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Controller;
+
+use OpenApi\Attributes\Get;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema\StoreConfig;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Service\StoreServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\GenericCollection;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\CollectionJson;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\PaginatedResponseTrait;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class StoreCollectionController extends AbstractApiController
+{
+    use PaginatedResponseTrait;
+
+    private const string ROUTE = '/classification-store/config/collection';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly StoreServiceInterface $storeService
+    ) {
+        parent::__construct($serializer);
+    }
+
+    #[Route(
+        self::ROUTE,
+        name: 'pimcore_studio_api_classification_store_get_config_collection',
+        methods: ['GET']
+    )]
+    #[Get(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'classification_store_get_config_collection',
+        description: 'classification_store_get_config_collection_description',
+        summary: 'classification_store_get_config_collection_summary',
+        tags: [Tags::ClassificationStore->value],
+    )]
+    #[SuccessResponse(
+        description: 'classification_store_get_config_collection_success_response',
+        content: new CollectionJson(new GenericCollection(StoreConfig::class))
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+    ])]
+    public function getStoreCollection(): JsonResponse
+    {
+        $collection = $this->storeService->listStores();
+
+        return $this->getPaginatedCollection(
+            $this->serializer,
+            $collection->getItems(),
+            $collection->getTotalItems()
+        );
+    }
+}
+

--- a/src/ClassificationStore/Controller/StoreCollectionController.php
+++ b/src/ClassificationStore/Controller/StoreCollectionController.php
@@ -74,4 +74,3 @@ final class StoreCollectionController extends AbstractApiController
         );
     }
 }
-

--- a/src/ClassificationStore/Event/StoreConfigEvent.php
+++ b/src/ClassificationStore/Event/StoreConfigEvent.php
@@ -34,4 +34,3 @@ final class StoreConfigEvent extends AbstractPreResponseEvent
         return $this->storeConfig;
     }
 }
-

--- a/src/ClassificationStore/Event/StoreConfigEvent.php
+++ b/src/ClassificationStore/Event/StoreConfigEvent.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Event;
+
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema\StoreConfig;
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+
+final class StoreConfigEvent extends AbstractPreResponseEvent
+{
+    public const string EVENT_NAME = 'pre_response.classification_store.config_collection';
+
+    public function __construct(
+        private readonly StoreConfig $storeConfig
+    ) {
+        parent::__construct($storeConfig);
+    }
+
+    /**
+     * Use this to get additional info out of the response object
+     */
+    public function getStoreConfig(): StoreConfig
+    {
+        return $this->storeConfig;
+    }
+}
+

--- a/src/ClassificationStore/Hydrator/StoreConfigHydrator.php
+++ b/src/ClassificationStore/Hydrator/StoreConfigHydrator.php
@@ -26,4 +26,3 @@ final readonly class StoreConfigHydrator implements StoreConfigHydratorInterface
         return new StoreConfig($storeConfig->getId(), $storeConfig->getName());
     }
 }
-

--- a/src/ClassificationStore/Hydrator/StoreConfigHydrator.php
+++ b/src/ClassificationStore/Hydrator/StoreConfigHydrator.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema\StoreConfig;
+use Pimcore\Model\DataObject\Classificationstore\StoreConfig as PimcoreStoreConfig;
+
+/**
+ * @internal
+ */
+final readonly class StoreConfigHydrator implements StoreConfigHydratorInterface
+{
+    public function hydrate(PimcoreStoreConfig $storeConfig): StoreConfig
+    {
+        return new StoreConfig($storeConfig->getId(), $storeConfig->getName());
+    }
+}
+

--- a/src/ClassificationStore/Hydrator/StoreConfigHydratorInterface.php
+++ b/src/ClassificationStore/Hydrator/StoreConfigHydratorInterface.php
@@ -23,4 +23,3 @@ interface StoreConfigHydratorInterface
 {
     public function hydrate(PimcoreStoreConfig $storeConfig): StoreConfig;
 }
-

--- a/src/ClassificationStore/Hydrator/StoreConfigHydratorInterface.php
+++ b/src/ClassificationStore/Hydrator/StoreConfigHydratorInterface.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema\StoreConfig;
+use Pimcore\Model\DataObject\Classificationstore\StoreConfig as PimcoreStoreConfig;
+
+/**
+ * @internal
+ */
+interface StoreConfigHydratorInterface
+{
+    public function hydrate(PimcoreStoreConfig $storeConfig): StoreConfig;
+}
+

--- a/src/ClassificationStore/Repository/StoreRepository.php
+++ b/src/ClassificationStore/Repository/StoreRepository.php
@@ -20,7 +20,6 @@ use Pimcore\Model\DataObject\Classificationstore\StoreConfig\Listing;
  */
 final class StoreRepository implements StoreRepositoryInterface
 {
-
     /**
      * {@inheritdoc}
      */

--- a/src/ClassificationStore/Repository/StoreRepository.php
+++ b/src/ClassificationStore/Repository/StoreRepository.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository;
+
+use Pimcore\Model\DataObject\Classificationstore\StoreConfig\Listing;
+
+/**
+ * @internal
+ */
+final class StoreRepository implements StoreRepositoryInterface
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function listStores(): array
+    {
+        return (new Listing())->load();
+    }
+}

--- a/src/ClassificationStore/Repository/StoreRepositoryInterface.php
+++ b/src/ClassificationStore/Repository/StoreRepositoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository;
+
+use Pimcore\Model\DataObject\Classificationstore\StoreConfig;
+
+/**
+ * @internal
+ */
+interface StoreRepositoryInterface
+{
+    /**
+     * @return StoreConfig[]
+     */
+    public function listStores(): array;
+}

--- a/src/ClassificationStore/Schema/StoreConfig.php
+++ b/src/ClassificationStore/Schema/StoreConfig.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+#[Schema(
+    schema: 'ClassificationStoreStoreConfig',
+    title: 'Classification Store Configuration',
+    required: [
+        'id',
+        'name',
+    ],
+    type: 'object'
+)]
+final class StoreConfig implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(description: 'ID', type: 'integer', example: 42)]
+        private readonly int $id,
+        #[Property(description: 'Name', type: 'string', example: 'value')]
+        private readonly string $name,
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/ClassificationStore/Service/StoreService.php
+++ b/src/ClassificationStore/Service/StoreService.php
@@ -1,0 +1,169 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Service;
+
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ConcreteObjectResolver;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Event\GroupEvent;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Event\GroupLayoutEvent;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Event\StoreConfigEvent;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Hydrator\GroupHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Hydrator\GroupLayoutHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Hydrator\StoreConfigHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\MappedParameter\LayoutParameter;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\MappedParameter\ListClassificationStoreParameter;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository\GroupConfigRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository\KeyGroupRelationRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository\StoreRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema\GroupLayout;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema\KeyLayout;
+use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema\StoreConfig;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function count;
+
+/**
+ * @internal
+ */
+final readonly class StoreService implements StoreServiceInterface, GroupServiceInterface
+{
+    public function __construct(
+        private StoreRepositoryInterface $storeRepository,
+        private ConcreteObjectResolver $concreteObjectResolver,
+        private GroupConfigRepositoryInterface $groupConfigRepository,
+        private EventDispatcherInterface $eventDispatcher,
+        private GroupHydratorInterface $groupHydrator,
+        private StoreConfigHydratorInterface $storeConfigHydrator,
+        private KeyGroupRelationRepositoryInterface $keyGroupRelationRepository,
+        private KeyGroupLayoutServiceInterface $keyGroupLayoutService,
+        private GroupLayoutHydratorInterface $groupLayoutHydrator,
+        private ClassDefinitionResolverInterface $classDefinitionResolver,
+    ) {
+    }
+
+    public function listStores(): Collection
+    {
+        $storeConfigs = $this->storeRepository->listStores();
+        $stores = [];
+        foreach ($storeConfigs as $storeConfig) {
+            $store = $this->storeConfigHydrator->hydrate($storeConfig);
+            $this->eventDispatcher->dispatch(
+                new StoreConfigEvent($store),
+                StoreConfigEvent::EVENT_NAME
+            );
+            $stores[] = $store;
+        }
+
+        return new Collection(count($stores), $stores);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGroups(ListClassificationStoreParameter $parameter): Collection
+    {
+        $allowedGroupIds = $this->getAllowedGroupIds($parameter);
+
+        if (count($allowedGroupIds) === 0) {
+            $allowedGroupIds = null;
+        }
+
+        $groups = $this->groupConfigRepository->getPaginatedGroupsByStore(
+            $parameter->getStoreId(),
+            $parameter,
+            $allowedGroupIds,
+            $parameter->getSearchTerm()
+        );
+
+        $hydratedGroups = [];
+        foreach ($groups as $group) {
+            $hydratedGroup = $this->groupHydrator->hydrate($group);
+            $this->eventDispatcher->dispatch(
+                new GroupEvent($hydratedGroup),
+                GroupEvent::EVENT_NAME
+            );
+            $hydratedGroups[] = $hydratedGroup;
+        }
+
+        return new Collection(
+            totalItems: $this->groupConfigRepository->getCountByStoreId($parameter->getStoreId()),
+            items: $hydratedGroups
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllowedGroupIds(ListClassificationStoreParameter $parameter): array
+    {
+        if (!$parameter->getClassId()) {
+            return [];
+        }
+
+        $class = $this->classDefinitionResolver->getById($parameter->getClassId());
+
+        if (!$class) {
+            throw new NotFoundException('Class', $parameter->getClassId());
+        }
+
+        $fieldDefinition = $class->getFieldDefinition($parameter->getFieldName());
+
+        if (!$fieldDefinition instanceof Classificationstore) {
+            throw new NotFoundException('field', $parameter->getFieldName());
+        }
+
+        return $fieldDefinition->getAllowedGroupIds();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLayoutDefinition(int $groupId, LayoutParameter $layoutParameter): GroupLayout
+    {
+        $keys = $this->keyGroupRelationRepository->getByGroupId($groupId);
+        $object = $this->concreteObjectResolver->getById($layoutParameter->getObjectId());
+
+        if (!$object) {
+            throw new NotFoundException('object', $layoutParameter->getObjectId());
+        }
+
+        $keyLayouts = [];
+        foreach ($keys as $key) {
+            $definition = $this->keyGroupLayoutService->getLayoutDefinition(
+                $key,
+                $layoutParameter->getFieldName(),
+                $object
+            );
+
+            $keyLayouts[] = new KeyLayout(
+                id: $key->getKeyId(),
+                name: $key->getName(),
+                description: $key->getDescription(),
+                definition: $definition,
+            );
+        }
+
+        $group = $this->groupConfigRepository->getById($groupId);
+        $groupLayout = $this->groupLayoutHydrator->hydrate($keyLayouts, $group);
+
+        $this->eventDispatcher->dispatch(
+            new GroupLayoutEvent($groupLayout),
+            GroupLayoutEvent::EVENT_NAME
+        );
+
+        return $groupLayout;
+    }
+}

--- a/src/ClassificationStore/Service/StoreService.php
+++ b/src/ClassificationStore/Service/StoreService.php
@@ -28,7 +28,6 @@ use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository\KeyGroupRe
 use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Repository\StoreRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema\GroupLayout;
 use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema\KeyLayout;
-use Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Schema\StoreConfig;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore;

--- a/src/ClassificationStore/Service/StoreServiceInterface.php
+++ b/src/ClassificationStore/Service/StoreServiceInterface.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\ClassificationStore\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
+
+/**
+ * @internal
+ */
+interface StoreServiceInterface
+{
+    public function listStores(): Collection;
+}

--- a/src/Grid/Service/GridSearchService.php
+++ b/src/Grid/Service/GridSearchService.php
@@ -61,7 +61,7 @@ final readonly class GridSearchService implements GridSearchServiceInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getDocumentSearchGrid(SearchGridParameter $searchParameter): Collection
     {

--- a/src/OpenApi/Attribute/Parameter/Query/ClassNamesParameter.php
+++ b/src/OpenApi/Attribute/Parameter/Query/ClassNamesParameter.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query;
+
+use Attribute;
+use OpenApi\Attributes\QueryParameter;
+use OpenApi\Attributes\Schema;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class ClassNamesParameter extends QueryParameter
+{
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'classNames',
+            description: 'Comma-separated list of class names',
+            required: false,
+            schema: new Schema(type: 'string', example: 'Car,Manufacturer,News')
+        );
+    }
+}
+

--- a/src/OpenApi/Attribute/Parameter/Query/ClassNamesParameter.php
+++ b/src/OpenApi/Attribute/Parameter/Query/ClassNamesParameter.php
@@ -30,4 +30,3 @@ final class ClassNamesParameter extends QueryParameter
         );
     }
 }
-

--- a/src/Setting/Controller/CountryCollectionController.php
+++ b/src/Setting/Controller/CountryCollectionController.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Setting\Controller;
+
+use OpenApi\Attributes\Get;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\GenericCollection;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\CollectionJson;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Setting\Schema\Country;
+use Pimcore\Bundle\StudioBackendBundle\Setting\Service\SettingsServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\PaginatedResponseTrait;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+use function count;
+
+/**
+ * @internal
+ */
+final class CountryCollectionController extends AbstractApiController
+{
+    use PaginatedResponseTrait;
+
+    private const string ROUTE = '/settings/available-countries';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly SettingsServiceInterface $settingsService
+    ) {
+        parent::__construct($serializer);
+    }
+
+    #[Route(
+        self::ROUTE,
+        name: 'pimcore_studio_api_settings_country_collection',
+        methods: ['GET']
+    )]
+    #[Get(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'settings_country_collection',
+        description: 'settings_country_collection_description',
+        summary: 'settings_country_collection_summary',
+        tags: [Tags::Settings->value],
+    )]
+    #[SuccessResponse(
+        description: 'settings_country_collection_success_response',
+        content: new CollectionJson(new GenericCollection(Country::class))
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+    ])]
+    public function getCountryCollection(): JsonResponse
+    {
+        $countries = $this->settingsService->getAvailableCountries();
+
+        return $this->getPaginatedCollection(
+            $this->serializer,
+            $countries,
+            count($countries)
+        );
+    }
+}
+

--- a/src/Setting/Controller/CountryCollectionController.php
+++ b/src/Setting/Controller/CountryCollectionController.php
@@ -75,4 +75,3 @@ final class CountryCollectionController extends AbstractApiController
         );
     }
 }
-

--- a/src/Setting/Event/PreResponse/CountryEvent.php
+++ b/src/Setting/Event/PreResponse/CountryEvent.php
@@ -34,4 +34,3 @@ final class CountryEvent extends AbstractPreResponseEvent
         return $this->country;
     }
 }
-

--- a/src/Setting/Event/PreResponse/CountryEvent.php
+++ b/src/Setting/Event/PreResponse/CountryEvent.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Setting\Event\PreResponse;
+
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+use Pimcore\Bundle\StudioBackendBundle\Setting\Schema\Country;
+
+final class CountryEvent extends AbstractPreResponseEvent
+{
+    public const string EVENT_NAME = 'pre_response.settings.available_country';
+
+    public function __construct(
+        private readonly Country $country
+    ) {
+        parent::__construct($country);
+    }
+
+    /**
+     * Use this to get additional info out of the response object
+     */
+    public function getCountry(): Country
+    {
+        return $this->country;
+    }
+}
+

--- a/src/Setting/Hydrator/CountryHydrator.php
+++ b/src/Setting/Hydrator/CountryHydrator.php
@@ -25,4 +25,3 @@ final readonly class CountryHydrator implements CountryHydratorInterface
         return new Country($name, $code);
     }
 }
-

--- a/src/Setting/Hydrator/CountryHydrator.php
+++ b/src/Setting/Hydrator/CountryHydrator.php
@@ -11,25 +11,18 @@ declare(strict_types=1);
  *  @license    Pimcore Open Core License (POCL)
  */
 
-namespace Pimcore\Bundle\StudioBackendBundle\Setting\Service;
+namespace Pimcore\Bundle\StudioBackendBundle\Setting\Hydrator;
 
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Setting\Schema\Country;
 
 /**
  * @internal
  */
-interface SettingsServiceInterface
+final readonly class CountryHydrator implements CountryHydratorInterface
 {
-    public function getSettings(): array;
-
-    /**
-     * @throws InvalidElementTypeException
-     */
-    public function getTreePageSize(string $elementType): int;
-
-    /**
-     * @return Country[]
-     */
-    public function getAvailableCountries(): array;
+    public function hydrate(string $name, string $code): Country
+    {
+        return new Country($name, $code);
+    }
 }
+

--- a/src/Setting/Hydrator/CountryHydratorInterface.php
+++ b/src/Setting/Hydrator/CountryHydratorInterface.php
@@ -22,4 +22,3 @@ interface CountryHydratorInterface
 {
     public function hydrate(string $name, string $code): Country;
 }
-

--- a/src/Setting/Hydrator/CountryHydratorInterface.php
+++ b/src/Setting/Hydrator/CountryHydratorInterface.php
@@ -11,25 +11,15 @@ declare(strict_types=1);
  *  @license    Pimcore Open Core License (POCL)
  */
 
-namespace Pimcore\Bundle\StudioBackendBundle\Setting\Service;
+namespace Pimcore\Bundle\StudioBackendBundle\Setting\Hydrator;
 
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Setting\Schema\Country;
 
 /**
  * @internal
  */
-interface SettingsServiceInterface
+interface CountryHydratorInterface
 {
-    public function getSettings(): array;
-
-    /**
-     * @throws InvalidElementTypeException
-     */
-    public function getTreePageSize(string $elementType): int;
-
-    /**
-     * @return Country[]
-     */
-    public function getAvailableCountries(): array;
+    public function hydrate(string $name, string $code): Country;
 }
+

--- a/src/Setting/Schema/Country.php
+++ b/src/Setting/Schema/Country.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Setting\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+#[Schema(
+    schema: 'AvailableCountry',
+    title: 'Available Country',
+    required: ['name', 'code'],
+    type: 'object'
+)]
+final class Country implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(description: 'Country name', type: 'string', example: 'Austria')]
+        public readonly string $name,
+        #[Property(description: 'Country ISO 3166-1 code', type: 'string', example: 'AT')]
+        public readonly string $code,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+}

--- a/src/Setting/Service/SettingsService.php
+++ b/src/Setting/Service/SettingsService.php
@@ -14,7 +14,11 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Setting\Service;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Setting\Event\PreResponse\CountryEvent;
+use Pimcore\Bundle\StudioBackendBundle\Setting\Hydrator\CountryHydratorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
+use Pimcore\Localization\LocaleServiceInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use function array_key_exists;
 use function sprintf;
 
@@ -26,6 +30,9 @@ final readonly class SettingsService implements SettingsServiceInterface
     use ElementProviderTrait;
 
     public function __construct(
+        private CountryHydratorInterface $countryHydrator,
+        private EventDispatcherInterface $eventDispatcher,
+        private LocaleServiceInterface $localeService,
         private SettingProviderLoaderInterface $settingProviderLoader
     ) {
     }
@@ -58,5 +65,25 @@ final readonly class SettingsService implements SettingsServiceInterface
         }
 
         return $settings[$settingKey];
+    }
+
+    public function getAvailableCountries(): array
+    {
+        $countries = $this->localeService->getDisplayRegions();
+        asort($countries);
+
+        $availableCountries = [];
+        foreach ($countries as $code => $name) {
+            if (strlen($code) === 2) {
+                $country = $this->countryHydrator->hydrate($name, $code);
+                $this->eventDispatcher->dispatch(
+                    new CountryEvent($country),
+                    CountryEvent::EVENT_NAME
+                );
+                $availableCountries[] = $country;
+            }
+        }
+
+        return $availableCountries;
     }
 }

--- a/src/Setting/Service/SettingsService.php
+++ b/src/Setting/Service/SettingsService.php
@@ -21,6 +21,7 @@ use Pimcore\Localization\LocaleServiceInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use function array_key_exists;
 use function sprintf;
+use function strlen;
 
 /**
  * @internal

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -293,6 +293,18 @@ class_all_layout_collection_description: |
     Get all available layouts for classes.
 class_all_layout_collection_success_response: List of all available class layouts
 class_all_layout_collection_summary: Get all available class layouts
+class_get_available_visible_fields_description: |
+  Get available visible fields for the specified data object classes. <br>
+  Returns system columns and common fields across all provided class names. <br>
+  The <strong>{classNames}</strong> must be a comma separated list of existing data object class names.
+class_get_available_visible_fields_summary: Get available visible fields for classes
+class_get_available_visible_fields_success_response: Successfully retrieved available visible fields
+class_get_selected_visible_fields_description: |
+  Get selected visible fields for the specified data object class and relation field. <br>
+  The <strong>{classId}</strong> must be an ID of existing data object class. <br>
+  The <strong>{relationField}</strong> must be the name of an existing relation field in the specified class.
+class_get_selected_visible_fields_summary: Get selected visible fields for a class relation field
+class_get_selected_visible_fields_success_response: Successfully retrieved selected visible fields
 data_object_add_description: |
   Add a new data object to the given <strong>{parentId}</strong>. <br> The <strong>{parentId}</strong> must be an ID of a folder or another data object. See the full description of request fields with the schema <strong>DataObjectAdd</strong>
 data_object_add_success_response: ID of added data object
@@ -858,6 +870,11 @@ system_settings_get_description: |
   System settings are public and need no login.
 system_settings_get_success_response: System settings data
 system_settings_get_summary: Get system settings
+settings_country_collection_description: |
+  Get all available countries in the system. <br>
+  Returns a list of countries with their codes and names
+settings_country_collection_summary: Get all available countries
+settings_country_collection_success_response: List of available countries
 simple_search_preview_get_description: |
   Returns search preview for elements based on the given type <strong>{elementType}</strong> and <strong>{id}</strong>. <br>
   The <strong>{id}</strong> must be an ID of an existing element of the provided <strong>{elementType}</strong>.
@@ -1166,6 +1183,10 @@ user_default_key_bindings_response: List of default key bindings
 user_upload_image_summary: Upload user image
 user_get_image_summary: Get user profile image
 user_get_image_success_response: User profile image
+class_field_collection_collection_description: |
+  Get all available field collection configurations in the system
+class_field_collection_collection_summary: Get all field collection configurations
+class_field_collection_collection_success_response: List of field collection configurations
 class_field_collection_object_layout_description: |
   Get all layouts from the field collection for an given object
 class_field_collection_object_layout_summary: Get all layouts from the field collection for an given object
@@ -1405,6 +1426,9 @@ tag_classification_store: Classification store operations
 classification_store_get_collections_description: Get all classification store collections for given fieldName
 classification_store_get_collections_summary: Get all classification store collections for given fieldName
 classification_store_get_collections_response: List of classification store collections
+classification_store_get_config_collection_description: Get all available classification stores
+classification_store_get_config_collection_summary: Get all classification store configurations
+classification_store_get_config_collection_success_response: List of classification store configurations
 classification_store_get_groups_description: Get all classification store groups for given fieldName
 classification_store_get_groups_summary: Get all classification store groups for given fieldName
 classification_store_get_groups_response: List of classification store groups


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-ui-bundle/issues/2189

## Additional info

- add endpoint to get available visible fields based on the class (e.g for object relation fields)
- add endpoint to get selected visible fields based on the field name and class
- add endpoint to get available countries
- add endpoint to list field collection configurations
- add endpoint to list classification store configurations