### PR TITLE
[Grid] globaly shared column config not available

### DIFF
--- a/src/Grid/Service/ConfigurationService.php
+++ b/src/Grid/Service/ConfigurationService.php
@@ -161,7 +161,7 @@ final readonly class ConfigurationService implements ConfigurationServiceInterfa
             return $this->getDefaultDataObjectGridConfiguration($folderId, $classId);
         }
 
-        $configuration =  $this->configurationRepository->getById($configurationId);
+        $configuration = $this->configurationRepository->getById($configurationId);
         $user = $this->securityService->getCurrentUser();
 
         if ($configuration->getClassId() !== $classId) {
@@ -363,10 +363,8 @@ final readonly class ConfigurationService implements ConfigurationServiceInterfa
         $filteredConfigurations = [];
         $currentUser = $this->securityService->getCurrentUser();
         foreach ($configurations as $configuration) {
-            if (
-                $configuration->isShareGlobal() ||
-                $this->userRoleShareService->isConfigurationSharedWithUser($configuration, $currentUser)
-            ) {
+            if ($this->userRoleShareService->isConfigurationSharedWithUser($configuration, $currentUser))
+            {
                 $hydratedConfiguration = $this->configurationHydrator->hydrate($configuration);
 
                 $this->dispatchConfigurationEvent($hydratedConfiguration);

--- a/src/Grid/Service/ConfigurationService.php
+++ b/src/Grid/Service/ConfigurationService.php
@@ -363,8 +363,7 @@ final readonly class ConfigurationService implements ConfigurationServiceInterfa
         $filteredConfigurations = [];
         $currentUser = $this->securityService->getCurrentUser();
         foreach ($configurations as $configuration) {
-            if ($this->userRoleShareService->isConfigurationSharedWithUser($configuration, $currentUser))
-            {
+            if ($this->userRoleShareService->isConfigurationSharedWithUser($configuration, $currentUser)) {
                 $hydratedConfiguration = $this->configurationHydrator->hydrate($configuration);
 
                 $this->dispatchConfigurationEvent($hydratedConfiguration);

--- a/src/Grid/Service/UserRoleShareService.php
+++ b/src/Grid/Service/UserRoleShareService.php
@@ -51,7 +51,10 @@ final readonly class UserRoleShareService implements UserRoleShareServiceInterfa
 
     public function isConfigurationSharedWithUser(GridConfiguration $gridConfiguration, UserInterface $user): bool
     {
-        if ($gridConfiguration->getOwner() === $user->getId()) {
+        if (
+            $gridConfiguration->isShareGlobal() ||
+            $gridConfiguration->getOwner() === $user->getId()
+        ) {
             return true;
         }
 


### PR DESCRIPTION
## Changes in this pull request
Resolves #1589 

## Additional info
- move permission check for globally shared configs to cover all cases