### PR TITLE
[Bug] Fix Symfony env var tracking for mercure_settings in prepend()

### DIFF
--- a/src/DependencyInjection/PimcoreStudioBackendExtension.php
+++ b/src/DependencyInjection/PimcoreStudioBackendExtension.php
@@ -268,14 +268,19 @@ class PimcoreStudioBackendExtension extends Extension implements PrependExtensio
             ]);
         }
 
-        foreach ($containerConfig['mercure_settings'] as $key => $setting) {
+        $processedConfig = $this->processConfiguration(
+            new Configuration(),
+            $container->getExtensionConfig(Configuration::ROOT_NODE)
+        );
+
+        foreach ($processedConfig['mercure_settings'] as $key => $setting) {
             if ($container->hasParameter('pimcore_studio_backend.mercure_settings.' . $key)) {
                 continue;
             }
 
             $container->setParameter(
                 'pimcore_studio_backend.mercure_settings.' . $key,
-                $containerConfig['mercure_settings'][$key]
+                $processedConfig['mercure_settings'][$key]
             );
         }
 


### PR DESCRIPTION
## Summary

Backport of #1805 targeting the `2025.4` branch.

In `PimcoreStudioBackendExtension::prepend()`, the `mercure_settings` parameters were set using `$containerConfig` from `getConfigNodeFromSymfonyTree()`, which internally calls `resolveValue()`. This strips `%env(X)%` references to plain strings, causing Symfony's container compiler to report env vars like `MERCURE_JWT_COOKIE_HOST` as "never used" even when correctly referenced in `mercure_settings` config.

**Fix:** call `$this->processConfiguration()` directly in `prepend()` so that env var placeholders are preserved as proper DI parameter references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)