### PR TITLE
[Assets] - zip download does not include subfolders

### DIFF
--- a/src/Asset/Controller/Download/DownloadZipController.php
+++ b/src/Asset/Controller/Download/DownloadZipController.php
@@ -76,7 +76,6 @@ final class DownloadZipController extends AbstractApiController
             ZipServiceInterface::DOWNLOAD_ZIP_FILE_NAME,
             ZipServiceInterface::DOWNLOAD_ZIP_FOLDER_NAME,
             MimeTypes::ZIP->value,
-            'assets.zip'
         );
     }
 }

--- a/src/Asset/Controller/Export/ZipAssetController.php
+++ b/src/Asset/Controller/Export/ZipAssetController.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Asset\Controller\Export;
 
+use OpenApi\Attributes\Items;
+use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Post;
+use OpenApi\Attributes\Property;
 use OpenApi\Attributes\RequestBody;
 use Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter\ExportAssetFileParameter;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Service\ExecutionEngine\ZipServiceInterface;
@@ -23,7 +26,6 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\MaxFileSizeExceededException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\StreamResourceNotFoundException;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Content\ScalarItemsJson;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\IdJson;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\CreatedResponse;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
@@ -62,7 +64,24 @@ final class ZipAssetController extends AbstractApiController
         tags: [Tags::Assets->name]
     )]
     #[RequestBody(
-        content: new ScalarItemsJson('integer', 'assets')
+        required: true,
+        content: new JsonContent(
+            properties: [
+                new Property(
+                    property: 'assets',
+                    description: 'Asset IDs to include in the zip',
+                    type: 'array',
+                    items: new Items(type: 'integer'),
+                ),
+                new Property(
+                    property: 'parentId',
+                    description: 'ID of the parent folder for relative path resolution in the zip. Defaults to root (1).',
+                    type: 'integer',
+                    example: 1,
+                ),
+            ],
+            type: 'object',
+        )
     )]
     #[CreatedResponse(
         description: 'asset_export_zip_created_response',

--- a/src/Asset/Controller/Export/ZipAssetController.php
+++ b/src/Asset/Controller/Export/ZipAssetController.php
@@ -75,7 +75,7 @@ final class ZipAssetController extends AbstractApiController
                 ),
                 new Property(
                     property: 'parentId',
-                    description: 'ID of the parent folder for relative path resolution in the zip. Defaults to root (1).',
+                    description: 'ID of the parent folder. Defaults to root (1).',
                     type: 'integer',
                     example: 1,
                 ),

--- a/src/Asset/ExecutionEngine/AutomationAction/Messenger/Handler/ZipDownloadHandler.php
+++ b/src/Asset/ExecutionEngine/AutomationAction/Messenger/Handler/ZipDownloadHandler.php
@@ -65,6 +65,7 @@ final class ZipDownloadHandler extends AbstractHandler
         }
 
         $assetIds = $this->extractConfigFieldFromJobStepConfig($message, ZipServiceInterface::ASSETS_TO_ZIP);
