### PR TITLE
[Tag]: Incorrect permission check in tags

### DIFF
--- a/src/Asset/Controller/Export/ZipFolderController.php
+++ b/src/Asset/Controller/Export/ZipFolderController.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Service\ExecutionEngine\ZipServiceI
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\MaxFileSizeExceededException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\StreamResourceNotFoundException;
@@ -48,8 +49,12 @@ final class ZipFolderController extends AbstractApiController
     }
 
     /**
-     * @throws ForbiddenException|NotFoundException|StreamResourceNotFoundException
-     * @throws EnvironmentException|MaxFileSizeExceededException
+     * @throws ForbiddenException
+     * @throws NotFoundException
+     * @throws StreamResourceNotFoundException
+     * @throws EnvironmentException
+     * @throws MaxFileSizeExceededException
+     * @throws InvalidQueryTypeException
      */
     #[Route('/assets/export/zip/folder', name: 'pimcore_studio_api_asset_export_zip_folder', methods: ['POST'])]
     #[IsGranted(UserPermissions::ASSETS->value)]

--- a/src/Asset/Controller/Grid/GetController.php
+++ b/src/Asset/Controller/Grid/GetController.php
@@ -17,6 +17,8 @@ use OpenApi\Attributes\Post;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\GdiParsingException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Attribute\Property\GridCollection;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Attribute\Request\GridRequestBody;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
@@ -46,7 +48,10 @@ final class GetController extends AbstractApiController
     }
 
     /**
-     * @throws InvalidArgumentException|GdiParsingException
+     * @throws InvalidArgumentException
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
+     * @throws GdiParsingException
      */
     #[Route('/assets/grid', name: 'pimcore_studio_api_get_asset_grid', methods: ['POST'])]
     #[IsGranted(UserPermissions::ASSETS->value)]

