### PR TITLE
[Bug]: Advanced Columns do not support classification store for now.

### DIFF
--- a/src/Grid/Column/Collector/DataObject/AdvancedColumnCollector.php
+++ b/src/Grid/Column/Collector/DataObject/AdvancedColumnCollector.php
@@ -32,6 +32,7 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Util\RelationField;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\SimpleField;
 use Pimcore\Bundle\StudioBackendBundle\ObjectBrick\Service\ObjectBrickServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
 use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToOneRelation;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks;
@@ -163,6 +164,10 @@ final class AdvancedColumnCollector implements
     {
         $simpleFields = $this->getSystemFields();
         foreach ($groupedDefinitions as $definition) {
+            if ($definition instanceof Classificationstore) {
+                continue;
+            }
+
             if ($definition instanceof Objectbricks) {
                 $simpleFields = [
                     ...$this->buildObjectBricksFields($definition),


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-ui-bundle/issues/3434

## Additional info
Currently, Advanced Columns do not support the Classification Store. This requires further discussion and decisions on how the functionality should be implemented. Please refer to [this](https://github.com/pimcore/studio-ui-bundle/issues/2524) improvement ticket for more details.
https://github.com/pimcore/studio-ui-bundle/issues/2524