+        $basePath = $this->extractConfigFieldFromJobStepConfig($message, ZipServiceInterface::ZIP_BASE_PATH) ?? '/';
         $assetCount = count($assetIds);
         if ($assetCount === 0) {
             $this->abort($this->getAbortData(
@@ -104,7 +105,7 @@ final class ZipDownloadHandler extends AbstractHandler
                 return;
             }
 
-            $this->zipService->addFile($archive, $asset);
+            $this->zipService->addFile($archive, $asset, $basePath);
 
             $this->updateProgress(
                 $this->publishService,
@@ -136,5 +137,8 @@ final class ZipDownloadHandler extends AbstractHandler
     {
         $this->stepConfiguration->setRequired(ZipServiceInterface::ASSETS_TO_ZIP);
         $this->stepConfiguration->setAllowedTypes(ZipServiceInterface::ASSETS_TO_ZIP, 'array');
+        $this->stepConfiguration->setDefined(ZipServiceInterface::ZIP_BASE_PATH);
+        $this->stepConfiguration->setAllowedTypes(ZipServiceInterface::ZIP_BASE_PATH, 'string');
+        $this->stepConfiguration->setDefault(ZipServiceInterface::ZIP_BASE_PATH, '/');
     }
 }

--- a/src/Asset/MappedParameter/ExportAssetFileParameter.php
+++ b/src/Asset/MappedParameter/ExportAssetFileParameter.php
@@ -20,12 +20,18 @@ final readonly class ExportAssetFileParameter
 {
     /** @param array<int> $assets */
     public function __construct(
-        private array $assets
+        private array $assets,
+        private int $parentId = 1,
     ) {
     }
 
     public function getAssets(): array
     {
         return $this->assets;
+    }
+
+    public function getParentId(): int
+    {
+        return $this->parentId;
     }
 }

--- a/src/Asset/Service/ExecutionEngine/ZipService.php
+++ b/src/Asset/Service/ExecutionEngine/ZipService.php
@@ -65,14 +65,17 @@ final readonly class ZipService implements ZipServiceInterface
     ) {
     }
 
-    public function addFile(ZipArchive $archive, Asset $asset): void
+    public function addFile(ZipArchive $archive, Asset $asset, string $basePath = '/'): void
     {
         $archive->addFile(
             $asset->getLocalFile(),
-            preg_replace(
-                '@^' . preg_quote($asset->getRealPath(), '@') . '@i',
-                '',
-                $asset->getRealFullPath()
+            ltrim(
+                preg_replace(
+                    '@^' . preg_quote($basePath, '@') . '@i',
+                    '',
+                    $asset->getRealFullPath()
+                ),
+                '/'
             )
         );
     }
@@ -149,7 +152,17 @@ final readonly class ZipService implements ZipServiceInterface
     {
         $this->validateDownloadItems($parameter->getAssets());
 
-        return $this->createJobRunAndStartExecution($parameter->getAssets());
+        $parentId = $parameter->getParentId();
+        if ($parentId === 1) {
+            return $this->createJobRunAndStartExecution($parameter->getAssets(), '/', 'assets.zip');
+        }
+
+        $parentAsset = $this->assetSearchService->getAssetById($parentId);
+        $basePath = $parentAsset->getFullPath();
+        $folderName = basename($basePath);
+        $downloadFilename = ($folderName !== '' ? $folderName : 'assets') . '.zip';
+
+        return $this->createJobRunAndStartExecution($parameter->getAssets(), $basePath, $downloadFilename);
     }
 
     /**
@@ -158,9 +171,12 @@ final readonly class ZipService implements ZipServiceInterface
     public function generateZipFileForFolders(ExportFolderFileParameter $parameter): int
     {
         $folders = $parameter->getFolders();
+        $folderPaths = [];
 
         $assets = [];
         foreach ($folders as $folder) {
+            $folderAsset = $this->assetSearchService->getAssetById($folder->getId());
+            $folderPaths[] = $folderAsset->getFullPath();
 
             $ids = $this->gridSearch->searchElementIdsForUser(
                 ElementTypes::TYPE_ASSET,
@@ -176,7 +192,12 @@ final readonly class ZipService implements ZipServiceInterface
             $this->validateDownloadItems($assets);
         }
 
-        return $this->createJobRunAndStartExecution($assets);
+        $basePath = $this->resolveCommonBasePath($folderPaths);
+        $downloadFilename = count($folderPaths) === 1
+            ? (basename($folderPaths[0]) ?: 'assets') . '.zip'
+            : 'assets.zip';
+
+        return $this->createJobRunAndStartExecution($assets, $basePath, $downloadFilename);
     }
 
     /**
@@ -302,8 +323,11 @@ final readonly class ZipService implements ZipServiceInterface
         }
     }
 
-    private function createJobRunAndStartExecution(array $assets): int
-    {
+    private function createJobRunAndStartExecution(
+        array $assets,
+        string $basePath = '/',
+        string $downloadFilename = 'assets.zip',
+    ): int {
         $job = new Job(
             name: Jobs::CREATE_ZIP->value,
             steps: [
@@ -311,8 +335,14 @@ final readonly class ZipService implements ZipServiceInterface
                     JobSteps::ZIP_CREATION->value,
                     ZipDownloadMessage::class,
                     '',
-                    [self::ASSETS_TO_ZIP => $assets]
+                    [
+                        self::ASSETS_TO_ZIP => $assets,
+                        self::ZIP_BASE_PATH => $basePath,
+                    ]
                 ),
+            ],
+            environmentData: [
+                self::ZIP_DOWNLOAD_FILENAME => $downloadFilename,
             ],
         );
 
@@ -323,5 +353,34 @@ final readonly class ZipService implements ZipServiceInterface
         );
 
         return $jobRun->getId();
+    }
+
+    /**
+     * @param string[] $folderPaths
+     */
+    private function resolveCommonBasePath(array $folderPaths): string
+    {
+        if (count($folderPaths) === 1) {
+            return dirname($folderPaths[0]);
+        }
+
+        $parts = array_map(
+            static fn(string $path) => explode('/', trim($path, '/')),
+            $folderPaths
+        );
+        $common = [];
+        $minLength = min(array_map('count', $parts));
+
+        for ($i = 0; $i < $minLength; $i++) {
+            $segment = $parts[0][$i];
+            foreach ($parts as $p) {
+                if ($p[$i] !== $segment) {
+                    break 2;
+                }
+            }
+            $common[] = $segment;
+        }
+
+        return '/' . implode('/', $common);
     }
 }

--- a/src/Asset/Service/ExecutionEngine/ZipService.php
+++ b/src/Asset/Service/ExecutionEngine/ZipService.php
@@ -36,6 +36,7 @@ use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\EnvironmentVariables
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Jobs;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset\DownloadDefaults;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset\DownloadLimits;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\TempFilePathTrait;
@@ -154,13 +155,18 @@ final readonly class ZipService implements ZipServiceInterface
 
         $parentId = $parameter->getParentId();
         if ($parentId === 1) {
-            return $this->createJobRunAndStartExecution($parameter->getAssets(), '/', 'assets.zip');
+            return $this->createJobRunAndStartExecution(
+                $parameter->getAssets(),
+                '/',
+                DownloadDefaults::DEFAULT_ZIP_FILENAME->value
+            );
         }
 
         $parentAsset = $this->assetSearchService->getAssetById($parentId);
         $basePath = $parentAsset->getFullPath();
         $folderName = basename($basePath);
-        $downloadFilename = ($folderName !== '' ? $folderName : 'assets') . '.zip';
+        $downloadFilename = ($folderName !== '' ? $folderName : DownloadDefaults::DEFAULT_FOLDER_NAME->value)
+            . DownloadDefaults::ZIP_EXTENSION->value;
 
         return $this->createJobRunAndStartExecution($parameter->getAssets(), $basePath, $downloadFilename);
     }
