### PR TITLE
3207 - [Studio Backend] - Remove unnecessary quotes from translation YAML files

### DIFF
--- a/translations/studio.de.yaml
+++ b/translations/studio.de.yaml
@@ -17,7 +17,7 @@ studio_ee_csv_data_collection_failed: 'Daten für den CSV-Export konnten für %i
 studio_ee_element_patch_failed: 'Element vom Typ %type% mit ID %id% konnte nicht aktualisiert werden: %message%'
 studio_ee_element_rewrite_references_failed: 'Referenzen von Element vom Typ %type% mit ID %id% konnten nicht umgeschrieben werden: %message%'
 studio_ee_element_tag_operation_failed: 'Tags für Element vom Typ %type% mit ID %id% konnten nicht per %operation% verarbeitet werden: %message%'
-studio_ee_no_element_data_found: 'Keine Daten gefunden'
+studio_ee_no_element_data_found: Keine Daten gefunden
 studio_ee_job_create_download_zip: Download-ZIP erstellen
 studio_ee_job_clone_assets: Assets klonen
 studio_ee_job_upload_zip_file: ZIP-Datei hochladen

--- a/translations/studio.en.yaml
+++ b/translations/studio.en.yaml
@@ -17,7 +17,7 @@ studio_ee_csv_data_collection_failed: 'Data for CSV export could not be extracte
 studio_ee_element_patch_failed: 'Element with type %type% with ID %id% could not be updated: %message%'
 studio_ee_element_rewrite_references_failed: 'Element references with type %type% with ID %id% could not be rewritten: %message%'
 studio_ee_element_tag_operation_failed: 'Could not %operation% tags for element type %type% and ID %id%: %message%'
-studio_ee_no_element_data_found: 'No data found'
+studio_ee_no_element_data_found: No data found
 studio_ee_job_create_download_zip: Create Download Zip
 studio_ee_job_clone_assets: Clone Assets
 studio_ee_job_upload_zip_file: Upload Zip File

--- a/translations/studio.es.yaml
+++ b/translations/studio.es.yaml
@@ -17,7 +17,7 @@ studio_ee_csv_data_collection_failed: 'Los datos para la exportación CSV no se 
 studio_ee_element_patch_failed: 'El elemento de tipo %type% con ID %id% no se pudo actualizar: %message%'
 studio_ee_element_rewrite_references_failed: 'Las referencias del elemento de tipo %type% con ID %id% no se pudieron reescribir: %message%'
 studio_ee_element_tag_operation_failed: 'No se pudo ejecutar %operation% en las etiquetas del elemento de tipo %type% con ID %id%: %message%'
-studio_ee_no_element_data_found: 'No se encontraron datos'
+studio_ee_no_element_data_found: No se encontraron datos
 studio_ee_job_create_download_zip: Crear ZIP de descarga
 studio_ee_job_clone_assets: Clonar assets
 studio_ee_job_upload_zip_file: Cargar archivo ZIP

--- a/translations/studio.fr.yaml
+++ b/translations/studio.fr.yaml
@@ -17,7 +17,7 @@ studio_ee_csv_data_collection_failed: "Les données pour l'export CSV n'ont pas 
 studio_ee_element_patch_failed: "L'élément de type %type% avec l'ID %id% n'a pas pu être mis à jour : %message%"
 studio_ee_element_rewrite_references_failed: "Les références de l'élément de type %type% avec l'ID %id% n'ont pas pu être réécrites : %message%"
 studio_ee_element_tag_operation_failed: "Impossible d'effectuer %operation% sur les tags de l'élément de type %type% avec l'ID %id% : %message%"
-studio_ee_no_element_data_found: 'Aucune donnée trouvée'
+studio_ee_no_element_data_found: Aucune donnée trouvée
 studio_ee_job_create_download_zip: Créer le ZIP de téléchargement
 studio_ee_job_clone_assets: Cloner les assets
 studio_ee_job_upload_zip_file: Téléverser le fichier ZIP

--- a/translations/studio.it.yaml
+++ b/translations/studio.it.yaml
@@ -17,7 +17,7 @@ studio_ee_csv_data_collection_failed: "I dati per l'esportazione CSV non sono st
 studio_ee_element_patch_failed: "L'elemento di tipo %type% con ID %id% non è stato aggiornato: %message%"
 studio_ee_element_rewrite_references_failed: "I riferimenti dell'elemento di tipo %type% con ID %id% non sono stati riscritti: %message%"
 studio_ee_element_tag_operation_failed: "Impossibile eseguire %operation% sui tag dell'elemento di tipo %type% con ID %id%: %message%"
-studio_ee_no_element_data_found: 'Nessun dato trovato'
+studio_ee_no_element_data_found: Nessun dato trovato
 studio_ee_job_create_download_zip: Crea ZIP per il download
 studio_ee_job_clone_assets: Clona asset
 studio_ee_job_upload_zip_file: Carica file ZIP

--- a/translations/studio.no.yaml
+++ b/translations/studio.no.yaml
@@ -17,7 +17,7 @@ studio_ee_csv_data_collection_failed: 'Data for CSV-eksporten kunne ikke hentes 
 studio_ee_element_patch_failed: 'Element av type %type% med ID %id% kunne ikke oppdateres: %message%'
 studio_ee_element_rewrite_references_failed: 'Referanser for element av type %type% med ID %id% kunne ikke skrives om: %message%'
 studio_ee_element_tag_operation_failed: 'Kunne ikke utføre %operation% på tagger for element av type %type% med ID %id%: %message%'
-studio_ee_no_element_data_found: 'Ingen data funnet'
+studio_ee_no_element_data_found: Ingen data funnet
 studio_ee_job_create_download_zip: Opprett nedlastings-ZIP
 studio_ee_job_clone_assets: Klon assets
 studio_ee_job_upload_zip_file: Last opp ZIP-fil

--- a/translations/studio.sv.yaml
+++ b/translations/studio.sv.yaml
@@ -17,7 +17,7 @@ studio_ee_csv_data_collection_failed: 'Data för CSV-exporten kunde inte extrahe
 studio_ee_element_patch_failed: 'Element av typ %type% med ID %id% kunde inte uppdateras: %message%'
 studio_ee_element_rewrite_references_failed: 'Referenser för element av typ %type% med ID %id% kunde inte skrivas om: %message%'
 studio_ee_element_tag_operation_failed: 'Kunde inte utföra %operation% på taggar för element av typ %type% med ID %id%: %message%'
-studio_ee_no_element_data_found: 'Ingen data hittades'
+studio_ee_no_element_data_found: Ingen data hittades
 studio_ee_job_create_download_zip: Skapa nedladdnings-ZIP
 studio_ee_job_clone_assets: Klona assets
 studio_ee_job_upload_zip_file: Ladda upp ZIP-fil


### PR DESCRIPTION
## Changes in this pull request
https://github.com/pimcore/studio-ui-bundle/issues/3207

Remove unnecessary quotes from translation YAML files. Only quotes required by YAML syntax are kept (interpolation placeholders, colons, special characters, boolean-like values, etc.).

## Additional info
- 7 unnecessary quotes removed across 7 files
- Validated with yaml.safe_load() — all values remain strings, no semantic changes