### PR TITLE
[GDPR] Add `hasParameters` field to email entry data

### DIFF
--- a/src/Gdpr/Provider/SentMailProvider.php
+++ b/src/Gdpr/Provider/SentMailProvider.php
@@ -47,6 +47,7 @@ final readonly class SentMailProvider implements DataProviderInterface
                 'subject' => $entry->getSubject(),
                 'hasHtmlLog' => $entry->getEmailLogExistsHtml() === 1,
                 'hasTextLog' => $entry->getEmailLogExistsText() === 1,
+                'hasParameters' => !empty($entry->getParams()),
                 '__gdprIsDeletable' => true,
             ]),
             $listing->load()


### PR DESCRIPTION
## Changes in this pull request
Followup to https://github.com/pimcore/studio-backend-bundle/issues/1627

## Additional info
This pull request makes a minor update to the `SentMailProvider` to enhance the data returned by the `findData` method. Specifically, it adds a new field to indicate whether email parameters are present for each entry.

- Data enrichment:
  * [`src/Gdpr/Provider/SentMailProvider.php`](diffhunk://#diff-9fd83b4c6eb272020006ff823ac17b148ef60471793547e01a692376104287e2R50): Added a `hasParameters` field to the returned data, which is set to `true` if the email entry has parameters (`getParams()` is not empty).