@@ -193,9 +199,7 @@ final readonly class ZipService implements ZipServiceInterface
         }
 
         $basePath = $this->resolveCommonBasePath($folderPaths);
-        $downloadFilename = count($folderPaths) === 1
-            ? (basename($folderPaths[0]) ?: 'assets') . '.zip'
-            : 'assets.zip';
+        $downloadFilename = $this->resolveDownloadFilename($folderPaths);
 
         return $this->createJobRunAndStartExecution($assets, $basePath, $downloadFilename);
     }
@@ -326,7 +330,7 @@ final readonly class ZipService implements ZipServiceInterface
     private function createJobRunAndStartExecution(
         array $assets,
         string $basePath = '/',
-        string $downloadFilename = 'assets.zip',
+        ?string $downloadFilename = null,
     ): int {
         $job = new Job(
             name: Jobs::CREATE_ZIP->value,
@@ -342,7 +346,7 @@ final readonly class ZipService implements ZipServiceInterface
                 ),
             ],
             environmentData: [
-                self::ZIP_DOWNLOAD_FILENAME => $downloadFilename,
+                self::ZIP_DOWNLOAD_FILENAME => $downloadFilename ?? DownloadDefaults::DEFAULT_ZIP_FILENAME->value,
             ],
         );
 
@@ -382,5 +386,22 @@ final readonly class ZipService implements ZipServiceInterface
         }
 
         return '/' . implode('/', $common);
