### PR TITLE
Fix icon names for object brick and field collection tree nodes

### DIFF
--- a/src/Class/Hydrator/FieldCollection/TreeNodeHydrator.php
+++ b/src/Class/Hydrator/FieldCollection/TreeNodeHydrator.php
@@ -28,7 +28,7 @@ final readonly class TreeNodeHydrator implements TreeNodeHydratorInterface
         return new FieldCollectionTreeNode(
             $definition->getKey() ?? '',
             $definition->getTitle() ?? '',
-            new ElementIcon(ElementIconTypes::NAME->value, 'field-collection'),
+            new ElementIcon(ElementIconTypes::NAME->value, 'field-collection-field'),
             $definition->getGroup(),
         );
     }

--- a/src/Class/Hydrator/ObjectBrick/TreeNodeHydrator.php
+++ b/src/Class/Hydrator/ObjectBrick/TreeNodeHydrator.php
@@ -28,7 +28,7 @@ final readonly class TreeNodeHydrator implements TreeNodeHydratorInterface
         return new ObjectBrickTreeNode(
             $definition->getKey() ?? '',
             $definition->getTitle() ?? '',
-            new ElementIcon(ElementIconTypes::NAME->value, 'objectbricks'),
+            new ElementIcon(ElementIconTypes::NAME->value, 'object-bricks'),
             $definition->getGroup(),
         );
     }


### PR DESCRIPTION
Align the icon names returned by the backend hydrators with the names registered in the frontend icon library:
- 'objectbricks' → 'object-bricks' (ObjectBrick TreeNodeHydrator)
- 'field-collection' → 'field-collection-field' (FieldCollection TreeNodeHydrator)

## Changes in this pull request
Resolves https://github.com/pimcore/studio-ui-bundle/issues/3086, https://github.com/pimcore/studio-ui-bundle/issues/3084

## Additional info
