### PR TITLE
[Documents]: Allow template setting when adding new document

### DIFF
--- a/src/Document/Schema/DocumentAddParameters.php
+++ b/src/Document/Schema/DocumentAddParameters.php
@@ -24,7 +24,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Document\DocumentTypes;
 #[Schema(
     title: 'DocumentAdd',
     required: [
-        'key', 'type', 'title', 'navigationName', 'docTypeId',
+        'key', 'type', 'title', 'navigationName', 'docTypeId', 'template',
         'translationsSourceId', 'language', 'inheritanceSourceId',
     ],
     type: 'object'
@@ -42,6 +42,8 @@ final readonly class DocumentAddParameters
         private ?string $navigationName = null,
         #[Property(description: 'Document type ID', type: 'string', example: DocumentTypes::PAGE->value)]
         private ?string $docTypeId = null,
+        #[Property(description: 'Document template', type: 'string', example: 'default')]
+        private ?string $template = null,
         #[Property(description: 'Id of the base document for new translation', type: 'integer', example: 33)]
         private ?int $translationsSourceId = null,
         #[Property(description: 'Document language when adding a translation', type: 'string', example: 'en')]
@@ -75,6 +77,11 @@ final readonly class DocumentAddParameters
     public function getDocTypeId(): ?string
     {
         return $this->docTypeId;
+    }
+
+    public function getTemplate(): ?string
+    {
+        return $this->template;
     }
 
     public function getTranslationsSourceId(): ?int

--- a/src/Document/Service/CreateService.php
+++ b/src/Document/Service/CreateService.php
@@ -106,12 +106,18 @@ final readonly class CreateService implements CreateServiceInterface
 
     private function addBaseData(UserInterface $user, DocumentAddParameters $parameters): array
     {
-        return [
+        $baseData = [
             'userOwner' => $user->getId(),
             'published' => false,
             'type' => $parameters->getType(),
             'key' => $this->serviceResolver->getValidKey($parameters->getKey(), ElementTypes::TYPE_DOCUMENT),
         ];
+
+        if ($parameters->getTemplate() !== null) {
+            $baseData['template'] = $parameters->getTemplate();
+        }
+
+        return $baseData;
     }
 
     private function addDocTypeData(


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/headless-documents/issues/229

## Additional info
When adding a new document, it should be possible to set template in the initial request
This is needed e.g for headless documents