### PR TITLE
[Feature]: Expose jobName on running-jobs API response and add distinct job names for folder operations (#3455)

### DIFF
--- a/src/Element/EventSubscriber/PatchSubscriber.php
+++ b/src/Element/EventSubscriber/PatchSubscriber.php
@@ -44,7 +44,10 @@ final readonly class PatchSubscriber implements EventSubscriberInterface
 
     public function onStateChanged(JobRunStateChangedEvent $event): void
     {
-        if ($event->getJobName() !== Jobs::PATCH_ELEMENTS->value) {
+        if (!in_array($event->getJobName(), [
+            Jobs::PATCH_ELEMENTS->value,
+            Jobs::PATCH_FOLDER_ELEMENTS->value,
+        ], true)) {
             return;
         }
 

--- a/src/ExecutionEngine/Hydrator/JobRunListHydrator.php
+++ b/src/ExecutionEngine/Hydrator/JobRunListHydrator.php
@@ -43,6 +43,7 @@ final class JobRunListHydrator implements JobRunListHydratorInterface
             totalSteps: $totalSteps,
             creationDate: $jobRun->getCreationDate(),
             modificationDate: $jobRun->getModificationDate(),
+            jobName: $jobRun->getJob()?->getName() ?? '',
         );
     }
 

--- a/src/ExecutionEngine/Repository/JobRunRepository.php
+++ b/src/ExecutionEngine/Repository/JobRunRepository.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Pimcore\Bundle\GenericExecutionEngineBundle\Entity\JobRun;
 use Pimcore\Bundle\StudioBackendBundle\Entity\ExecutionEngine\JobRunHidden;
+use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\CollectionFilterParameter;
 
 /**
@@ -59,14 +60,15 @@ final readonly class JobRunRepository implements JobRunRepositoryInterface
         $qb->andWhere('jr.ownerId = :ownerId')
             ->setParameter('ownerId', $ownerId);
 
-        $qb->setFirstResult($parameter->getFilters()->getStart());
-        $qb->setMaxResults($parameter->getFilters()->getPageSize());
+        $filters = $parameter->getFilters() ?? new FilterParameter();
+        $qb->setFirstResult($filters->getStart());
+        $qb->setMaxResults($filters->getPageSize());
 
         $this->applyFilter($parameter, $qb);
 
         $qb->orderBy(
-            'jr.'.$parameter->getFilters()->getSortFilter()->getKey(),
-            $parameter->getFilters()->getSortFilter()->getDirection());
+            'jr.'.$filters->getSortFilter()->getKey(),
+            $filters->getSortFilter()->getDirection());
 
         // Add execution contexts condition
         $qb->andWhere('jr.executionContext IN (:executionContexts)')

--- a/src/ExecutionEngine/Schema/JobRun.php
+++ b/src/ExecutionEngine/Schema/JobRun.php
@@ -25,7 +25,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
     title: 'JobRun',
     required: [
         'id', 'ownerId', 'state', 'executionContext', 'totalElements', 'currentMessage',
-        'jobRunChildId', 'currentStep', 'totalSteps', 'creationDate', 'modificationDate',
+        'jobRunChildId', 'currentStep', 'totalSteps', 'creationDate', 'modificationDate', 'jobName',
     ],
     type: 'object'
 )]
@@ -56,6 +56,8 @@ final class JobRun implements AdditionalAttributesInterface
         private readonly ?int $creationDate = null,
         #[Property(description: 'Modification date', type: 'integer', example: null)]
         private readonly ?int $modificationDate = null,
+        #[Property(description: 'The name of the job', type: 'string', example: 'studio_ee_job_delete_assets')]
+        private readonly string $jobName = '',
     ) {
     }
 
@@ -112,5 +114,10 @@ final class JobRun implements AdditionalAttributesInterface
     public function getTotalSteps(): ?int
     {
         return $this->totalSteps;
+    }
+
+    public function getJobName(): string
+    {
+        return $this->jobName;
     }
 }

--- a/src/ExecutionEngine/Util/Jobs.php
+++ b/src/ExecutionEngine/Util/Jobs.php
@@ -21,9 +21,11 @@ enum Jobs: string
     case UPLOAD_ASSETS = 'studio_ee_job_upload_assets';
     case ZIP_FILE_UPLOAD = 'studio_ee_job_upload_zip_file';
     case CREATE_CSV = 'studio_ee_job_create_csv';
-    case COLLECT_EXPORT_FOLDER_ELEMENTS = 'studio_ee_job_collect_folder_export_elements';
+    case COLLECT_CSV_FOLDER_EXPORT_ELEMENTS = 'studio_ee_job_collect_csv_folder_export_elements';
+    case COLLECT_XLSX_FOLDER_EXPORT_ELEMENTS = 'studio_ee_job_collect_xlsx_folder_export_elements';
     case CREATE_XLSX = 'studio_ee_job_create_xlsx';
     case PATCH_ELEMENTS = 'studio_ee_job_patch_elements';
+    case PATCH_FOLDER_ELEMENTS = 'studio_ee_job_patch_folder_elements';
     case CLONE_DATA_OBJECTS = 'studio_ee_job_clone_data_objects';
     case REWRITE_REFERENCES = 'studio_ee_job_rewrite_element_references';
     case DELETE_DATA_OBJECTS = 'studio_ee_job_delete_data_objects';

--- a/src/Export/EventSubscriber/FolderCollectionSubscriber.php
+++ b/src/Export/EventSubscriber/FolderCollectionSubscriber.php
@@ -45,8 +45,10 @@ final readonly class FolderCollectionSubscriber implements EventSubscriberInterf
 
     public function onStateChanged(JobRunStateChangedEvent $event): void
     {
-        if ($event->getJobName() !== Jobs::COLLECT_EXPORT_FOLDER_ELEMENTS->value) {
-
+        if (!in_array($event->getJobName(), [
+            Jobs::COLLECT_CSV_FOLDER_EXPORT_ELEMENTS->value,
+            Jobs::COLLECT_XLSX_FOLDER_EXPORT_ELEMENTS->value,
+        ], true)) {
             return;
         }
 

--- a/src/Export/Service/ExecutionEngine/ExportService.php
+++ b/src/Export/Service/ExecutionEngine/ExportService.php
@@ -140,7 +140,9 @@ final readonly class ExportService implements ExportServiceInterface
     ): int {
         $name = $this->createJobNameByFormat($exportFormat);
         if ($isFolder) {
-            $name = Jobs::COLLECT_EXPORT_FOLDER_ELEMENTS->value;
+            $name = $exportFormat === ExportFormat::XLSX->value
+                ? Jobs::COLLECT_XLSX_FOLDER_EXPORT_ELEMENTS->value
+                : Jobs::COLLECT_CSV_FOLDER_EXPORT_ELEMENTS->value;
         }
 
         $jobRun = $this->jobExecutionAgent->startJobExecution(

--- a/src/Migrations/Version20260505124233.php
+++ b/src/Migrations/Version20260505124233.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Bundle\StudioBackendBundle\Entity\ExecutionEngine\JobRunHidden;
+
+/**
+ * @internal
+ */
+final class Version20260505124233 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Hide studio job runs added by new job types (e.g. patch_folder_elements, collect_csv/xlsx_folder_export_elements)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+            INSERT INTO ' . JobRunHidden::TABLE_NAME . ' (jobRunId)
+            SELECT jr.id
+            FROM generic_execution_engine_job_run jr
+            LEFT JOIN ' . JobRunHidden::TABLE_NAME . " jrh ON jr.id = jrh.jobRunId
+            WHERE jrh.jobRunId IS NULL
+            AND jr.executionContext IN ('studio_stop_on_error', 'studio_continue_on_error')
+        ");
+    }
+}

--- a/src/Patcher/Service/PatchService.php
+++ b/src/Patcher/Service/PatchService.php
@@ -99,7 +99,7 @@ final readonly class PatchService implements PatchServiceInterface
         }
 
         $job = new Job(
-            Jobs::PATCH_ELEMENTS->value,
+            Jobs::PATCH_FOLDER_ELEMENTS->value,
             [
                 new JobStep(
                     JobSteps::ELEMENT_FOLDER_PATCHING->value,


### PR DESCRIPTION
## Summary

- Exposes `jobName` on the `JobRun` API response so the frontend can rehydrate running jobs after a page reload
- Adds distinct job names for folder operations (`PATCH_FOLDER_ELEMENTS`, `COLLECT_CSV/XLSX_FOLDER_EXPORT_ELEMENTS`) so the frontend can distinguish them from their single-element counterparts
- Adds migration to hide existing job runs of the new job types on upgrade

## Related

Part of pimcore/studio-ui-bundle#3455
Related to pimcore/studio-ui-bundle#3468