### PR TITLE
[Bug] fix objectbrick fields missing in brick assignment

### DIFF
--- a/doc/03_Extending/02_Additional_and_Custom_Attributes.md
+++ b/doc/03_Extending/02_Additional_and_Custom_Attributes.md
@@ -155,6 +155,7 @@ For more details and frontend customization options, see the [Custom Icons & Too
 - `pre_response.class_definition.folder.collection`
 - `pre_response.class_definition.identifier_data`
 - `pre_response.class_definition.object_brick_data`
+- `pre_response.class_definition.object_brick_field`
 - `pre_response.class_definition.tree`
 - `pre_response.class_field_by_type`
 - `pre_response.classification_store.collection`

--- a/src/Class/Controller/DefinitionConfiguration/BrickFieldsController.php
+++ b/src/Class/Controller/DefinitionConfiguration/BrickFieldsController.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Controller\DefinitionConfiguration;
+
+use OpenApi\Attributes\Get;
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinitionBrickField;
+use Pimcore\Bundle\StudioBackendBundle\Class\Service\ClassDefinitionServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\StringParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\ItemsJson;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class BrickFieldsController extends AbstractApiController
+{
+    private const string ROUTE = '/class/definition/configuration-view/detail/{id}/brick-fields';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly ClassDefinitionServiceInterface $classDefinitionService,
+    ) {
+        parent::__construct($serializer);
+    }
+
+    /**
+     * @throws NotFoundException
+     */
+    #[Route(
+        path: self::ROUTE,
+        name: 'pimcore_studio_api_class_definition_get_brick_fields',
+        methods: ['GET']
+    )]
+    #[IsGranted(UserPermissions::CLASS_DEFINITION->value)]
+    #[Get(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'class_definition_get_brick_fields',
+        description: 'class_definition_get_brick_fields_description',
+        summary: 'class_definition_get_brick_fields_summary',
+        tags: [Tags::ClassDefinition->value]
+    )]
+    #[StringParameter(
+        name: 'id',
+        example: 'CAR',
+        description: 'Class definition unique identifier',
+        required: true
+    )]
+    #[SuccessResponse(
+        description: 'class_definition_get_brick_fields_success_response',
+        content: new ItemsJson(ClassDefinitionBrickField::class)
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::FORBIDDEN,
+        HttpResponseCodes::BAD_REQUEST,
+        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::NOT_FOUND,
+    ])]
+    public function getClassDefinitionBrickFields(string $id): JsonResponse
+    {
+        return $this->jsonResponse(['items' => $this->classDefinitionService->getClassDefinitionBrickFields($id)]);
+    }
+}

--- a/src/Class/Event/ClassDefinitionBrickFieldEvent.php
+++ b/src/Class/Event/ClassDefinitionBrickFieldEvent.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Event;
+
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinitionBrickField;
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+
+final class ClassDefinitionBrickFieldEvent extends AbstractPreResponseEvent
+{
+    public const string EVENT_NAME = 'pre_response.class_definition.object_brick_field';
+
+    public function __construct(private readonly ClassDefinitionBrickField $brickField)
+    {
+        parent::__construct($this->brickField);
+    }
+
+    public function getBrickField(): ClassDefinitionBrickField
+    {
+        return $this->brickField;
+    }
+}

--- a/src/Class/Hydrator/ClassDefinitionHydrator.php
+++ b/src/Class/Hydrator/ClassDefinitionHydrator.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Class\Hydrator;
 
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinition as ClassDefinitionSchema;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinitionBrickData;
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinitionBrickField;
 use Pimcore\Bundle\StudioBackendBundle\Icon\Service\IconServiceInterface;
 use Pimcore\Model\DataObject\ClassDefinition;
 
@@ -64,5 +65,10 @@ final readonly class ClassDefinitionHydrator implements ClassDefinitionHydratorI
     public function hydrateBrickData(string $key, string $fieldName): ClassDefinitionBrickData
     {
         return new ClassDefinitionBrickData($key, $fieldName);
+    }
+
+    public function hydrateBrickField(string $fieldName): ClassDefinitionBrickField
+    {
+        return new ClassDefinitionBrickField($fieldName);
     }
 }

