### PR TITLE
[DataObjects] localized fields sometimes missing fields for empty data

### DIFF
--- a/src/DataObject/Data/Adapter/LocalizedFieldsAdapter.php
+++ b/src/DataObject/Data/Adapter/LocalizedFieldsAdapter.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**

--- a/src/DataObject/Data/Adapter/LocalizedFieldsAdapter.php
+++ b/src/DataObject/Data/Adapter/LocalizedFieldsAdapter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -136,7 +137,7 @@ final readonly class LocalizedFieldsAdapter implements
             ElementPermissions::LANGUAGE_VIEW_PERMISSIONS
         );
 
-        $attributes = array_keys(reset($originalValue));
+        $attributes = array_keys(array_merge(...array_values($originalValue)));
         $result = [];
         foreach ($attributes as $attribute) {
             foreach ($languages as $language) {


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-ui-bundle/issues/3338

## Additional info
Unfilled fields for the first language caused these fields to be dropped entirely in the API response, even though the fields may have been filled for other languages.
Fixed by taking all languages and their fields into account.