### PR TITLE
Updated names of class type icons

### DIFF
--- a/src/Class/Util/ClassDefinitionType.php
+++ b/src/Class/Util/ClassDefinitionType.php
@@ -44,10 +44,10 @@ enum ClassDefinitionType: string
     public function icon(): string
     {
         return match ($this) {
-            self::FieldCollection => 'fieldcollection',
+            self::FieldCollection => 'field-collection-field',
             self::ClassDefinition => 'class',
-            self::CustomLayout => 'custom_views',
-            self::ObjectBrick => 'objectbricks',
+            self::CustomLayout => 'custom-layout',
+            self::ObjectBrick => 'object-bricks',
         };
     }
 


### PR DESCRIPTION
## Changes in this pull request
Completes https://github.com/pimcore/studio-ui-bundle/pull/3166

## Additional info
This pull request updates the icon names returned by the `icon()` method in the `ClassDefinitionType` enum to use more consistent and descriptive naming conventions.

**UI Consistency Improvements:**

* Updated icon names in the `icon()` method of `ClassDefinitionType` to use hyphenated and more descriptive strings (e.g., `field-collection-field`, `custom-layout`, `object-bricks`) instead of previous concatenated names.