### PR TITLE
Add robotsTxt perspective permission to SEO context permissions

### DIFF
--- a/src/Bundle/Seo/EventSubscriber/StudioContextPermissionsSubscriber.php
+++ b/src/Bundle/Seo/EventSubscriber/StudioContextPermissionsSubscriber.php
@@ -44,5 +44,12 @@ final readonly class StudioContextPermissionsSubscriber implements EventSubscrib
                 ContextPermissionGroups::EXPERIENCE_ECOMMERCE->value
             )
         );
+
+        $this->permissionsService->add(
+            new ContextPermissionData(
+                'robotsTxt',
+                ContextPermissionGroups::EXPERIENCE_ECOMMERCE->value
+            )
+        );
     }
 }


### PR DESCRIPTION
Registers the robotsTxt navigation permission in the SEO bundle's Studio context permissions.

Needed for https://github.com/pimcore/studio-ui-bundle/pull/3396