+    }
+
+    /**
+     * @param string[] $folderPaths
+     */
+    private function resolveDownloadFilename(array $folderPaths): string
+    {
+        if (count($folderPaths) !== 1) {
+            return DownloadDefaults::DEFAULT_ZIP_FILENAME->value;
+        }
+
+        $folderName = basename($folderPaths[0]);
+        if ($folderName === '') {
+            $folderName = DownloadDefaults::DEFAULT_FOLDER_NAME->value;
+        }
+
+        return $folderName . DownloadDefaults::ZIP_EXTENSION->value;
     }
 }

--- a/src/Asset/Service/ExecutionEngine/ZipServiceInterface.php
+++ b/src/Asset/Service/ExecutionEngine/ZipServiceInterface.php
@@ -50,7 +50,11 @@ interface ZipServiceInterface
 
     public const UPLOAD_ZIP_FILE_PATH = self::UPLOAD_ZIP_FOLDER_PATH . '/' . self::UPLOAD_ZIP_FILE_NAME_LOCAL;
 
-    public function addFile(ZipArchive $archive, Asset $asset): void;
+    public const ZIP_BASE_PATH = 'zip_base_path';
+
+    public const ZIP_DOWNLOAD_FILENAME = 'zip_download_filename';
+
+    public function addFile(ZipArchive $archive, Asset $asset, string $basePath = '/'): void;
 
     public function extractArchiveFiles(
         ZipArchive $archive,

--- a/src/Export/Service/DownloadService.php
+++ b/src/Export/Service/DownloadService.php
@@ -146,7 +146,8 @@ final readonly class DownloadService implements DownloadServiceInterface
             $jobRun = $this->jobRunRepository->getJobRunById($jobRunId);
             $environmentData = $jobRun->getJob()?->getEnvironmentData() ?? [];
 
-            return $environmentData[ZipServiceInterface::ZIP_DOWNLOAD_FILENAME] ?? DownloadDefaults::DEFAULT_ZIP_FILENAME->value;
+            return $environmentData[ZipServiceInterface::ZIP_DOWNLOAD_FILENAME] ??
+                DownloadDefaults::DEFAULT_ZIP_FILENAME->value;
         } catch (Exception) {
             return DownloadDefaults::DEFAULT_ZIP_FILENAME->value;
         }

--- a/src/Export/Service/DownloadService.php
+++ b/src/Export/Service/DownloadService.php
@@ -15,6 +15,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\Export\Service;
 
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
+use Pimcore\Bundle\GenericExecutionEngineBundle\Repository\JobRunRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\ExecutionEngine\ZipServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\StorageServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
@@ -40,6 +42,7 @@ final readonly class DownloadService implements DownloadServiceInterface
 
     public function __construct(
         private ExecutionEngineServiceInterface $executionEngineService,
+        private JobRunRepositoryInterface $jobRunRepository,
         private LoggerInterface $logger,
         private StorageServiceInterface $storageService,
     ) {
@@ -53,9 +56,14 @@ final readonly class DownloadService implements DownloadServiceInterface
         string $tempFileName,
         string $tempFolderName,
         string $mimeType,
-        string $downloadName,
+        ?string $downloadName = null,
     ): StreamedResponse {
         $this->executionEngineService->validateJobRun($jobRunId);
+
+        if ($downloadName === null) {
+            $downloadName = $this->resolveDownloadName($jobRunId);
+        }
+
         $fileName = $this->getTempFileName($jobRunId, $tempFileName);
         $folderName = $this->getTempFileName($jobRunId, $tempFolderName);
         $filePath = $folderName . '/' . $fileName;
@@ -128,6 +136,21 @@ final readonly class DownloadService implements DownloadServiceInterface
         );
 
         return $response;
