### PR TITLE
[Bug] Fix Symfony env var tracking for mercure_settings in prepend()

### DIFF
--- a/src/DependencyInjection/PimcoreStudioBackendExtension.php
+++ b/src/DependencyInjection/PimcoreStudioBackendExtension.php
@@ -268,14 +268,19 @@ class PimcoreStudioBackendExtension extends Extension implements PrependExtensio
             ]);
         }
 
-        foreach ($containerConfig['mercure_settings'] as $key => $setting) {
+        $processedConfig = $this->processConfiguration(
+            new Configuration(),
+            $container->getExtensionConfig(Configuration::ROOT_NODE)
+        );
+
+        foreach ($processedConfig['mercure_settings'] as $key => $setting) {
             if ($container->hasParameter('pimcore_studio_backend.mercure_settings.' . $key)) {
                 continue;
             }
 
             $container->setParameter(
                 'pimcore_studio_backend.mercure_settings.' . $key,
-                $containerConfig['mercure_settings'][$key]
+                $processedConfig['mercure_settings'][$key]
             );
         }
 


### PR DESCRIPTION
## Problem

In `PimcoreStudioBackendExtension::prepend()`, the `mercure_settings` container parameters were being set using `$containerConfig` obtained from `ConfigurationHelper::getConfigNodeFromSymfonyTree()`. That helper internally calls `resolveValue()`, which strips `%env(X)%` references down to plain strings.

As a result, Symfony's container compiler never sees these as proper env var parameter references, and reports env vars like `MERCURE_JWT_COOKIE_HOST` as **"never used"** — even when correctly referenced in `mercure_settings` configuration — causing a deployment failure.

## Fix

Replace the use of `$containerConfig` in the `mercure_settings` loop inside `prepend()` with a fresh call to `$this->processConfiguration()`, which preserves `%env(X)%` placeholders as proper DI parameter references that Symfony can track through compilation.

## Test

Verified on Upsun (Platform.sh Flex) with `MERCURE_JWT_COOKIE_HOST` set via env var: container compiles cleanly with no "never used" warning and the env var is correctly resolved at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)