### PR TITLE
[GDPR] fix permission issues when exporting elements

### DIFF
--- a/src/Gdpr/Provider/AssetsProvider.php
+++ b/src/Gdpr/Provider/AssetsProvider.php
@@ -27,6 +27,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Model\Asset;
 use Symfony\Component\HttpFoundation\Response;
+use function sprintf;
 
 /**
  * @internal

--- a/src/Gdpr/Provider/AssetsProvider.php
+++ b/src/Gdpr/Provider/AssetsProvider.php
@@ -17,11 +17,13 @@ use Pimcore\Bundle\GenericDataIndexBundle\Enum\Search\SortDirection;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Provider\AssetQueryProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\AssetSearchServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\Gdpr\Provider\Legacy\AssetExporterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Gdpr\Schema\GdprDataRow;
 use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Model\Asset;
 use Symfony\Component\HttpFoundation\Response;
@@ -128,6 +130,10 @@ final readonly class AssetsProvider implements DataProviderInterface
 
         if (!$asset) {
             throw new NotFoundException('Asset Not Found', $id);
+        }
+
+        if (!$asset->isAllowed(ElementPermissions::VIEW_PERMISSION)) {
+            throw new ForbiddenException(sprintf('Access Denied for asset with id "%d".', $asset->getId()));
         }
 
         return $this->assetExporter->doExportData($asset);

--- a/src/Gdpr/Provider/DataObjectProvider.php
+++ b/src/Gdpr/Provider/DataObjectProvider.php
@@ -17,11 +17,13 @@ use Pimcore\Bundle\GenericDataIndexBundle\Enum\Search\SortDirection;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Provider\DataObjectQueryProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\DataObjectSearchServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\Gdpr\Provider\Legacy\ObjectExporterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Gdpr\Schema\GdprDataRow;
 use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Concrete;
@@ -130,6 +132,10 @@ final readonly class DataObjectProvider implements DataProviderInterface
 
         if (!$object instanceof Concrete) {
             throw new NotFoundException('Requested object is not a Concrete data object', $id);
+        }
+
+        if (!$object->isAllowed(ElementPermissions::VIEW_PERMISSION)) {
+            throw new ForbiddenException(sprintf('Access Denied for object with id "%d".', $object->getId()));
         }
 
         $export = [

--- a/src/Gdpr/Provider/DataObjectProvider.php
+++ b/src/Gdpr/Provider/DataObjectProvider.php
@@ -27,6 +27,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Concrete;
+use function sprintf;
 
 /**
  * @internal

--- a/src/Gdpr/Provider/PimcoreUserProvider.php
+++ b/src/Gdpr/Provider/PimcoreUserProvider.php
@@ -213,6 +213,6 @@ final readonly class PimcoreUserProvider implements DataProviderInterface
      */
     public function getRequiredPermissions(): array
     {
-        return [UserPermissions::PIMCORE_USER->value];
+        return [UserPermissions::USER_MANAGEMENT->value];
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-ui-bundle/issues/2886

## Additional info
Check for view permissions when accessing Objects & Assets.
Fix `PimcoreUserProvider` requiring `UserPermissions::PIMCORE_USER` instead of `UserPermissions::USER_MANAGEMENT`.