--- a/src/Asset/Service/AssetService.php
+++ b/src/Asset/Service/AssetService.php
@@ -26,19 +26,14 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Image;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Text;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Unknown;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Type\Video;
-use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\AssetQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Provider\AssetQueryProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Request\ElementParameters;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\SearchIndexFilterInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\AssetSearchServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidFilterServiceTypeException;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidFilterTypeException;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Filter\Service\FilterServiceProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
@@ -60,6 +55,7 @@ final readonly class AssetService implements AssetServiceInterface
     use UserPermissionTrait;
 
     public function __construct(
+        private AssetQueryProviderInterface $assetQueryProvider,
         private AssetSearchServiceInterface $assetSearchService,
         private AssetServiceResolverInterface $assetServiceResolver,
         private EventDispatcherInterface $eventDispatcher,
@@ -71,15 +67,16 @@ final readonly class AssetService implements AssetServiceInterface
     }
 
     /**
-     * @throws InvalidFilterServiceTypeException|SearchException|InvalidQueryTypeException|InvalidFilterTypeException
+     * {@inheritdoc}
      */
     public function getAssets(ElementParameters $parameters): Collection
     {
         /** @var SearchIndexFilterInterface $filterService */
         $filterService = $this->filterServiceProvider->create(SearchIndexFilterInterface::SERVICE_TYPE);
 
-        /** @var AssetQueryInterface $assetQuery */
+        $assetQuery = $this->assetQueryProvider->createAssetQuery();
         $assetQuery = $filterService->applyFilters(
+            $assetQuery,
             $parameters,
             ElementTypes::TYPE_ASSET
         );
@@ -99,7 +96,7 @@ final readonly class AssetService implements AssetServiceInterface
     }
 
     /**
-     * @throws SearchException|NotFoundException|UserNotFoundException
+     * {@inheritdoc}
      */
     public function getAsset(
         int $id,
@@ -121,7 +118,7 @@ final readonly class AssetService implements AssetServiceInterface
     }
 
     /**
-     * @throws SearchException|NotFoundException
+     * {@inheritdoc}
      */
     public function getAssetForUser(
         int $id,
@@ -135,7 +132,7 @@ final readonly class AssetService implements AssetServiceInterface
     }
 
     /**
-     * @throws SearchException|NotFoundException
+     * {@inheritdoc}
      */
     public function getAssetFolder(int $id, bool $checkPermissionsForCurrentUser = true): AssetFolder
     {
@@ -154,7 +151,7 @@ final readonly class AssetService implements AssetServiceInterface
     }
 
     /**
-     * @throws SearchException|NotFoundException
+     * {@inheritdoc}
      */
     public function getAssetFolderForUser(int $id, UserInterface $user): AssetFolder
     {
@@ -170,7 +167,7 @@ final readonly class AssetService implements AssetServiceInterface
     }
 
     /**
-     * @throws SearchException
+     * {@inheritdoc}
      */
     public function assetFolderExists(int $id, bool $checkPermissionsForCurrentUser = true): bool
     {
@@ -184,7 +181,7 @@ final readonly class AssetService implements AssetServiceInterface
     }
 
     /**
-     * @throws SearchException
+     * {@inheritdoc}
      */
     public function assetFolderExistsForUser(int $id, UserInterface $user): bool
     {
@@ -198,7 +195,7 @@ final readonly class AssetService implements AssetServiceInterface
     }
 
     /**
-     * @throws ForbiddenException|NotFoundException
+     * {@inheritdoc}
      */
     public function getAssetElement(
         UserInterface $user,
@@ -215,7 +212,7 @@ final readonly class AssetService implements AssetServiceInterface
     }
 
     /**
-     * @throws ForbiddenException|NotFoundException
+     * {@inheritdoc}
      */
     public function getAssetElementByPath(
         UserInterface $user,
@@ -252,7 +249,7 @@ final readonly class AssetService implements AssetServiceInterface
     }
 
     /**
-     * @throws DatabaseException|ForbiddenException
+     * {@inheritdoc}
      */
     public function clearThumbnails(int $id): void
     {

--- a/src/Asset/Service/ExecutionEngine/ZipService.php
+++ b/src/Asset/Service/ExecutionEngine/ZipService.php
@@ -152,6 +152,9 @@ final readonly class ZipService implements ZipServiceInterface
         return $this->createJobRunAndStartExecution($parameter->getAssets());
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function generateZipFileForFolders(ExportFolderFileParameter $parameter): int
     {
         $folders = $parameter->getFolders();

--- a/src/Asset/Service/ExecutionEngine/ZipServiceInterface.php
+++ b/src/Asset/Service/ExecutionEngine/ZipServiceInterface.php
@@ -17,6 +17,7 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter\ExportAssetFilePara
 use Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter\ExportFolderFileParameter;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\MaxFileSizeExceededException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Model\Asset;
@@ -70,6 +71,9 @@ interface ZipServiceInterface
      */
     public function generateZipFileForAssets(ExportAssetFileParameter $parameter): int;
 
+    /**
+     * @throws InvalidQueryTypeException
+     */
     public function generateZipFileForFolders(ExportFolderFileParameter $parameter): int;
 
     /**

--- a/src/DataIndex/Filter/FilterInterface.php
+++ b/src/DataIndex/Filter/FilterInterface.php
@@ -20,5 +20,12 @@ use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
  */
 interface FilterInterface
 {
+    /**
+     * @template T of QueryInterface
+     *
+     * @param T $query
+     *
+     * @return T
+     */
     public function apply(mixed $parameters, QueryInterface $query): QueryInterface;
 }

--- a/src/DataIndex/Filter/TagFilter.php
+++ b/src/DataIndex/Filter/TagFilter.php
@@ -39,9 +39,11 @@ final class TagFilter implements FilterInterface
         
         $user = $query->getSearch()->getUser();
         if (!$user || !$user->isAllowed(UserPermissions::TAGS_SEARCH->value)) {
-            throw new ForbiddenException(sprintf(
-                'User does not have permission: %s',
-                UserPermissions::TAGS_SEARCH->value)
+            throw new ForbiddenException(
+                sprintf(
+                    'User does not have permission: %s',
+                    UserPermissions::TAGS_SEARCH->value
+                )
             );
         }
 

--- a/src/DataIndex/Filter/TagFilter.php
+++ b/src/DataIndex/Filter/TagFilter.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter;
 
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\SimpleColumnFiltersParameterInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 
 /**
  * @internal
@@ -33,6 +35,14 @@ final class TagFilter implements FilterInterface
 
         if (!$filter) {
             return $query;
+        }
+        
+        $user = $query->getSearch()->getUser();
+        if (!$user || !$user->isAllowed(UserPermissions::TAGS_SEARCH->value)) {
+            throw new ForbiddenException(sprintf(
+                'User does not have permission: %s',
+                UserPermissions::TAGS_SEARCH->value)
+            );
         }
 
         $filterValue = $filter->getFilterValue();

--- a/src/DataIndex/Grid/GridSearch.php
+++ b/src/DataIndex/Grid/GridSearch.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\DataIndex\DocumentSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\AssetQueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\DataObjectQueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\DocumentQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\SearchIndexFilterInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\AssetSearchServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\DataObjectSearchServiceInterface;
@@ -30,6 +31,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
+use Pimcore\Bundle\StudioBackendBundle\Factory\QueryFactoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\Filter\Service\FilterServiceProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
@@ -46,10 +48,11 @@ final readonly class GridSearch implements GridSearchInterface
     private SearchIndexFilterInterface $filterService;
 
     public function __construct(
-        private FilterServiceProviderInterface $filterServiceProvider,
         private AssetSearchServiceInterface $assetSearchService,
         private DataObjectSearchServiceInterface $dataObjectSearchService,
         private DocumentSearchServiceInterface $documentSearchService,
+        private FilterServiceProviderInterface $filterServiceProvider,
+        private QueryFactoryInterface $queryFactory,
         private SecurityServiceInterface $securityService
     ) {
         $this->filterService = $this->filterServiceProvider->create(SearchIndexFilterInterface::SERVICE_TYPE);
@@ -99,13 +102,8 @@ final readonly class GridSearch implements GridSearchInterface
         GridParameter $gridParameter,
         UserInterface $user
     ): AssetSearchResult|DataObjectSearchResult|DocumentSearchResult {
-        $filter = $gridParameter->getFilters();
-        $type = $this->getStudioElementType($type);
-        $filter = $this->setFilterPath($filter, $type, $gridParameter->getFolderId(), $user);
-
         /** @var AssetQueryInterface|DataObjectQueryInterface|DocumentQueryInterface $query */
-        $query = $this->filterService->applyFilters($filter, $type);
-        $query->setUser($user);
+        $query = $this->getSearchQuery($type, $gridParameter, $user);
 
         return match($type) {
             ElementTypes::TYPE_ASSET => $this->assetSearchService->searchAssets($query),
@@ -120,19 +118,31 @@ final readonly class GridSearch implements GridSearchInterface
         GridParameter $gridParameter,
         UserInterface $user
     ): array {
-        $filter = $gridParameter->getFilters();
-        $type = $this->getStudioElementType($type);
-        $filter = $this->setFilterPath($filter, $type, $gridParameter->getFolderId(), $user);
-
         /** @var AssetQueryInterface|DataObjectQueryInterface $query */
-        $query = $this->filterService->applyFilters($filter, $type);
-        $query->setUser($user);
+        $query = $this->getSearchQuery($type, $gridParameter, $user);
 
         return match($type) {
             ElementTypes::TYPE_ASSET => $this->assetSearchService->fetchAssetIds($query),
             ElementTypes::TYPE_DATA_OBJECT => $this->dataObjectSearchService->fetchDataObjectIds($query),
             default => throw new InvalidElementTypeException($type)
         };
+    }
+
+    private function getSearchQuery(
+        string $type,
+        GridParameter $gridParameter,
+        UserInterface $user
+    ): QueryInterface
+    {
+        $filter = $gridParameter->getFilters();
+        $type = $this->getStudioElementType($type);
+        $filter = $this->setFilterPath($filter, $type, $gridParameter->getFolderId(), $user);
+
+        $query = $this->queryFactory->create($type);
+        $query = $this->filterService->applyFilters($query, $filter, $type);
+        $query->setUser($user);
+
+        return $query;
     }
 
     private function setFilterPath(

--- a/src/DataIndex/Grid/GridSearch.php
+++ b/src/DataIndex/Grid/GridSearch.php
@@ -27,10 +27,8 @@ use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\DataObjectSearchService
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\DocumentSearchServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\DataObject;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\Type\DataObjectFolder;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
 use Pimcore\Bundle\StudioBackendBundle\Factory\QueryFactoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\Filter\Service\FilterServiceProviderInterface;
@@ -59,7 +57,7 @@ final readonly class GridSearch implements GridSearchInterface
     }
 
     /**
-     * @throws NotFoundException|SearchException|InvalidArgumentException
+     * {@inheritdoc}
      */
     public function searchAssets(GridParameter $gridParameter): AssetSearchResult
     {
@@ -70,6 +68,9 @@ final readonly class GridSearch implements GridSearchInterface
         );
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function searchAssetsForUser(GridParameter $gridParameter, UserInterface $user): AssetSearchResult
     {
         return $this->searchElementsForUser(
@@ -79,6 +80,9 @@ final readonly class GridSearch implements GridSearchInterface
         );
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function searchDataObjects(GridParameter $gridParameter): DataObjectSearchResult
     {
         return $this->searchElementsForUser(
@@ -88,6 +92,9 @@ final readonly class GridSearch implements GridSearchInterface
         );
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function searchDocuments(GridParameter $gridParameter): DocumentSearchResult
     {
         return $this->searchElementsForUser(
@@ -97,6 +104,9 @@ final readonly class GridSearch implements GridSearchInterface
         );
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function searchElementsForUser(
         string $type,
         GridParameter $gridParameter,
@@ -113,6 +123,9 @@ final readonly class GridSearch implements GridSearchInterface
         };
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function searchElementIdsForUser(
         string $type,
         GridParameter $gridParameter,

--- a/src/DataIndex/Grid/GridSearchInterface.php
+++ b/src/DataIndex/Grid/GridSearchInterface.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Grid;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\AssetSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\DataObjectSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\DocumentSearchResult;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
@@ -37,12 +38,18 @@ interface GridSearchInterface
 
     public function searchDocuments(GridParameter $gridParameter): DocumentSearchResult;
 
+    /**
+     * @throws InvalidQueryTypeException
+     */
     public function searchElementsForUser(
         string $type,
         GridParameter $gridParameter,
         UserInterface $user
     ): AssetSearchResult|DataObjectSearchResult|DocumentSearchResult;
 
+    /**
+     * @throws InvalidQueryTypeException
+     */
     public function searchElementIdsForUser(
         string $type,
         GridParameter $gridParameter,

--- a/src/DataIndex/Grid/GridSearchInterface.php
+++ b/src/DataIndex/Grid/GridSearchInterface.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Grid;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\AssetSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\DataObjectSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\DocumentSearchResult;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
@@ -28,14 +29,23 @@ use Pimcore\Model\UserInterface;
 interface GridSearchInterface
 {
     /**
-     * @throws NotFoundException|SearchException
+     *  @throws InvalidQueryTypeException|InvalidElementTypeException
      */
     public function searchAssets(GridParameter $gridParameter): AssetSearchResult;
 
+    /**
+     *  @throws InvalidQueryTypeException|InvalidElementTypeException
+     */
     public function searchAssetsForUser(GridParameter $gridParameter, UserInterface $user): AssetSearchResult;
 
+    /**
+     *  @throws InvalidQueryTypeException|InvalidElementTypeException
+     */
     public function searchDataObjects(GridParameter $gridParameter): DataObjectSearchResult;
 
+    /**
+     *  @throws InvalidQueryTypeException|InvalidElementTypeException
+     */
     public function searchDocuments(GridParameter $gridParameter): DocumentSearchResult;
 
     /**

--- a/src/DataIndex/Query/TreeQuery.php
+++ b/src/DataIndex/Query/TreeQuery.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Factory\QueryFactoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\CollectionParametersInterface;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\ElementTreeWidgetConfig;
 use Pimcore\Bundle\StudioBackendBundle\Setting\Service\SettingsServiceInterface;
@@ -33,6 +34,7 @@ use function sprintf;
 final readonly class TreeQuery implements TreeQueryInterface
 {
     public function __construct(
+        private QueryFactoryInterface $queryFactory,
         private SettingsServiceInterface $settingsService,
         private DataObjectServiceInterface $dataObjectService,
         private ElementServiceInterface $elementService,
@@ -49,7 +51,9 @@ final readonly class TreeQuery implements TreeQueryInterface
         ?int $parentId = null,
     ): QueryInterface {
         $type = $widget->getElementType();
-        $query = $filterService->applyFilters($this->getQueryParameters($widget, $parentId), $type);
+        $query = $this->queryFactory->create($type);
+        $query = $filterService->applyFilters($query, $this->getQueryParameters($widget, $parentId), $type);
+
         if ($type === ElementTypes::TYPE_DATA_OBJECT) {
             $this->handleTreeSorting(
                 $type,

--- a/src/DataIndex/SearchIndexFilter.php
+++ b/src/DataIndex/SearchIndexFilter.php
@@ -18,7 +18,6 @@ use Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\Filters;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidFilterTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
-use Pimcore\Bundle\StudioBackendBundle\Factory\QueryFactoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
 
@@ -28,17 +27,21 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
 final readonly class SearchIndexFilter implements SearchIndexFilterInterface
 {
     public function __construct(
-        private FilterLoaderInterface $filterLoader,
-        private QueryFactoryInterface $queryFactory
+        private FilterLoaderInterface $filterLoader
     ) {
     }
 
     /**
+     * @template T of QueryInterface
+     *
+     * @param T $query
+     *
+     * @return T
+     *
      * @throws InvalidQueryTypeException|InvalidFilterTypeException
      */
-    public function applyFilters(mixed $parameters, string $type): QueryInterface
+    public function applyFilters(QueryInterface $query, mixed $parameters, string $type): QueryInterface
     {
-        $query = $this->queryFactory->create($type);
         // apply default filters
         $filters = $this->filterLoader->loadFilters();
 

--- a/src/DataIndex/SearchIndexFilterInterface.php
+++ b/src/DataIndex/SearchIndexFilterInterface.php
@@ -15,7 +15,6 @@ namespace Pimcore\Bundle\StudioBackendBundle\DataIndex;
 
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidFilterTypeException;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Filter\Service\FilterServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\CollectionParametersInterface;
 
@@ -24,10 +23,20 @@ use Pimcore\Bundle\StudioBackendBundle\MappedParameter\CollectionParametersInter
  */
 interface SearchIndexFilterInterface extends FilterServiceInterface
 {
-    public const SERVICE_TYPE = 'search_index_filter';
+    public const string SERVICE_TYPE = 'search_index_filter';
 
     /**
-     * @throws InvalidQueryTypeException|InvalidFilterTypeException
+     * @template T of QueryInterface
+     *
+     * @param T $query
+     *
+     * @return T
+     *
+     * @throws InvalidFilterTypeException
      */
-    public function applyFilters(CollectionParametersInterface $parameters, string $type): QueryInterface;
+    public function applyFilters(
+        QueryInterface $query,
+        CollectionParametersInterface $parameters,
+        string $type
+    ): QueryInterface;
 }

--- a/src/DataObject/Controller/Grid/GetController.php
+++ b/src/DataObject/Controller/Grid/GetController.php
@@ -17,6 +17,8 @@ use Exception;
 use OpenApi\Attributes\Post;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Attribute\Property\GridCollection;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Attribute\Request\GridRequestBody;
@@ -49,8 +51,10 @@ final class GetController extends AbstractApiController
 
     /**
      * @throws InvalidArgumentException
-     * @throws Exception
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
      * @throws NotFoundException
+     * @throws Exception
      */
     #[Route('/data-objects/grid/{classId}', name: 'pimcore_studio_api_get_data_object_grid', methods: ['POST'])]
     #[IsGranted(UserPermissions::DATA_OBJECTS->value)]

--- a/src/DataObject/Service/DataObjectService.php
+++ b/src/DataObject/Service/DataObjectService.php
@@ -17,6 +17,7 @@ use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Provider\DataObjectQueryProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\DataObjectQuery;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Request\DataObjectParameters;
@@ -73,6 +74,7 @@ final readonly class DataObjectService implements DataObjectServiceInterface
     public function __construct(
         private ClassDefinitionResolverInterface $classDefinitionResolver,
         private DataServiceInterface $dataService,
+        private DataObjectQueryProviderInterface $dataObjectQueryProvider,
         private DataObjectSearchServiceInterface $dataObjectSearchService,
         private DataObjectServiceResolverInterface $dataObjectServiceResolver,
         private FactoryInterface $factory,
@@ -118,7 +120,9 @@ final readonly class DataObjectService implements DataObjectServiceInterface
         /** @var SearchIndexFilterInterface $filterService */
         $filterService = $this->filterServiceProvider->create(SearchIndexFilterInterface::SERVICE_TYPE);
 
+        $query = $this->dataObjectQueryProvider->createDataObjectQuery();
         $query = $filterService->applyFilters(
+            $query,
             $parameters,
             ElementTypes::TYPE_DATA_OBJECT
         );

--- a/src/Document/Service/DocumentService.php
+++ b/src/Document/Service/DocumentService.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Document\Service;
 
 use Pimcore\Bundle\StaticResolverBundle\Models\Document\DocumentServiceResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Provider\DocumentQueryProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\DocumentQueryInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Request\ElementParameters;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\SearchIndexFilterInterface;
@@ -50,6 +51,7 @@ final readonly class DocumentService implements DocumentServiceInterface
     public function __construct(
         private CreateServiceInterface $createService,
         private DataServiceInterface $dataService,
+        private DocumentQueryProviderInterface $documentQueryProvider,
         private DocumentSearchServiceInterface $documentSearchService,
         private DocumentServiceResolverInterface $documentServiceResolver,
         private EventDispatcherInterface $eventDispatcher,
@@ -82,8 +84,9 @@ final readonly class DocumentService implements DocumentServiceInterface
         /** @var SearchIndexFilterInterface $filterService */
         $filterService = $this->filterServiceProvider->create(SearchIndexFilterInterface::SERVICE_TYPE);
 
-        /** @var DocumentQueryInterface $documentQuery */
+        $documentQuery = $this->documentQueryProvider->createDocumentQuery();
         $documentQuery = $filterService->applyFilters(
+            $documentQuery,
             $parameters,
             ElementTypes::TYPE_DOCUMENT
         );
@@ -146,7 +149,7 @@ final readonly class DocumentService implements DocumentServiceInterface
     }
 
     /**
-     * @throws ForbiddenException|NotFoundException
+     * {@inheritdoc}
      */
     public function getDocumentElementByPath(UserInterface $user, string $path): DocumentModel
     {
@@ -172,7 +175,7 @@ final readonly class DocumentService implements DocumentServiceInterface
     }
 
     /**
-     * @throws InvalidElementTypeException|NotFoundException
+     * {@inheritdoc}
      */
     private function getDocumentDetailData(DocumentDetail $document): void
     {

--- a/src/Grid/Service/GridSearchServiceInterface.php
+++ b/src/Grid/Service/GridSearchServiceInterface.php
@@ -15,6 +15,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service;
 
 use Exception;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\SearchGridParameter;
 use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
@@ -26,11 +28,15 @@ interface GridSearchServiceInterface
 {
     /**
      * @throws InvalidArgumentException
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
      */
     public function getAssetSearchGrid(SearchGridParameter $gridParameter): Collection;
 
     /**
      * @throws InvalidArgumentException
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
      * @throws NotFoundException
      * @throws Exception
      */
@@ -38,6 +44,8 @@ interface GridSearchServiceInterface
 
     /**
      * @throws InvalidArgumentException
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
      */
     public function getDocumentSearchGrid(SearchGridParameter $searchParameter): Collection;
 }

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -110,8 +110,7 @@ final class GridService implements GridServiceInterface
     }
 
     /**
-     * @throws NotFoundException
-     * @throws Exception
+     * {@inheritdoc}
      */
     public function getDataObjectGrid(
         GridParameter $gridParameter,

--- a/src/Grid/Service/GridServiceInterface.php
+++ b/src/Grid/Service/GridServiceInterface.php
@@ -15,6 +15,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service;
 
 use Exception;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnCollectorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnDefinitionInterface;
@@ -69,11 +71,15 @@ interface GridServiceInterface
 
     /**
      * @throws InvalidArgumentException
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
      */
     public function getAssetGrid(GridParameter $gridParameter): Collection;
 
     /**
      * @throws NotFoundException
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
      * @throws Exception
      */
     public function getDataObjectGrid(
@@ -83,6 +89,8 @@ interface GridServiceInterface
 
     /**
      * @throws InvalidArgumentException
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
      */
     public function getDocumentGrid(GridParameter $gridParameter): Collection;
 

--- a/src/Search/Controller/Asset/GetSearchResultController.php
+++ b/src/Search/Controller/Asset/GetSearchResultController.php
@@ -16,6 +16,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\Search\Controller\Asset;
 use OpenApi\Attributes\Post;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Attribute\Property\GridCollection;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Attribute\Request\SearchGridRequestBody;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\SearchGridParameter;
@@ -46,6 +48,8 @@ final class GetSearchResultController extends AbstractApiController
 
     /**
      * @throws InvalidArgumentException
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
      */
     #[Route('/search/assets', name: 'pimcore_studio_api_get_asset_search', methods: ['POST'])]
     #[IsGranted(UserPermissions::ASSETS->value)]

--- a/src/Search/Controller/DataObject/GetSearchResultController.php
+++ b/src/Search/Controller/DataObject/GetSearchResultController.php
@@ -17,6 +17,8 @@ use Exception;
 use OpenApi\Attributes\Post;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Attribute\Property\GridCollection;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Attribute\Request\SearchGridRequestBody;
@@ -51,8 +53,10 @@ final class GetSearchResultController extends AbstractApiController
 
     /**
      * @throws InvalidArgumentException
-     * @throws Exception
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
      * @throws NotFoundException
+     * @throws Exception
      */
     #[Route('/search/data-objects', name: 'pimcore_studio_api_get_data_object_search', methods: ['POST'])]
     #[IsGranted(UserPermissions::DATA_OBJECTS->value)]

--- a/src/Search/Controller/Document/GetSearchResultController.php
+++ b/src/Search/Controller/Document/GetSearchResultController.php
@@ -16,6 +16,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\Search\Controller\Document;
 use OpenApi\Attributes\Post;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Attribute\Property\GridCollection;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Attribute\Request\SearchGridRequestBody;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\SearchGridParameter;
@@ -46,6 +48,8 @@ final class GetSearchResultController extends AbstractApiController
 
     /**
      * @throws InvalidArgumentException
+     * @throws InvalidQueryTypeException
+     * @throws InvalidElementTypeException
      */
     #[Route('/search/documents', name: 'pimcore_studio_api_get_document_search', methods: ['POST'])]
     #[IsGranted(UserPermissions::DOCUMENTS->value)]

--- a/src/Tag/Controller/CollectionController.php
+++ b/src/Tag/Controller/CollectionController.php
@@ -55,7 +55,7 @@ final class CollectionController extends AbstractApiController
      * @throws InvalidQueryTypeException
      */
     #[Route('/tags', name: 'pimcore_studio_api_tags', methods: ['GET'])]
-    #[IsGranted(UserPermissions::TAGS_SEARCH->value)]
+    #[IsGranted(UserPermissions::TAGS_CONFIGURATION->value)]
     #[Get(
         path: self::PREFIX . '/tags',
         operationId: 'tag_get_collection',

--- a/src/Tag/Controller/Element/CollectionController.php
+++ b/src/Tag/Controller/Element/CollectionController.php
@@ -48,7 +48,7 @@ final class CollectionController extends AbstractApiController
     }
 
     #[Route('/tags/{elementType}/{id}', name: 'pimcore_studio_api_get_element_tags', methods: ['GET'])]
-    #[IsGranted(UserPermissions::TAGS_SEARCH->value)]
+    #[IsGranted(UserPermissions::TAGS_CONFIGURATION->value)]
     #[Get(
         path: self::PREFIX . '/tags/{elementType}/{id}',
         operationId: 'tag_get_collection_for_element_by_type_and_id',

--- a/src/Tag/Controller/GetController.php
+++ b/src/Tag/Controller/GetController.php
@@ -42,7 +42,7 @@ final class GetController extends AbstractApiController
     }
 
     #[Route('/tags/{id}', name: 'pimcore_studio_api_get_tag', methods: ['GET'])]
-    #[IsGranted(UserPermissions::TAGS_SEARCH->value)]
+    #[IsGranted(UserPermissions::TAGS_CONFIGURATION->value)]
     #[Get(
         path: self::PREFIX . '/tags/{id}',
         operationId: 'tag_get_by_id',


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-backend-bundle/issues/1777

## Additional info
The permission `tags_search` was checked in the config listing but this is incorrect. The permission should be used for the grid filter only.