+    }
+
+    /**
+     * @throws EnvironmentException
+     */
+    private function resolveDownloadName(int $jobRunId): string
+    {
+        try {
+            $jobRun = $this->jobRunRepository->getJobRunById($jobRunId);
+            $environmentData = $jobRun->getJob()?->getEnvironmentData() ?? [];
+
+            return $environmentData[ZipServiceInterface::ZIP_DOWNLOAD_FILENAME] ?? 'assets.zip';
+        } catch (\Exception) {
+            return 'assets.zip';
+        }
     }
 
     /**

--- a/src/Export/Service/DownloadService.php
+++ b/src/Export/Service/DownloadService.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Export\Service;
 
+use Exception;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use Pimcore\Bundle\GenericExecutionEngineBundle\Repository\JobRunRepositoryInterface;
@@ -23,6 +24,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\StreamResourceNotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Service\ExecutionEngineServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset\DownloadDefaults;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset\MimeTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseHeaders;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\StreamedResponseTrait;
@@ -138,18 +140,15 @@ final readonly class DownloadService implements DownloadServiceInterface
         return $response;
     }
 
-    /**
-     * @throws EnvironmentException
-     */
     private function resolveDownloadName(int $jobRunId): string
     {
         try {
             $jobRun = $this->jobRunRepository->getJobRunById($jobRunId);
             $environmentData = $jobRun->getJob()?->getEnvironmentData() ?? [];
 
-            return $environmentData[ZipServiceInterface::ZIP_DOWNLOAD_FILENAME] ?? 'assets.zip';
-        } catch (\Exception) {
-            return 'assets.zip';
+            return $environmentData[ZipServiceInterface::ZIP_DOWNLOAD_FILENAME] ?? DownloadDefaults::DEFAULT_ZIP_FILENAME->value;
+        } catch (Exception) {
+            return DownloadDefaults::DEFAULT_ZIP_FILENAME->value;
         }
     }
 

--- a/src/Export/Service/DownloadServiceInterface.php
+++ b/src/Export/Service/DownloadServiceInterface.php
@@ -33,7 +33,7 @@ interface DownloadServiceInterface
         string $tempFileName,
         string $tempFolderName,
         string $mimeType,
-        string $downloadName,
+        ?string $downloadName = null,
     ): StreamedResponse;
 
     /**

--- a/src/Util/Constant/Asset/DownloadDefaults.php
+++ b/src/Util/Constant/Asset/DownloadDefaults.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset;
+
+/**
+ * @internal
+ */
+enum DownloadDefaults: string
+{
+    case DEFAULT_ZIP_FILENAME = 'assets.zip';
+    case DEFAULT_FOLDER_NAME = 'assets';
+    case ZIP_EXTENSION = '.zip';
+}

--- a/tests/Unit/Asset/MappedParameter/ExportFolderFileParameterTest.php
+++ b/tests/Unit/Asset/MappedParameter/ExportFolderFileParameterTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Asset\MappedParameter;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter\ExportFolderFileParameter;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
+use Pimcore\Model\Element\ElementDescriptor;
+
+/**
+ * @internal
+ */
+final class ExportFolderFileParameterTest extends Unit
+{
+    public function testThrowsInvalidArgumentExceptionWhenFoldersEmpty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ExportFolderFileParameter([], null);
+    }
+
+    public function testGetFiltersReturnsDefaultFilterParameterWhenNull(): void
+    {
+        $parameter = new ExportFolderFileParameter([1], null);
+        $filters = $parameter->getFilters();
+
+        $this->assertInstanceOf(FilterParameter::class, $filters);
+    }
+
+    public function testGetFoldersReturnsElementDescriptors(): void
+    {
+        $parameter = new ExportFolderFileParameter([1, 2, 3], null);
+        $folders = $parameter->getFolders();
+
+        $this->assertCount(3, $folders);
+        foreach ($folders as $folder) {
+            $this->assertInstanceOf(ElementDescriptor::class, $folder);
+        }
+    }
+}