--- a/src/Class/Hydrator/ClassDefinitionHydratorInterface.php
+++ b/src/Class/Hydrator/ClassDefinitionHydratorInterface.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Class\Hydrator;
 
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinition as ClassDefinitionSchema;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinitionBrickData;
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinitionBrickField;
 use Pimcore\Model\DataObject\ClassDefinition;
 
 /**
@@ -25,4 +26,6 @@ interface ClassDefinitionHydratorInterface
     public function hydrate(ClassDefinition $data): ClassDefinitionSchema;
 
     public function hydrateBrickData(string $key, string $fieldName): ClassDefinitionBrickData;
+
+    public function hydrateBrickField(string $fieldName): ClassDefinitionBrickField;
 }

--- a/src/Class/Schema/ClassDefinitionBrickField.php
+++ b/src/Class/Schema/ClassDefinitionBrickField.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Class\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+#[Schema(
+    schema: 'ClassDefinitionBrickField',
+    title: 'Class Definition Object Brick Field',
+    required: ['fieldName'],
+    type: 'object'
+)]
+final class ClassDefinitionBrickField implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(
+            description: 'Name of the class definition field of type object brick',
+            type: 'string',
+            example: 'saleInformation'
+        )]
+        private readonly string $fieldName,
+    ) {
+    }
+
+    public function getFieldName(): string
+    {
+        return $this->fieldName;
+    }
+}

--- a/src/Class/Service/ClassDefinitionService.php
+++ b/src/Class/Service/ClassDefinitionService.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Class\Service;
 
+use Override;
 use Pimcore\Bundle\StudioBackendBundle\Class\Event\ClassDefinitionBrickEvent;
+use Pimcore\Bundle\StudioBackendBundle\Class\Event\ClassDefinitionBrickFieldEvent;
 use Pimcore\Bundle\StudioBackendBundle\Class\Event\ClassDefinitionEvent;
 use Pimcore\Bundle\StudioBackendBundle\Class\Event\ClassDefinitionListEvent;
 use Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\ClassDefinitionHydratorInterface;
@@ -26,6 +28,7 @@ use Pimcore\Bundle\StudioBackendBundle\OpenApi\Schema\JsonExport;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Model\DataObject\ClassDefinition as CoreClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -156,6 +159,30 @@ final readonly class ClassDefinitionService implements ClassDefinitionServiceInt
         }
 
         return $hydratedBricks;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClassDefinitionBrickFields(string $id): array
+    {
+        $class = $this->classDefinitionRepository->getClassDefinitionById($id);
+
+        $brickFields = [];
+        foreach ($class->getFieldDefinitions() as $fieldName => $fieldDefinition) {
+            if (!$fieldDefinition instanceof Objectbricks) {
+                continue;
+            }
+
+            $brickField = $this->classDefinitionHydrator->hydrateBrickField($fieldName);
+            $this->eventDispatcher->dispatch(
+                new ClassDefinitionBrickFieldEvent($brickField),
+                ClassDefinitionBrickFieldEvent::EVENT_NAME
+            );
+            $brickFields[] = $brickField;
+        }
+
+        return $brickFields;
     }
 
     /**

--- a/src/Class/Service/ClassDefinitionServiceInterface.php
+++ b/src/Class/Service/ClassDefinitionServiceInterface.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Class\Service;
 use Pimcore\Bundle\StudioBackendBundle\Class\MappedParameter\CreateClassDefinitionParameters;
 use Pimcore\Bundle\StudioBackendBundle\Class\MappedParameter\UpdateParameters;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinition as ClassDefinitionSchema;
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinitionBrickField;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinitionList;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ConflictException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementExistsException;
@@ -83,4 +84,11 @@ interface ClassDefinitionServiceInterface
      * @throws NotFoundException
      */
     public function getClassDefinitionBricks(string $id): array;
+
+    /**
+     * @return ClassDefinitionBrickField[]
+     *
+     * @throws NotFoundException
+     */
+    public function getClassDefinitionBrickFields(string $id): array;
 }

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -1669,6 +1669,11 @@ class_definition_get_bricks_usages_description: |
   The <strong>{id}</strong> must be an ID of an existing class definition.
 class_definition_get_bricks_usages_summary: Get object bricks usage data for the class definition
 class_definition_get_bricks_usages_success_response: Object bricks usage data
+class_definition_get_brick_fields_description: |
+  Get all object brick field names for the given class definition ID <strong>{id}</strong> <br>
+  The <strong>{id}</strong> must be an ID of an existing class definition.
+class_definition_get_brick_fields_summary: Get object brick fields for the class definition
+class_definition_get_brick_fields_success_response: List of object brick field names
 class_definition_get_data_object_class: Data object class
 class_definition_get_success_response: Class definition
 class_definition_get_identifier_data_description: |


### PR DESCRIPTION
## Changes in this pull request
Related to #1802 

## Additional info
* Adds a new endpoint for getting the fieldnames of `objectbrick` fields for a given class
* FE needs to be adjusted to use new endpoint to fill the dropdown for the objectbrick assignment