### PR TITLE
[Task] Adaptions for admin settings

### DIFF
--- a/src/Setting/Controller/UpdateAdminSettingsController.php
+++ b/src/Setting/Controller/UpdateAdminSettingsController.php
@@ -34,7 +34,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 final class UpdateAdminSettingsController extends AbstractApiController
 {
-    private const string ROUTE = '/settings/admin';
+    private const string ROUTE = '/settings/admin/save';
 
     public function __construct(
         SerializerInterface $serializer,

--- a/src/Setting/Hydrator/AdminSettingsHydrator.php
+++ b/src/Setting/Hydrator/AdminSettingsHydrator.php
@@ -30,6 +30,7 @@ final readonly class AdminSettingsHydrator implements AdminSettingsHydratorInter
             $data['branding']['color_login_screen'] ?? '',
             $data['branding']['color_admin_interface'] ?? '',
             $data['branding']['color_admin_interface_background'] ?? '',
+            $data['branding']['login_screen_custom_background_image'] ?? '',
             $data['branding']['login_screen_custom_image'] ?? '',
         );
 
@@ -52,11 +53,22 @@ final readonly class AdminSettingsHydrator implements AdminSettingsHydratorInter
 
         return [
             'branding' => [
-                'login_screen_invert_colors' => $branding->getLoginScreenInvertColors(),
+                'login_screen_invert_colors' => $branding->isLoginScreenInvertColors(),
                 'color_login_screen' => $branding->getColorLoginScreen(),
                 'color_admin_interface' => $branding->getColorAdminInterface(),
                 'color_admin_interface_background' => $branding->getColorAdminInterfaceBackground(),
-                'login_screen_custom_image' => $branding->getLoginScreenCustomImage(),
+                'login_screen_custom_image' =>
+                    str_replace(
+                        '%',
+                        '%%',
+                        $branding->getLoginScreenCustomImage()
+                    ),
+                'login_screen_custom_background_image' =>
+                    str_replace(
+                        '%',
+                        '%%',
+                        $branding->getLoginScreenCustomBackgroundImage()
+                    ),
             ],
             'assets' => [
                 'hide_edit_image' => $assets->getHideEditImage(),

--- a/src/Setting/Repository/AdminSettingRepository.php
+++ b/src/Setting/Repository/AdminSettingRepository.php
@@ -29,16 +29,16 @@ final class AdminSettingRepository implements AdminSettingRepositoryInterface
 
     private const string ASSETS = 'assets';
 
-    private const string SCOPE = 'pimcore_admin_system_settings';
+    private const string SCOPE = 'pimcore_studio_admin_system_settings';
 
-    private const string CACHE_KEY = 'pimcore_admin_system_settings_config';
+    private const string CACHE_KEY = 'pimcore_studio_admin_system_settings_config';
 
     private ?LocationAwareConfigRepository $locationAwareConfigRepository = null;
 
     public function __construct(
         private readonly array $adminConfig,
         private readonly RuntimeCacheResolverInterface $cacheResolver,
-        private SystemConfigResolverInterface $systemConfigResolver
+        private readonly SystemConfigResolverInterface $systemConfigResolver
     ) {
     }
 
@@ -58,20 +58,7 @@ final class AdminSettingRepository implements AdminSettingRepositoryInterface
     {
         $repository = $this->getRepository();
 
-        $data[self::BRANDING] = [
-            'login_screen_invert_colors' => $values['branding']['login_screen_invert_colors'],
-            'color_login_screen' => $values['branding']['color_login_screen'],
-            'color_admin_interface' => $values['branding']['color_admin_interface'],
-            'color_admin_interface_background' => $values['branding']['color_admin_interface_background'],
-            'login_screen_custom_image' => str_replace('%', '%%', $values['branding']['login_screen_custom_image']),
-        ];
-
-        $data[self::ASSETS] = [
-            'hide_edit_image' => $values['assets']['hide_edit_image'],
-            'disable_tree_preview' => $values['assets']['disable_tree_preview'],
-        ];
-
-        $repository->saveConfig(self::CONFIG_ID, $data, function ($data) {
+        $repository->saveConfig(self::CONFIG_ID, $values, function ($data) {
             return [
                 'pimcore_admin' => $data,
             ];

--- a/src/Setting/Schema/Branding.php
+++ b/src/Setting/Schema/Branding.php
@@ -32,44 +32,55 @@ final readonly class Branding
 {
     public function __construct(
         #[Property(description: 'Invert colors on login screen', type: 'boolean', example: false)]
-        private bool $login_screen_invert_colors,
+        private bool $loginScreenInvertColors,
         #[Property(description: 'Color for login screen', type: 'string', example: '#3C3F41')]
-        private string $color_login_screen,
+        private string $colorLoginScreen,
         #[Property(description: 'Color for admin interface', type: 'string', example: '#3C3F41')]
-        private string $color_admin_interface,
+        private string $colorAdminInterface,
         #[Property(description: 'Background color for admin interface', type: 'string', example: '#FFFFFF')]
-        private string $color_admin_interface_background,
+        private string $colorAdminInterfaceBackground,
         #[Property(
             description: 'Custom image for login screen',
             type: 'string',
-            example: '/bundles/pimcoreadmin/img/login-screen.jpg')
+            example: '/Sample Content/Logo/login_background.png')
         ]
-        private string $login_screen_custom_image,
+        private string $loginScreenCustomBackgroundImage,
+        #[Property(
+            description: 'Custom image for login screen',
+            type: 'string',
+            example: '/Sample Content/Logo/login_logo.png')
+        ]
+        private string $loginScreenCustomImage,
     ) {
     }
 
-    public function getLoginScreenInvertColors(): bool
+    public function isLoginScreenInvertColors(): bool
     {
-        return $this->login_screen_invert_colors;
+        return $this->loginScreenInvertColors;
     }
 
     public function getColorLoginScreen(): string
     {
-        return $this->color_login_screen;
+        return $this->colorLoginScreen;
     }
 
     public function getColorAdminInterface(): string
     {
-        return $this->color_admin_interface;
+        return $this->colorAdminInterface;
     }
 
     public function getColorAdminInterfaceBackground(): string
     {
-        return $this->color_admin_interface_background;
+        return $this->colorAdminInterfaceBackground;
+    }
+
+    public function getLoginScreenCustomBackgroundImage(): string
+    {
+        return $this->loginScreenCustomBackgroundImage;
     }
 
     public function getLoginScreenCustomImage(): string
     {
-        return $this->login_screen_custom_image;
+        return $this->loginScreenCustomImage;
     }
 }


### PR DESCRIPTION
- Settings are stored in a different scope to differentiate between studio settings and admin-classic-ui settings
- `loginScreenCustomBackgroundImage` & `loginScreenCustomImage` are path references now

