### PR TITLE
[DataObjects] [Search] fix missing localized fields in search preview

### DIFF
--- a/src/DataObject/Data/Adapter/LocalizedFieldsAdapter.php
+++ b/src/DataObject/Data/Adapter/LocalizedFieldsAdapter.php
@@ -199,7 +199,7 @@ final readonly class LocalizedFieldsAdapter implements
             return $data;
         }
         $language = $this->getPreviewLanguage($value);
-        $attributes = array_keys(reset($originalValue));
+        $attributes = array_keys(array_merge(...array_values($originalValue)));
 
         foreach ($attributes as $attribute) {
             try {


### PR DESCRIPTION
## Changes in this pull request
Related to https://github.com/pimcore/studio-ui-bundle/issues/3338

## Additional info
The bug in the linked issue also applied to localized fields in the search element preview. Applied change from #1766 to fix