### PR TITLE
[Tag]: Allow tags_search permission on GET tag endpoints

### DIFF
--- a/src/Tag/Controller/CollectionController.php
+++ b/src/Tag/Controller/CollectionController.php
@@ -28,13 +28,13 @@ use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
 use Pimcore\Bundle\StudioBackendBundle\Tag\MappedParameter\TagsParameters;
 use Pimcore\Bundle\StudioBackendBundle\Tag\Schema\Tag;
 use Pimcore\Bundle\StudioBackendBundle\Tag\Service\TagServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Security\PermissionsToCheck;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\PaginatedResponseTrait;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -55,7 +55,6 @@ final class CollectionController extends AbstractApiController
      * @throws InvalidQueryTypeException
      */
     #[Route('/tags', name: 'pimcore_studio_api_tags', methods: ['GET'])]
-    #[IsGranted(UserPermissions::TAGS_CONFIGURATION->value)]
     #[Get(
         path: self::PREFIX . '/tags',
         operationId: 'tag_get_collection',
@@ -81,6 +80,14 @@ final class CollectionController extends AbstractApiController
     public function getTags(
         #[MapQueryString] TagsParameters $parameters): JsonResponse
     {
+        $this->denyAccessUnlessGranted(
+            'HasOneOf',
+            new PermissionsToCheck([
+                UserPermissions::TAGS_CONFIGURATION->value,
+                UserPermissions::TAGS_SEARCH->value,
+            ])
+        );
+
         return $this->jsonResponse(['items' => $this->tagService->listTags($parameters)]);
     }
 }

--- a/src/Tag/Controller/GetController.php
+++ b/src/Tag/Controller/GetController.php
@@ -22,11 +22,11 @@ use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessRespons
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
 use Pimcore\Bundle\StudioBackendBundle\Tag\Schema\Tag;
 use Pimcore\Bundle\StudioBackendBundle\Tag\Service\TagServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Security\PermissionsToCheck;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -42,7 +42,6 @@ final class GetController extends AbstractApiController
     }
 
     #[Route('/tags/{id}', name: 'pimcore_studio_api_get_tag', methods: ['GET'])]
-    #[IsGranted(UserPermissions::TAGS_CONFIGURATION->value)]
     #[Get(
         path: self::PREFIX . '/tags/{id}',
         operationId: 'tag_get_by_id',
@@ -61,6 +60,14 @@ final class GetController extends AbstractApiController
     ])]
     public function getTags(int $id): JsonResponse
     {
+        $this->denyAccessUnlessGranted(
+            'HasOneOf',
+            new PermissionsToCheck([
+                UserPermissions::TAGS_CONFIGURATION->value,
+                UserPermissions::TAGS_SEARCH->value,
+            ])
+        );
+
         return $this->jsonResponse($this->tagService->getTag($id));
     }
 }


### PR DESCRIPTION
Related to #1777

The `GET /tags` and `GET /tags/{id}` endpoints were requiring `tags_configuration`, which blocked users who only have `tags_search` from loading the tag tree in the filter sidebar.

Both endpoints now accept either `tags_configuration` or `tags_search` using the existing `HasOneOfUserPermissionVoter`.