### PR TITLE
[Task]: Update PHP version requirement to include 8.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "php": "~8.3.0 || ~8.4.0",
+    "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
     "league/csv": "^9.22",
     "nesbot/carbon": "^3.8.4",
     "pimcore/static-resolver-bundle": "^3.5.0 || ^2026.1",


### PR DESCRIPTION
## Changes in this pull request
2026.1 extends to PHP 8.5 and removed 8.3, trying with this PR to see if tests would pass for 8.5 support

## Additional info
