### PR TITLE
[Bug] fix missing select options

### DIFF
--- a/src/Class/Repository/ClassDefinitionRepository.php
+++ b/src/Class/Repository/ClassDefinitionRepository.php
@@ -335,7 +335,6 @@ readonly class ClassDefinitionRepository implements ClassDefinitionRepositoryInt
         return $values;
     }
 
-    // TODO: test nesting & multiselect functionality
     private function applyOptionsProviderDefaults(array $config): array
     {
         $type = $config['optionsProviderType'] ?? null;

--- a/src/Class/Repository/ClassDefinitionRepository.php
+++ b/src/Class/Repository/ClassDefinitionRepository.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Class\Repository;
 
 use Exception;
+use Pimcore\Bundle\CoreBundle\OptionsProvider\SelectOptionsOptionsProvider;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\MappedParameter\CreateClassDefinitionParameters;
@@ -208,6 +209,7 @@ readonly class ClassDefinitionRepository implements ClassDefinitionRepositoryInt
             $values = $this->sanitizeCompositeIndices($values);
             $values = $this->removeProtectedFields($values);
             $config = $this->prepareLayoutConfiguration($config);
+            $config = $this->applyOptionsProviderDefaults($config);
 
             $classDefinition->setValues($values);
 
@@ -331,6 +333,27 @@ readonly class ClassDefinitionRepository implements ClassDefinitionRepositoryInt
         );
 
         return $values;
+    }
+
+    // TODO: test nesting & multiselect functionality
+    private function applyOptionsProviderDefaults(array $config): array
+    {
+        $type = $config['optionsProviderType'] ?? null;
+        $class = $config['optionsProviderClass'] ?? null;
+
+        if ($type === 'select_options' && empty($class)) {
+            $config['optionsProviderClass'] = SelectOptionsOptionsProvider::class;
+        }
+
+        if (isset($config['children']) && is_array($config['children'])) {
+            foreach ($config['children'] as $key => $child) {
+                if (is_array($child)) {
+                    $config['children'][$key] = $this->applyOptionsProviderDefaults($child);
+                }
+            }
+        }
+
+        return $config;
     }
 
     private function prepareLayoutConfiguration(array $config): array


### PR DESCRIPTION
## Changes in this pull request
Resolves #1806 

## Additional info
* Add default for the `optionsProviderClass` if `select_options` was chosen for a select field, similar to old frontend logic 