### PR TITLE
Include property data as its versioned.

### DIFF
--- a/src/Version/Hydrator/DataObjectVersionHydrator.php
+++ b/src/Version/Hydrator/DataObjectVersionHydrator.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Version\Hydrator;
 
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Icon\Service\IconServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Property\Hydrator\PropertyHydratorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Version\Schema\DataObjectVersion;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Concrete;
@@ -26,7 +27,8 @@ final readonly class DataObjectVersionHydrator implements DataObjectVersionHydra
 {
     public function __construct(
         private DataServiceInterface $dataService,
-        private IconServiceInterface $iconService
+        private IconServiceInterface $iconService,
+        private PropertyHydratorInterface $propertyHydrator
     ) {
     }
 
@@ -61,6 +63,13 @@ final readonly class DataObjectVersionHydrator implements DataObjectVersionHydra
         );
 
         $this->dataService->setObjectDetailData($hydratedDataObject, $dataObject);
+
+        $properties = [];
+        foreach ($dataObject->getProperties() as $property) {
+            $properties[] = $this->propertyHydrator->hydrateElementProperty($property);
+        }
+
+        $hydratedDataObject->setProperties($properties);
 
         return $hydratedDataObject;
     }

--- a/src/Version/Schema/DataObjectVersion.php
+++ b/src/Version/Schema/DataObjectVersion.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Version\Schema;
 
+use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Util\Trait\ClassDataTrait;
+use Pimcore\Bundle\StudioBackendBundle\Property\Schema\ElementProperty;
 use Pimcore\Bundle\StudioBackendBundle\Response\Element;
 use Pimcore\Bundle\StudioBackendBundle\Response\ElementIcon;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
@@ -66,6 +68,8 @@ final class DataObjectVersion extends Element implements AdditionalAttributesInt
         private array $objectData = [],
         #[Property(description: 'Allow variants', type: 'bool', example: false)]
         private ?bool $allowVariants = null,
+        #[Property(description: 'Properties', type: 'array', items: new Items(ref: ElementProperty::class))]
+        private array $properties = [],
     ) {
         parent::__construct(
             $id,
@@ -135,5 +139,15 @@ final class DataObjectVersion extends Element implements AdditionalAttributesInt
     public function setAllowVariants(bool $allowVariants): void
     {
         $this->allowVariants = $allowVariants;
+    }
+
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    public function setProperties(array $properties): void
+    {
+        $this->properties = $properties;
     }
 }


### PR DESCRIPTION
Property data is versioned data, and should be included with the DataObjectVersion data so it can be displayed on the Versions tab. 

This pull requests add the Property schema to the version data. A separate pull request to the Studio-UI bundle will be required to display the property updates / changes on the UI.