### PR TITLE
[Custom Reports]: Make element_type and element_class_id optional in CsvCreationHandler

### DIFF
--- a/src/ExecutionEngine/AutomationAction/AbstractHandler.php
+++ b/src/ExecutionEngine/AutomationAction/AbstractHandler.php
@@ -156,6 +156,16 @@ class AbstractHandler extends AbstractAutomationActionHandler
         throw new EnvironmentException('How did I get here?');
     }
 
+    protected function extractOptionalConfigFieldFromJobStepConfig(
+        GenericExecutionEngineMessageInterface $message,
+        string $key,
+        mixed $default = null,
+    ): mixed {
+        $config = $this->getCurrentJobStepConfig($message);
+
+        return array_key_exists($key, $config) ? $config[$key] : $default;
+    }
+
     protected function updateContextArrayValues(JobRun $jobRun, string $key, array $value): void
     {
         $context = $jobRun->getContext();

--- a/src/Export/ExecutionEngine/AutomationAction/Messenger/Handler/CsvCreationHandler.php
+++ b/src/Export/ExecutionEngine/AutomationAction/Messenger/Handler/CsvCreationHandler.php
@@ -22,7 +22,6 @@ use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Trait\HandlerProgres
 use Pimcore\Bundle\StudioBackendBundle\Export\ExecutionEngine\AutomationAction\Messenger\Messages\CsvCreationMessage;
 use Pimcore\Bundle\StudioBackendBundle\Export\Model\GridExportData;
 use Pimcore\Bundle\StudioBackendBundle\Export\Service\ExportServiceInterface;
-use Pimcore\Bundle\StudioBackendBundle\Export\Util\Trait\ExportCreationHandlerSetupTrait;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\PublishServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\UserTopicServiceInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -33,7 +32,6 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final class CsvCreationHandler extends AbstractHandler
 {
-    use ExportCreationHandlerSetupTrait;
     use HandlerProgressTrait;
 
     public function __construct(
@@ -66,8 +64,8 @@ final class CsvCreationHandler extends AbstractHandler
 
         $columns = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CONFIG_COLUMNS->value);
         $settings = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CONFIG_CONFIGURATION->value);
-        $elementType = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::ELEMENT_TYPE->value);
-        $classId = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::ELEMENT_CLASS_ID->value);
+        $elementType = $this->extractOptionalConfigFieldFromJobStepConfig($message, StepConfig::ELEMENT_TYPE->value);
+        $classId = $this->extractOptionalConfigFieldFromJobStepConfig($message, StepConfig::ELEMENT_CLASS_ID->value);
         $headers = $settings[StepConfig::SETTINGS_HEADER->value] ?? StepConfig::SETTINGS_HEADER_NO_HEADER->value;
         $delimiter = $settings[StepConfig::SETTINGS_DELIMITER->value] ?? null;
 
@@ -105,5 +103,25 @@ final class CsvCreationHandler extends AbstractHandler
             $jobRun,
             $this->getJobStep($message)->getName()
         );
+    }
+
+    protected function configureStep(): void
+    {
+        $this->stepConfiguration->setRequired(StepConfig::CONFIG_CONFIGURATION->value);
+        $this->stepConfiguration->setAllowedTypes(
+            StepConfig::CONFIG_CONFIGURATION->value,
+            StepConfig::CONFIG_TYPE_ARRAY->value
+        );
+        $this->stepConfiguration->setRequired(StepConfig::CONFIG_COLUMNS->value);
+        $this->stepConfiguration->setAllowedTypes(
+            StepConfig::CONFIG_COLUMNS->value,
+            StepConfig::CONFIG_TYPE_ARRAY->value
+        );
+        $this->stepConfiguration->setDefaults([
+            StepConfig::CONFIG_COLUMNS->value => [],
+            StepConfig::CONFIG_CONFIGURATION->value => [],
+            StepConfig::ELEMENT_TYPE->value => null,
+            StepConfig::ELEMENT_CLASS_ID->value => null,
+        ]);
     }
 }


### PR DESCRIPTION
## Problem

The custom report CSV export fails with:

> The required options "element_class_id", "element_type" are missing.

`CsvCreationHandler` uses `ExportCreationHandlerSetupTrait` which marks `element_type`, `element_class_id`, and `columns` as required step config fields. This is correct for element grid exports (assets, data-objects), but the custom report flow reuses the same `CsvCreationMessage` / `CsvCreationHandler` without those fields — custom reports are not tied to any element type, so the collection step pre-builds all CSV data itself.

## Fix

- Remove `ExportCreationHandlerSetupTrait` from `CsvCreationHandler` and override `configureStep` directly: only `CONFIG_CONFIGURATION` and `CONFIG_COLUMNS` remain required (with empty-array defaults); `ELEMENT_TYPE` and `ELEMENT_CLASS_ID` become optional with `null` defaults.
- Add `extractOptionalConfigFieldFromJobStepConfig` helper to `AbstractHandler` for safe extraction with a default value.
- Switch `CsvCreationHandler` to use the optional extractor for `element_type` and `element_class_id`.

The existing element-grid CSV export flow is unaffected — it still provides all fields, they are just no longer enforced at the step-config validation level.