### PR TITLE
[Bug]: Classification Store unable to rename due to Description is NULL 

### DIFF
--- a/src/ClassificationStore/Repository/Configuration/CollectionRepository.php
+++ b/src/ClassificationStore/Repository/Configuration/CollectionRepository.php
@@ -100,7 +100,7 @@ final readonly class CollectionRepository implements CollectionRepositoryInterfa
     {
         $config = $this->getById($id);
         $config->setName($name);
-        $config->setDescription($description);
+        $config->setDescription($description ?? '');
 
         try {
             $config->save();

--- a/src/ClassificationStore/Repository/Configuration/StoreRepository.php
+++ b/src/ClassificationStore/Repository/Configuration/StoreRepository.php
@@ -94,7 +94,7 @@ final readonly class StoreRepository implements StoreRepositoryInterface
         }
 
         $config->setName($name);
-        $config->setDescription($description);
+        $config->setDescription($description ?? '');
 
         try {
             $config->save();


### PR DESCRIPTION
## Changes in this pull request
Resolves #1799 

## Additional info
- core setter does not allow null even tho the property is nullable