### PR TITLE
[System Settings] Improve saving of data

### DIFF
--- a/src/Setting/Provider/SystemSettingsProvider.php
+++ b/src/Setting/Provider/SystemSettingsProvider.php
@@ -81,7 +81,7 @@ final readonly class SystemSettingsProvider implements SettingsProviderInterface
 
         foreach ($languages as $language) {
             $preparedData['general.fallbackLanguages.' . $language] =
-                implode(',', $data['general']['fallback_languages'][$language]) ?? '';
+                implode(',', $data['general']['fallback_languages'][$language]);
 
             $preparedData['documents.error_pages.localized.' . $language] =
                 $data['documents']['error_pages']['localized'][$language]['fullPath'] ?? '';

--- a/src/Setting/Provider/SystemSettingsProvider.php
+++ b/src/Setting/Provider/SystemSettingsProvider.php
@@ -84,7 +84,7 @@ final readonly class SystemSettingsProvider implements SettingsProviderInterface
                 implode(',', $data['general']['fallback_languages'][$language]) ?? '';
 
             $preparedData['documents.error_pages.localized.' . $language] =
-                $data['documents']['error_pages']['localized'][$language] ?? '';
+                $data['documents']['error_pages']['localized'][$language]['fullPath'] ?? '';
         }
 
         $preparedData['objects.versions.days'] = $data['objects']['versions']['days'];
@@ -93,7 +93,7 @@ final readonly class SystemSettingsProvider implements SettingsProviderInterface
         $preparedData['assets.versions.steps'] = $data['assets']['versions']['steps'];
         $preparedData['documents.versions.days'] = $data['documents']['versions']['days'];
         $preparedData['documents.versions.steps'] = $data['documents']['versions']['steps'];
-        $preparedData['documents.error_pages.default'] = $data['documents']['error_pages']['default'];
+        $preparedData['documents.error_pages.default'] = $data['documents']['error_pages']['default']['fullPath'] ?? '';
         $preparedData['general.validLanguages'] = implode(',', $languages);
         $preparedData['general.fallbackLanguages'] = $data['general']['fallback_languages'];
         $preparedData['general.requiredLanguages'] = implode(',', $data['general']['required_languages']);

--- a/src/Setting/Provider/SystemSettingsProvider.php
+++ b/src/Setting/Provider/SystemSettingsProvider.php
@@ -81,7 +81,7 @@ final readonly class SystemSettingsProvider implements SettingsProviderInterface
 
         foreach ($languages as $language) {
             $preparedData['general.fallbackLanguages.' . $language] =
-                $data['general']['fallback_languages'][$language] ?? '';
+                implode(',', $data['general']['fallback_languages'][$language]) ?? '';
 
             $preparedData['documents.error_pages.localized.' . $language] =
                 $data['documents']['error_pages']['localized'][$language] ?? '';
@@ -96,7 +96,7 @@ final readonly class SystemSettingsProvider implements SettingsProviderInterface
         $preparedData['documents.error_pages.default'] = $data['documents']['error_pages']['default'];
         $preparedData['general.validLanguages'] = implode(',', $languages);
         $preparedData['general.fallbackLanguages'] = $data['general']['fallback_languages'];
-        $preparedData['general.requiredLanguages'] = implode($data['general']['required_languages']);
+        $preparedData['general.requiredLanguages'] = implode(',', $data['general']['required_languages']);
         $preparedData['general.domain'] = $data['general']['domain'];
         $preparedData['general.redirect_to_maindomain'] = $data['general']['redirect_to_maindomain'];
         $preparedData['general.defaultLanguage'] = $data['general']['default_language'];


### PR DESCRIPTION
## Changes in this pull request

## Additional info
This pull request updates the `prepareSettingsForUpdate` method in `SystemSettingsProvider` to improve how language and document settings are processed before saving. The changes focus on ensuring array values are consistently converted to comma-separated strings and that file paths are correctly extracted from nested arrays.

**Improvements to data preparation for settings update:**

* Fallback languages for each language are now stored as comma-separated strings instead of arrays.
* Error page paths for both localized and default settings now extract the `'fullPath'` value from the nested arrays, defaulting to an empty string if not present. [[1]](diffhunk://#diff-8593904c1eafb980007b5246257040b27eaa9d3559181578bdebf4402afb842aL84-R87) [[2]](diffhunk://#diff-8593904c1eafb980007b5246257040b27eaa9d3559181578bdebf4402afb842aL96-R99)
* Required languages are now joined into a single comma-separated string, ensuring consistency with how valid languages are handled.