### PR TITLE
Added `showAppLoggerTab` to endpoint

### DIFF
--- a/src/DataObject/Data/Model/ClassData.php
+++ b/src/DataObject/Data/Model/ClassData.php
@@ -23,6 +23,7 @@ final readonly class ClassData
         private bool $allowVariants,
         private bool $showVariants,
         private bool $hasPreview,
+        private bool $showAppLoggerTab,
     ) {
     }
 
@@ -44,5 +45,10 @@ final readonly class ClassData
     public function getHasPreview(): bool
     {
         return $this->hasPreview;
+    }
+
+    public function getShowAppLoggerTab(): bool
+    {
+        return $this->showAppLoggerTab;
     }
 }

--- a/src/DataObject/Schema/DataObjectDetail.php
+++ b/src/DataObject/Schema/DataObjectDetail.php
@@ -30,6 +30,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\WorkflowAvailableTrait;
         'allowInheritance',
         'showVariants',
         'hasPreview',
+        'showAppLoggerTab',
         'hasWorkflowAvailable',
     ],
     type: 'object'

--- a/src/DataObject/Service/DataService.php
+++ b/src/DataObject/Service/DataService.php
@@ -78,6 +78,7 @@ final readonly class DataService implements DataServiceInterface
         $dataObject->setAllowVariants($classData->getAllowVariants());
         $dataObject->setShowVariants($classData->getShowVariants());
         $dataObject->setHasPreview($classData->getHasPreview());
+        $dataObject->setShowAppLoggerTab($classData->getShowAppLoggerTab());
         $dataObject->setObjectData($this->getDetailObjectData($element, $fieldDefinitions));
 
         if ($dataObject instanceof DataObjectDetail) {
@@ -304,7 +305,8 @@ final readonly class DataService implements DataServiceInterface
             $class->getAllowInherit(),
             $class->getAllowVariants(),
             $class->getShowVariants(),
-            (bool)$class->getLinkGeneratorReference()
+            (bool)$class->getLinkGeneratorReference(),
+            $class->getShowAppLoggerTab()
         );
     }
 

--- a/src/DataObject/Util/Trait/ClassDataTrait.php
+++ b/src/DataObject/Util/Trait/ClassDataTrait.php
@@ -29,6 +29,9 @@ trait ClassDataTrait
     #[Property(description: 'Has preview', type: 'bool', example: false)]
     private ?bool $hasPreview = null;
 
+    #[Property(description: 'Show application logger tab', type: 'bool', example: false)]
+    private ?bool $showAppLoggerTab = null;
+
     public function getShowVariants(): ?bool
     {
         return $this->showVariants;
@@ -57,5 +60,15 @@ trait ClassDataTrait
     public function setHasPreview(bool $hasPreview): void
     {
         $this->hasPreview = $hasPreview;
+    }
+
+    public function getShowAppLoggerTab(): ?bool
+    {
+        return $this->showAppLoggerTab;
+    }
+
+    public function setShowAppLoggerTab(bool $showAppLoggerTab): void
+    {
+        $this->showAppLoggerTab = $showAppLoggerTab;
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Partly-Resolves https://github.com/pimcore/studio-ui-bundle/issues/3485

## Additional info
This pull request adds support for a new `showAppLoggerTab` property across several classes related to data object details, ensuring that this property is available, set, and transferred throughout the data object detail flow. The changes include updating constructors, schemas, and trait methods to handle this new property.

**Support for `showAppLoggerTab` property:**

* `ClassData` constructor and methods: Added the `showAppLoggerTab` property to the constructor and provided a getter method. [[1]](diffhunk://#diff-62208ddca538535ef26eea952118b07e9d7c64f4e8bfb8dfa1fa62eaf32b4c66R26) [[2]](diffhunk://#diff-62208ddca538535ef26eea952118b07e9d7c64f4e8bfb8dfa1fa62eaf32b4c66R49-R53)
* `DataObjectDetail` schema: Included `showAppLoggerTab` in the list of properties for the object schema.
* `DataService`: 
  * Set the `showAppLoggerTab` property on data objects in `setObjectDetailData`.
  * Passed `showAppLoggerTab` when constructing `ClassData` in `getObjectClassData`.
* `ClassDataTrait`: 
  * Added the `showAppLoggerTab` property with an annotation.
  * Implemented getter and setter methods for `showAppLoggerTab`.

These changes ensure that the `showAppLoggerTab` property is consistently available and properly handled throughout the relevant data object classes and services.