### PR TITLE
[Task]: Avoid method name "clone"

### DIFF
--- a/src/Bundle/CustomReport/Repository/CustomReportRepository.php
+++ b/src/Bundle/CustomReport/Repository/CustomReportRepository.php
@@ -137,7 +137,7 @@ final class CustomReportRepository implements CustomReportRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function clone(Config $existingConfig, string $newName): Config
+    public function cloneConfig(Config $existingConfig, string $newName): Config
     {
         $newConfig = new Config();
         if (!$newConfig->isWriteable()) {

--- a/src/Bundle/CustomReport/Repository/CustomReportRepositoryInterface.php
+++ b/src/Bundle/CustomReport/Repository/CustomReportRepositoryInterface.php
@@ -52,7 +52,7 @@ interface CustomReportRepositoryInterface
     /**
      * @throws NotWriteableException
      */
-    public function clone(Config $existingConfig, string $newName): Config;
+    public function cloneConfig(Config $existingConfig, string $newName): Config;
 
     /**
      * @throws NotWriteableException

--- a/src/Bundle/CustomReport/Service/CustomReportService.php
+++ b/src/Bundle/CustomReport/Service/CustomReportService.php
@@ -135,7 +135,7 @@ final readonly class CustomReportService implements CustomReportServiceInterface
         }
 
         $reportToClone = $this->getCustomReportByName($reportName);
-        $config = $this->customReportRepository->clone($reportToClone, $newName);
+        $config = $this->customReportRepository->cloneConfig($reportToClone, $newName);
 
         return $this->customReportHydrator->extractReportDetails($config);
     }


### PR DESCRIPTION
## Additional info
clone is a reserved method name from PHP 8.5 and cannot be used for custom methods anymore.