--- a/tests/Unit/Asset/Service/ExecutionEngine/ZipServiceTest.php
+++ b/tests/Unit/Asset/Service/ExecutionEngine/ZipServiceTest.php
@@ -1,0 +1,215 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Asset\Service\ExecutionEngine;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericExecutionEngineBundle\Agent\JobExecutionAgentInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\ExecutionEngine\ZipService;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Grid\GridSearchInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\AssetSearchServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\StorageServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Model\Asset;
+use ReflectionMethod;
+use ZipArchive;
+
+/**
+ * @internal
+ */
+final class ZipServiceTest extends Unit
+{
+    private string $zipPath = '';
+
+    /** @var string[] */
+    private array $tempFiles = [];
+
+    protected function _after(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+
+        if ($this->zipPath !== '' && file_exists($this->zipPath)) {
+            unlink($this->zipPath);
+        }
+    }
+
+    public function testSameFilenameInDifferentFoldersWithCommonBasePath(): void
+    {
+        $service = $this->createService();
+        $archive = $this->createZipArchive();
+
+        $asset1 = $this->createAssetMock('/parent/folder1/image.jpg');
+        $asset2 = $this->createAssetMock('/parent/folder2/image.jpg');
+
+        $service->addFile($archive, $asset1, '/parent');
+        $service->addFile($archive, $asset2, '/parent');
+
+        $entries = $this->getZipEntries($archive);
+
+        $this->assertCount(2, $entries);
+        $this->assertContains('folder1/image.jpg', $entries);
+        $this->assertContains('folder2/image.jpg', $entries);
+    }
+
+    public function testRootBasePath(): void
+    {
+        $service = $this->createService();
+        $archive = $this->createZipArchive();
+
+        $asset = $this->createAssetMock('/some/deep/path/file.txt');
+
+        $service->addFile($archive, $asset, '/');
+
+        $entries = $this->getZipEntries($archive);
+
+        $this->assertCount(1, $entries);
+        $this->assertContains('some/deep/path/file.txt', $entries);
+    }
+
+    public function testDirectParentBasePath(): void
+    {
+        $service = $this->createService();
+        $archive = $this->createZipArchive();
+
+        $asset = $this->createAssetMock('/photos/vacation/beach.jpg');
+
+        $service->addFile($archive, $asset, '/photos/vacation');
+
+        $entries = $this->getZipEntries($archive);
+
+        $this->assertCount(1, $entries);
+        $this->assertContains('beach.jpg', $entries);
+    }
+
+    public function testDefaultBasePathBehavesAsRoot(): void
+    {
+        $service = $this->createService();
+        $archive = $this->createZipArchive();
+
+        $asset = $this->createAssetMock('/folder/file.txt');
+
+        $service->addFile($archive, $asset);
+
+        $entries = $this->getZipEntries($archive);
+
+        $this->assertCount(1, $entries);
+        $this->assertContains('folder/file.txt', $entries);
+    }
+
+    public function testResolveCommonBasePathSingleFolder(): void
+    {
+        $result = $this->invokeResolveCommonBasePath(['/photos/vacation']);
+        $this->assertSame('/photos', $result);
+    }
+
+    public function testResolveCommonBasePathSingleRootChild(): void
+    {
+        $result = $this->invokeResolveCommonBasePath(['/assets']);
+        $this->assertSame('/', $result);
+    }
+
+    public function testResolveCommonBasePathTwoSiblingFolders(): void
+    {
+        $result = $this->invokeResolveCommonBasePath(['/parent/folder1', '/parent/folder2']);
+        $this->assertSame('/parent', $result);
+    }
+
+    public function testResolveCommonBasePathNestedFolders(): void
+    {
+        $result = $this->invokeResolveCommonBasePath(['/a/b/c', '/a/b/d']);
+        $this->assertSame('/a/b', $result);
+    }
+
+    public function testResolveCommonBasePathNoCommonPrefix(): void
+    {
+        $result = $this->invokeResolveCommonBasePath(['/photos/vacation', '/documents/work']);
+        $this->assertSame('/', $result);
+    }
+
+    public function testResolveCommonBasePathDeeplyNested(): void
+    {
+        $result = $this->invokeResolveCommonBasePath(['/a/b/c/d/e', '/a/b/c/d/f', '/a/b/c/x']);
+        $this->assertSame('/a/b/c', $result);
+    }
+
+    /**
+     * @param string[] $folderPaths
+     */
+    private function invokeResolveCommonBasePath(array $folderPaths): string
+    {
+        $service = $this->createService();
+        $method = new ReflectionMethod(ZipService::class, 'resolveCommonBasePath');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $folderPaths);
+    }
+
+    private function createService(): ZipService
+    {
+        return new ZipService(
+            $this->makeEmpty(AssetSearchServiceInterface::class),
+            $this->makeEmpty(JobExecutionAgentInterface::class),
+            $this->makeEmpty(SecurityServiceInterface::class),
+            $this->makeEmpty(StorageServiceInterface::class),
+            $this->makeEmpty(UploadServiceInterface::class),
+            $this->makeEmpty(GridSearchInterface::class),
+            [],
+        );
+    }
+
+    private function createZipArchive(): ZipArchive
+    {
+        $this->zipPath = tempnam(sys_get_temp_dir(), 'zip_test_') . '.zip';
+        $archive = new ZipArchive();
+        $archive->open($this->zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+        return $archive;
+    }
+
+    private function createAssetMock(string $realFullPath): Asset
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'asset_test_');
+        file_put_contents($tempFile, 'test content');
+        $this->tempFiles[] = $tempFile;
+
+        return $this->makeEmpty(Asset::class, [
+            'getLocalFile' => $tempFile,
+            'getRealFullPath' => $realFullPath,
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getZipEntries(ZipArchive $archive): array
+    {
+        $archive->close();
+
+        $readArchive = new ZipArchive();
+        $readArchive->open($this->zipPath, ZipArchive::RDONLY);
+
+        $entries = [];
+        for ($i = 0; $i < $readArchive->numFiles; $i++) {
+            $entries[] = $readArchive->getNameIndex($i);
+        }
+
+        $readArchive->close();
+
+        return $entries;
+    }
+}

--- a/tests/Unit/Export/Service/DownloadServiceTest.php
+++ b/tests/Unit/Export/Service/DownloadServiceTest.php
@@ -20,6 +20,11 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\UnableToDeleteFile;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\StorageServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
+use Pimcore\Bundle\GenericExecutionEngineBundle\Entity\JobRun;
+use Pimcore\Bundle\GenericExecutionEngineBundle\Model\Job;
+use Pimcore\Bundle\GenericExecutionEngineBundle\Model\JobStep;
+use Pimcore\Bundle\GenericExecutionEngineBundle\Repository\JobRunRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\ExecutionEngine\ZipServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Service\ExecutionEngineServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Export\Service\DownloadService;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset\MimeTypes;
@@ -403,13 +408,148 @@ final class DownloadServiceTest extends Unit
     /**
      * @throws Exception
      */
+    public function testResolveDownloadNameFromJobRunEnvironmentData(): void
+    {
+        $stream = fopen('php://memory', 'rb+');
+        fwrite($stream, 'data');
+        rewind($stream);
+
+        $storage = $this->makeEmpty(FilesystemOperator::class, [
+            'readStream' => $stream,
+            'fileSize' => 4,
+        ]);
+
+        $job = new Job(
+            name: 'test-job',
+            steps: [new JobStep('step', 'SomeMessage', '', [])],
+            environmentData: [ZipServiceInterface::ZIP_DOWNLOAD_FILENAME => 'my-folder.zip'],
+        );
+
+        $jobRun = $this->makeEmpty(JobRun::class, [
+            'getJob' => $job,
+        ]);
+
+        $service = $this->createService(
+            storageService: $this->makeEmpty(StorageServiceInterface::class, [
+                'getTempStorage' => $storage,
+                'tempFileExists' => true,
+            ]),
+            jobRunRepository: $this->makeEmpty(JobRunRepositoryInterface::class, [
+                'getJobRunById' => $jobRun,
+            ]),
+        );
+
+        $response = $service->downloadResourceByJobRunId(
+            jobRunId: 1,
+            tempFileName: 'export_{id}.zip',
+            tempFolderName: 'export_{id}',
+            mimeType: 'application/zip',
+        );
+
+        $this->assertSame(
+            'attachment; filename="my-folder.zip"',
+            $response->headers->get('Content-Disposition'),
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testResolveDownloadNameFallsBackWhenKeyMissing(): void
+    {
+        $stream = fopen('php://memory', 'rb+');
+        fwrite($stream, 'data');
+        rewind($stream);
+
+        $storage = $this->makeEmpty(FilesystemOperator::class, [
+            'readStream' => $stream,
+            'fileSize' => 4,
+        ]);
+
+        $job = new Job(
+            name: 'test-job',
+            steps: [new JobStep('step', 'SomeMessage', '', [])],
+            environmentData: [],
+        );
+
+        $jobRun = $this->makeEmpty(JobRun::class, [
+            'getJob' => $job,
+        ]);
+
+        $service = $this->createService(
+            storageService: $this->makeEmpty(StorageServiceInterface::class, [
+                'getTempStorage' => $storage,
+                'tempFileExists' => true,
+            ]),
+            jobRunRepository: $this->makeEmpty(JobRunRepositoryInterface::class, [
+                'getJobRunById' => $jobRun,
+            ]),
+        );
+
+        $response = $service->downloadResourceByJobRunId(
+            jobRunId: 1,
+            tempFileName: 'export_{id}.zip',
+            tempFolderName: 'export_{id}',
+            mimeType: 'application/zip',
+        );
+
+        $this->assertSame(
+            'attachment; filename="assets.zip"',
+            $response->headers->get('Content-Disposition'),
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testResolveDownloadNameFallsBackOnException(): void
+    {
+        $stream = fopen('php://memory', 'rb+');
+        fwrite($stream, 'data');
+        rewind($stream);
+
+        $storage = $this->makeEmpty(FilesystemOperator::class, [
+            'readStream' => $stream,
+            'fileSize' => 4,
+        ]);
+
+        $service = $this->createService(
+            storageService: $this->makeEmpty(StorageServiceInterface::class, [
+                'getTempStorage' => $storage,
+                'tempFileExists' => true,
+            ]),
+            jobRunRepository: $this->makeEmpty(JobRunRepositoryInterface::class, [
+                'getJobRunById' => function () {
+                    throw new \RuntimeException('Job run not found');
+                },
+            ]),
+        );
+
+        $response = $service->downloadResourceByJobRunId(
+            jobRunId: 1,
+            tempFileName: 'export_{id}.zip',
+            tempFolderName: 'export_{id}',
+            mimeType: 'application/zip',
+        );
+
+        $this->assertSame(
+            'attachment; filename="assets.zip"',
+            $response->headers->get('Content-Disposition'),
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
     private function createService(
         ?ExecutionEngineServiceInterface $executionEngineService = null,
         ?StorageServiceInterface $storageService = null,
         ?LoggerInterface $logger = null,
+        ?JobRunRepositoryInterface $jobRunRepository = null,
     ): DownloadService {
         return new DownloadService(
             $executionEngineService ?? $this->makeEmpty(ExecutionEngineServiceInterface::class),
+            $jobRunRepository ?? $this->makeEmpty(JobRunRepositoryInterface::class),
             $logger ?? $this->makeEmpty(LoggerInterface::class),
             $storageService ?? $this->makeEmpty(StorageServiceInterface::class),
         );


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-ui-bundle/issues/3387

## Additional info
- zip download should include sub-folder in order to prevent the exclusion of files with same names
- download should include sub-folders based on the provided root (parent) folder ID