### PR TITLE
Fix JobRun schema serializing jobRunChildId as childJobRunId

### DIFF
--- a/src/ExecutionEngine/Schema/JobRun.php
+++ b/src/ExecutionEngine/Schema/JobRun.php
@@ -91,7 +91,7 @@ final class JobRun implements AdditionalAttributesInterface
         return $this->creationDate;
     }
 
-    public function getChildJobRunId(): ?int
+    public function getJobRunChildId(): ?int
     {
         return $this->jobRunChildId;
     }


### PR DESCRIPTION
The getter was named `getChildJobRunId()` instead of `getJobRunChildId()`. Symfony's serializer derives the JSON key from the getter name, so the field was serialized as `childJobRunId` in the API response instead of `jobRunChildId`. This prevented the frontend from building parent-child job run chains during rehydration, causing parent-child jobs (zip upload, clone, folder export) to show "finished" state while the child job was still running.

Fixes https://github.com/pimcore/studio-ui-bundle/issues/3524