### PR TITLE
[Bug][Data Object Editor] null pointer exception in column collectors when layout definitions are unavailable

### DIFF
--- a/src/Grid/Column/Collector/DataObject/AdvancedColumnCollector.php
+++ b/src/Grid/Column/Collector/DataObject/AdvancedColumnCollector.php
@@ -74,6 +74,10 @@ final class AdvancedColumnCollector implements
             $this->getUser()
         );
 
+        if ($layoutDefinitions === null) {
+            return [];
+        }
+
         $children = $layoutDefinitions->getChildren();
 
         $collectedDefinitions = $this->collectSupportedDefinitions($children);
@@ -285,6 +289,10 @@ final class AdvancedColumnCollector implements
             $this->getFolderId(),
             $this->getUser()
         );
+
+        if ($filteredLayoutDefinitions === null) {
+            return [];
+        }
 
         return $this->getDefaultFields(
             $this->collectSupportedDefinitions($filteredLayoutDefinitions->getChildren())

--- a/src/Grid/Column/Collector/DataObject/FieldDefinitionCollector.php
+++ b/src/Grid/Column/Collector/DataObject/FieldDefinitionCollector.php
@@ -75,6 +75,10 @@ final class FieldDefinitionCollector implements
 
         $classDefinition = $this->classDefinitionService->getClassDefinition($this->getClassId());
 
+        if ($layoutDefinitions === null) {
+            return [];
+        }
+
         $children = $layoutDefinitions->getChildren();
 
         $this->groupDefinitions($children, true, $classDefinition->getName(), false);


### PR DESCRIPTION
Fixes a 500 error (`Call to a member function getChildren() on null`) when requesting available columns for a class that has no layout definitions.

`getFilteredLayoutDefinitions` can return `null`, but `FieldDefinitionCollector` and `AdvancedColumnCollector` called `->getChildren()` on the result without a null check. Added early returns in all three affected call sites.

Related to https://github.com/pimcore/studio-ui-bundle/issues/3493