### PR TITLE
[Object Editor] - add viewports and languages to object editor preview

### DIFF
--- a/config/data_objects.yaml
+++ b/config/data_objects.yaml
@@ -43,6 +43,11 @@ services:
   Pimcore\Bundle\StudioBackendBundle\DataObject\Service\SelectOptionsServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\DataObject\Service\SelectOptionsService
 
+  Pimcore\Bundle\StudioBackendBundle\DataObject\Service\PreviewConfigServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\DataObject\Service\PreviewConfigService
+    arguments:
+      $defaultPreviewGenerator: '@Pimcore\Bundle\StudioBackendBundle\DataObject\Legacy\PreviewGenerator'
+
   Pimcore\Bundle\StudioBackendBundle\DataObject\Service\PreviewUrlServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\DataObject\Service\PreviewUrlService
     arguments: [ '@Pimcore\Bundle\StudioBackendBundle\DataObject\Legacy\PreviewGenerator' ]

--- a/config/data_objects.yaml
+++ b/config/data_objects.yaml
@@ -69,6 +69,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\ObjectLayoutHydratorInterface:
     class: Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\ObjectLayoutHydrator
 
+  Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\PreviewConfigHydratorInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\PreviewConfigHydrator
+
   Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\SelectOptionHydratorInterface:
     class: Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\SelectOptionHydrator
 

--- a/doc/03_Extending/02_Additional_and_Custom_Attributes.md
+++ b/doc/03_Extending/02_Additional_and_Custom_Attributes.md
@@ -184,6 +184,7 @@ For more details and frontend customization options, see the [Custom Icons & Too
 - `pre_response.data_object.dynamic_select_option`
 - `pre_response.data_object.formated_path`
 - `pre_response.data_object.layout`
+- `pre_response.data_object.preview_config_entry`
 - `pre_response.data_object_version`
 - `pre_response.dependency`
 - `pre_response.document`

--- a/src/DataObject/Controller/PreviewController.php
+++ b/src/DataObject/Controller/PreviewController.php
@@ -17,14 +17,18 @@ use OpenApi\Attributes\Get;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\MappedParameter\PreviewParameter;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\PreviewUrlServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\IntParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\TextFieldParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\RedirectResponse as RedirectResponseAttribute;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -33,11 +37,14 @@ final class PreviewController extends AbstractApiController
 {
     public function __construct(
         SerializerInterface $serializer,
-        private PreviewUrlServiceInterface $previewUrlService
+        private readonly PreviewUrlServiceInterface $previewUrlService,
     ) {
         parent::__construct($serializer);
     }
 
+    /**
+     * @throws InvalidArgumentException|NotFoundException
+     */
     #[Route('/data-objects/preview/{id}', name: 'pimcore_studio_api_data_objects_preview', methods: ['GET'])]
     #[IsGranted(UserPermissions::DATA_OBJECTS->value)]
     #[Get(
@@ -48,15 +55,33 @@ final class PreviewController extends AbstractApiController
         tags: [Tags::DataObjects->value]
     )]
     #[IdParameter(type: 'data object')]
-    #[IntParameter(name: 'site', description: 'Site ID', required: false)]
+    #[IntParameter(
+        name: 'site',
+        description: 'Site ID for multi-site setups',
+        required: false,
+        example: 0,
+    )]
+    #[TextFieldParameter(
+        name: 'locale',
+        description: 'Any additional query parameter is forwarded to the preview generator.',
+        required: false,
+        example: 'en',
+    )]
     #[RedirectResponseAttribute(description: 'data_object_preview_by_id_success_response')]
     #[DefaultResponses([
+        HttpResponseCodes::INTERNAL_SERVER_ERROR,
+        HttpResponseCodes::NOT_FOUND,
         HttpResponseCodes::REDIRECT,
+        HttpResponseCodes::UNAUTHORIZED,
     ])]
-    public function preview(int $id, int $site = 0): RedirectResponse
+    public function preview(int $id, Request $request): RedirectResponse
     {
+        $queryParams = $request->query->all();
+        $site = (int) ($queryParams['site'] ?? 0);
+        unset($queryParams['site']);
+
         return new RedirectResponse(
-            $this->previewUrlService->getPreviewUrl(new PreviewParameter($id, $site))
+            $this->previewUrlService->getPreviewUrl(new PreviewParameter($id, $site), $queryParams)
         );
     }
 }

--- a/src/DataObject/Controller/PreviewController.php
+++ b/src/DataObject/Controller/PreviewController.php
@@ -61,12 +61,6 @@ final class PreviewController extends AbstractApiController
         required: false,
         example: 0,
     )]
-    #[TextFieldParameter(
-        name: 'locale',
-        description: 'Any additional query parameter is forwarded to the preview generator.',
-        required: false,
-        example: 'en',
-    )]
     #[RedirectResponseAttribute(description: 'data_object_preview_by_id_success_response')]
     #[DefaultResponses([
         HttpResponseCodes::INTERNAL_SERVER_ERROR,

--- a/src/DataObject/Event/PreResponse/PreviewConfigEvent.php
+++ b/src/DataObject/Event/PreResponse/PreviewConfigEvent.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Event\PreResponse;
+
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\PreviewConfigEntry;
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+
+final class PreviewConfigEvent extends AbstractPreResponseEvent
+{
+    public const string EVENT_NAME = 'pre_response.data_object.preview_config_entry';
+
+    public function __construct(
+        private readonly PreviewConfigEntry $previewConfigEntry,
+    ) {
+        parent::__construct($this->previewConfigEntry);
+    }
+
+    public function getPreviewConfigEntry(): PreviewConfigEntry
+    {
+        return $this->previewConfigEntry;
+    }
+}

--- a/src/DataObject/Hydrator/ObjectLayoutHydrator.php
+++ b/src/DataObject/Hydrator/ObjectLayoutHydrator.php
@@ -27,7 +27,7 @@ final readonly class ObjectLayoutHydrator implements ObjectLayoutHydratorInterfa
     ) {
     }
 
-    public function hydrateLayout(Panel $panel): Layout
+    public function hydrateLayout(Panel $panel, ?array $previewConfig = null): Layout
     {
         return new Layout(
             $panel->getName(),
@@ -47,7 +47,8 @@ final readonly class ObjectLayoutHydrator implements ObjectLayoutHydratorInterfa
             $this->iconService->getIconForLayout($panel->getIcon()),
             $panel->getLabelAlign(),
             $panel->getLabelWidth(),
-            $panel->getBorder()
+            $panel->getBorder(),
+            $previewConfig,
         );
     }
 }

--- a/src/DataObject/Hydrator/PreviewConfigHydrator.php
+++ b/src/DataObject/Hydrator/PreviewConfigHydrator.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\PreviewConfigEntry;
+
+/**
+ * @internal
+ */
+final readonly class PreviewConfigHydrator implements PreviewConfigHydratorInterface
+{
+    public function hydratePreviewConfigEntry(array $rawEntry): PreviewConfigEntry
+    {
+        $values = [];
+        $entryValues = $rawEntry['values'] ?? [];
+        foreach ($entryValues as $label => $value) {
+            $values[] = ['key' => $label, 'value' => $value];
+        }
+
+        return new PreviewConfigEntry(
+            $rawEntry['name'],
+            $rawEntry['label'],
+            $values,
+            (string) $rawEntry['defaultValue'],
+        );
+    }
+}

--- a/src/DataObject/Hydrator/PreviewConfigHydratorInterface.php
+++ b/src/DataObject/Hydrator/PreviewConfigHydratorInterface.php
@@ -13,13 +13,15 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator;
 
-use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\Layout;
-use Pimcore\Model\DataObject\ClassDefinition\Layout\Panel;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\PreviewConfigEntry;
 
 /**
  * @internal
  */
-interface ObjectLayoutHydratorInterface
+interface PreviewConfigHydratorInterface
 {
-    public function hydrateLayout(Panel $panel, ?array $previewConfig = null): Layout;
+    /**
+     * @param array<string, mixed> $rawEntry
+     */
+    public function hydratePreviewConfigEntry(array $rawEntry): PreviewConfigEntry;
 }

--- a/src/DataObject/Schema/Layout.php
+++ b/src/DataObject/Schema/Layout.php
@@ -85,6 +85,13 @@ class Layout implements AdditionalAttributesInterface
         private readonly int $labelWidth = 100,
         #[Property(description: 'Border', type: 'bool', example: false)]
         private readonly bool $border = false,
+        #[Property(
+            description: 'Preview configuration for locale/site selectors',
+            type: 'array',
+            items: new Items(ref: PreviewConfigEntry::class),
+            nullable: true,
+        )]
+        private readonly ?array $previewConfig = null,
     ) {
     }
 
@@ -176,5 +183,13 @@ class Layout implements AdditionalAttributesInterface
     public function getChildren(): array
     {
         return $this->children;
+    }
+
+    /**
+     * @return array<int, PreviewConfigEntry>|null
+     */
+    public function getPreviewConfig(): ?array
+    {
+        return $this->previewConfig;
     }
 }

--- a/src/DataObject/Schema/PreviewConfigEntry.php
+++ b/src/DataObject/Schema/PreviewConfigEntry.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Schema;
+
+use OpenApi\Attributes\Items;
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+#[Schema(
+    title: 'Preview Config Entry',
+    required: ['name', 'label', 'values', 'defaultValue'],
+    type: 'object',
+)]
+final class PreviewConfigEntry implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(description: 'Parameter name', type: 'string', example: 'locale')]
+        private readonly string $name,
+        #[Property(description: 'Display label', type: 'string', example: 'Locale')]
+        private readonly string $label,
+        #[Property(
+            description: 'Available values as key-value pairs',
+            type: 'array',
+            items: new Items(
+                properties: [
+                    new Property(property: 'key', type: 'string', example: 'English (en)'),
+                    new Property(property: 'value', type: 'string', example: 'en'),
+                ],
+                type: 'object',
+            ),
+        )]
+        private readonly array $values,
+        #[Property(description: 'Default selected value', type: 'string', example: 'en')]
+        private readonly string $defaultValue,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
+    public function getDefaultValue(): string
+    {
+        return $this->defaultValue;
+    }
+}

--- a/src/DataObject/Service/DataService.php
+++ b/src/DataObject/Service/DataService.php
@@ -305,7 +305,7 @@ final readonly class DataService implements DataServiceInterface
             $class->getAllowInherit(),
             $class->getAllowVariants(),
             $class->getShowVariants(),
-            (bool)$class->getLinkGeneratorReference(),
+            $class->getLinkGeneratorReference() || $class->getPreviewGeneratorReference(),
             $class->getShowAppLoggerTab()
         );
     }

--- a/src/DataObject/Service/LayoutService.php
+++ b/src/DataObject/Service/LayoutService.php
@@ -18,9 +18,7 @@ use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResol
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\CustomLayoutRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Event\PreResponse\LayoutEvent;
-use Pimcore\Bundle\StudioBackendBundle\DataObject\Event\PreResponse\PreviewConfigEvent;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\ObjectLayoutHydratorInterface;
-use Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\PreviewConfigHydratorInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\Layout;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
@@ -33,7 +31,6 @@ use Pimcore\Bundle\StudioBackendBundle\Workflow\Util\Trait\WorkflowLayoutTrait;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Layout as CoreLayout;
 use Pimcore\Model\DataObject\ClassDefinition\Layout\Panel;
-use Pimcore\Model\DataObject\ClassDefinition\PreviewGeneratorInterface;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\UserInterface;
@@ -56,8 +53,7 @@ final readonly class LayoutService implements LayoutServiceInterface
         private DataObjectServiceResolverInterface $dataObjectServiceResolver,
         private EventDispatcherInterface $eventDispatcher,
         private ObjectLayoutHydratorInterface $hydrator,
-        private PreviewConfigHydratorInterface $previewConfigHydrator,
-        private PreviewGeneratorInterface $defaultPreviewGenerator,
+        private PreviewConfigServiceInterface $previewConfigService,
         private SecurityLayoutServiceInterface $securityLayoutService,
         private SecurityServiceInterface $securityService,
         private WorkflowDetailsServiceInterface $workflowDetailsService,
@@ -96,7 +92,7 @@ final readonly class LayoutService implements LayoutServiceInterface
             throw new NotFoundException(type: 'class layout for data object', id: $id);
         }
 
-        $previewConfig = $this->getPreviewConfig($dataObject, $class);
+        $previewConfig = $this->previewConfigService->getPreviewConfig($dataObject, $class);
 
         return $this->hydrateLayout($layout, $previewConfig);
     }
@@ -176,36 +172,5 @@ final readonly class LayoutService implements LayoutServiceInterface
         $this->eventDispatcher->dispatch(new LayoutEvent($hydratedLayout), LayoutEvent::EVENT_NAME);
 
         return $hydratedLayout;
-    }
-
-    private function getPreviewConfig(Concrete $dataObject, ClassDefinition $class): ?array
-    {
-        $previewGenerator = $class->getPreviewGenerator();
-
-        if (!$previewGenerator && $class->getLinkGenerator()) {
-            $previewGenerator = $this->defaultPreviewGenerator;
-        }
-
-        if (!$previewGenerator) {
-            return null;
-        }
-
-        $rawConfig = $previewGenerator->getPreviewConfig($dataObject);
-
-        if (empty($rawConfig)) {
-            return null;
-        }
-
-        $previewConfig = [];
-        foreach ($rawConfig as $rawEntry) {
-            $entry = $this->previewConfigHydrator->hydratePreviewConfigEntry($rawEntry);
-            $this->eventDispatcher->dispatch(
-                new PreviewConfigEvent($entry),
-                PreviewConfigEvent::EVENT_NAME,
-            );
-            $previewConfig[] = $entry;
-        }
-
-        return $previewConfig;
     }
 }

--- a/src/DataObject/Service/LayoutService.php
+++ b/src/DataObject/Service/LayoutService.php
@@ -18,7 +18,9 @@ use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResol
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\CustomLayoutRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Event\PreResponse\LayoutEvent;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Event\PreResponse\PreviewConfigEvent;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\ObjectLayoutHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\PreviewConfigHydratorInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\Layout;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
@@ -31,6 +33,7 @@ use Pimcore\Bundle\StudioBackendBundle\Workflow\Util\Trait\WorkflowLayoutTrait;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Layout as CoreLayout;
 use Pimcore\Model\DataObject\ClassDefinition\Layout\Panel;
+use Pimcore\Model\DataObject\ClassDefinition\PreviewGeneratorInterface;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\UserInterface;
@@ -53,6 +56,8 @@ final readonly class LayoutService implements LayoutServiceInterface
         private DataObjectServiceResolverInterface $dataObjectServiceResolver,
         private EventDispatcherInterface $eventDispatcher,
         private ObjectLayoutHydratorInterface $hydrator,
+        private PreviewConfigHydratorInterface $previewConfigHydrator,
+        private PreviewGeneratorInterface $defaultPreviewGenerator,
         private SecurityLayoutServiceInterface $securityLayoutService,
         private SecurityServiceInterface $securityService,
         private WorkflowDetailsServiceInterface $workflowDetailsService,
@@ -91,7 +96,9 @@ final readonly class LayoutService implements LayoutServiceInterface
             throw new NotFoundException(type: 'class layout for data object', id: $id);
         }
 
-        return $this->hydrateLayout($layout);
+        $previewConfig = $this->getPreviewConfig($dataObject, $class);
+
+        return $this->hydrateLayout($layout, $previewConfig);
     }
 
     /**
@@ -163,11 +170,42 @@ final readonly class LayoutService implements LayoutServiceInterface
         return $this->getLastLayoutId($workflows);
     }
 
-    private function hydrateLayout(Panel $layout): Layout
+    private function hydrateLayout(Panel $layout, ?array $previewConfig = null): Layout
     {
-        $hydratedLayout = $this->hydrator->hydrateLayout($layout);
+        $hydratedLayout = $this->hydrator->hydrateLayout($layout, $previewConfig);
         $this->eventDispatcher->dispatch(new LayoutEvent($hydratedLayout), LayoutEvent::EVENT_NAME);
 
         return $hydratedLayout;
+    }
+
+    private function getPreviewConfig(Concrete $dataObject, ClassDefinition $class): ?array
+    {
+        $previewGenerator = $class->getPreviewGenerator();
+
+        if (!$previewGenerator && $class->getLinkGenerator()) {
+            $previewGenerator = $this->defaultPreviewGenerator;
+        }
+
+        if (!$previewGenerator) {
+            return null;
+        }
+
+        $rawConfig = $previewGenerator->getPreviewConfig($dataObject);
+
+        if (empty($rawConfig)) {
+            return null;
+        }
+
+        $previewConfig = [];
+        foreach ($rawConfig as $rawEntry) {
+            $entry = $this->previewConfigHydrator->hydratePreviewConfigEntry($rawEntry);
+            $this->eventDispatcher->dispatch(
+                new PreviewConfigEvent($entry),
+                PreviewConfigEvent::EVENT_NAME,
+            );
+            $previewConfig[] = $entry;
+        }
+
+        return $previewConfig;
     }
 }

--- a/src/DataObject/Service/PreviewConfigService.php
+++ b/src/DataObject/Service/PreviewConfigService.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Event\PreResponse\PreviewConfigEvent;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\PreviewConfigHydratorInterface;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\PreviewGeneratorInterface;
+use Pimcore\Model\DataObject\Concrete;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+final readonly class PreviewConfigService implements PreviewConfigServiceInterface
+{
+    public function __construct(
+        private EventDispatcherInterface $eventDispatcher,
+        private PreviewConfigHydratorInterface $previewConfigHydrator,
+        private PreviewGeneratorInterface $defaultPreviewGenerator,
+    ) {
+    }
+
+    public function getPreviewConfig(Concrete $dataObject, ClassDefinition $class): ?array
+    {
+        $previewGenerator = $class->getPreviewGenerator();
+
+        if (!$previewGenerator && $class->getLinkGenerator()) {
+            $previewGenerator = $this->defaultPreviewGenerator;
+        }
+
+        if (!$previewGenerator) {
+            return null;
+        }
+
+        $rawConfig = $previewGenerator->getPreviewConfig($dataObject);
+
+        if (empty($rawConfig)) {
+            return null;
+        }
+
+        $previewConfig = [];
+        foreach ($rawConfig as $rawEntry) {
+            $entry = $this->previewConfigHydrator->hydratePreviewConfigEntry($rawEntry);
+            $this->eventDispatcher->dispatch(
+                new PreviewConfigEvent($entry),
+                PreviewConfigEvent::EVENT_NAME,
+            );
+            $previewConfig[] = $entry;
+        }
+
+        return $previewConfig;
+    }
+}

--- a/src/DataObject/Service/PreviewConfigServiceInterface.php
+++ b/src/DataObject/Service/PreviewConfigServiceInterface.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\PreviewConfigEntry;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\Concrete;
+
+/**
+ * @internal
+ */
+interface PreviewConfigServiceInterface
+{
+    /**
+     * @return list<PreviewConfigEntry>|null
+     */
+    public function getPreviewConfig(Concrete $dataObject, ClassDefinition $class): ?array;
+}

--- a/src/DataObject/Service/PreviewUrlService.php
+++ b/src/DataObject/Service/PreviewUrlService.php
@@ -32,35 +32,35 @@ final readonly class PreviewUrlService implements PreviewUrlServiceInterface
 
     public function __construct(
         private PreviewGeneratorInterface $defaultPreviewGenerator,
-        private ServiceResolverInterface $serviceResolver
+        private ServiceResolverInterface $serviceResolver,
     ) {
     }
 
-    /**
-     * @throws Exception|NotFoundException
-     */
-    public function getPreviewUrl(PreviewParameter $previewParameter): string
+    public function getPreviewUrl(PreviewParameter $parameter, array $additionalParams = []): string
     {
         $dataObject = $this->getElement(
             $this->serviceResolver,
             ElementTypes::TYPE_OBJECT,
-            $previewParameter->getId()
+            $parameter->getId()
         );
 
         if (!$dataObject instanceof Concrete) {
-            throw new NotFoundException('Data Object', $previewParameter->getId());
+            throw new NotFoundException('Data Object', $parameter->getId());
         }
 
-        $url = $this->getPreviewGenerator($dataObject)?->generatePreviewUrl(
-            $dataObject,
-            ['preview' => true, 'context' => $this]
-        );
+        $params = array_merge(['preview' => true, 'context' => $this], $additionalParams);
+
+        try {
+            $url = $this->getPreviewGenerator($dataObject)?->generatePreviewUrl($dataObject, $params);
+        } catch (Exception) {
+            $url = null;
+        }
 
         if (!$url) {
             throw new InvalidArgumentException('Could not generate preview url');
         }
 
-        return $this->buildRedirectUrl($url, $previewParameter);
+        return $this->buildRedirectUrl($url, $parameter->getId(), $parameter->getSite());
     }
 
     /**
@@ -77,7 +77,7 @@ final readonly class PreviewUrlService implements PreviewUrlServiceInterface
         return $previewService;
     }
 
-    private function buildRedirectUrl(string $url, PreviewParameter $previewParameter): string
+    private function buildRedirectUrl(string $url, int $id, int $site): string
     {
         // replace all remaining % signs
         $url = str_replace('%', '%25', $url);
@@ -85,8 +85,8 @@ final readonly class PreviewUrlService implements PreviewUrlServiceInterface
 
         $redirectParameters = array_filter([
             'pimcore_studio_preview' => true,
-            'pimcore_object_preview' => $previewParameter->getId(),
-            'site' => $previewParameter->getSite(),
+            'pimcore_object_preview' => $id,
+            'site' => $site,
             'dc' => time(),
         ]);
 

--- a/src/DataObject/Service/PreviewUrlServiceInterface.php
+++ b/src/DataObject/Service/PreviewUrlServiceInterface.php
@@ -13,12 +13,20 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Service;
 
+use Exception;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\MappedParameter\PreviewParameter;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 
 /**
- * @interal
+ * @internal
  */
 interface PreviewUrlServiceInterface
 {
-    public function getPreviewUrl(PreviewParameter $previewParameter): string;
+    /**
+     * @param array<string, mixed> $additionalParams
+     *
+     * @throws InvalidArgumentException|NotFoundException
+     */
+    public function getPreviewUrl(PreviewParameter $parameter, array $additionalParams = []): string;
 }

--- a/tests/Unit/DataObject/Hydrator/PreviewConfigHydratorTest.php
+++ b/tests/Unit/DataObject/Hydrator/PreviewConfigHydratorTest.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataObject\Hydrator;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\PreviewConfigHydrator;
+
+/**
+ * @internal
+ */
+final class PreviewConfigHydratorTest extends Unit
+{
+    private PreviewConfigHydrator $hydrator;
+
+    protected function _before(): void
+    {
+        $this->hydrator = new PreviewConfigHydrator();
+    }
+
+    public function testHydratePreviewConfigEntryWithValues(): void
+    {
+        $rawEntry = [
+            'name' => 'locale',
+            'label' => 'Locale',
+            'values' => ['English' => 'en', 'German' => 'de'],
+            'defaultValue' => 'en',
+        ];
+
+        $result = $this->hydrator->hydratePreviewConfigEntry($rawEntry);
+
+        $this->assertSame('locale', $result->getName());
+        $this->assertSame('Locale', $result->getLabel());
+        $this->assertSame([
+            ['key' => 'English', 'value' => 'en'],
+            ['key' => 'German', 'value' => 'de'],
+        ], $result->getValues());
+        $this->assertSame('en', $result->getDefaultValue());
+    }
+
+    public function testHydratePreviewConfigEntryWithEmptyValues(): void
+    {
+        $rawEntry = [
+            'name' => 'site',
+            'label' => 'Site',
+            'values' => [],
+            'defaultValue' => 'default',
+        ];
+
+        $result = $this->hydrator->hydratePreviewConfigEntry($rawEntry);
+
+        $this->assertSame([], $result->getValues());
+        $this->assertSame('site', $result->getName());
+    }
+
+    public function testHydratePreviewConfigEntryWithMissingValues(): void
+    {
+        $rawEntry = [
+            'name' => 'site',
+            'label' => 'Site',
+            'defaultValue' => 'default',
+        ];
+
+        $result = $this->hydrator->hydratePreviewConfigEntry($rawEntry);
+
+        $this->assertSame([], $result->getValues());
+    }
+
+    public function testHydratePreviewConfigEntryWithMultipleValues(): void
+    {
+        $rawEntry = [
+            'name' => 'environment',
+            'label' => 'Environment',
+            'values' => [
+                'Development' => 'dev',
+                'Staging' => 'staging',
+                'Production' => 'prod',
+                'QA' => 'qa',
+            ],
+            'defaultValue' => 'dev',
+        ];
+
+        $result = $this->hydrator->hydratePreviewConfigEntry($rawEntry);
+
+        $expected = [
+            ['key' => 'Development', 'value' => 'dev'],
+            ['key' => 'Staging', 'value' => 'staging'],
+            ['key' => 'Production', 'value' => 'prod'],
+            ['key' => 'QA', 'value' => 'qa'],
+        ];
+        $this->assertSame($expected, $result->getValues());
+    }
+
+    public function testHydratePreviewConfigEntryDefaultValueCastToString(): void
+    {
+        $rawEntry = [
+            'name' => 'port',
+            'label' => 'Port',
+            'values' => [],
+            'defaultValue' => 8080,
+        ];
+
+        $result = $this->hydrator->hydratePreviewConfigEntry($rawEntry);
+
+        $this->assertSame('8080', $result->getDefaultValue());
+    }
+}

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -1334,9 +1334,9 @@ data_object_list_saved_grid_configurations_description: |
 data_object_list_saved_grid_configurations_summary: List all saved grid configurations for data objects
 data_object_list_saved_grid_configurations_success_response: List of saved grid configurations for data objects
 data_object_preview_by_id_description: |
-    Preview data object by ID and site. Data Object must be stored in the session first to be able to preview it.
+    Preview data object by ID. Additional query parameters (e.g. locale, site) are forwarded to the preview generator configured on the data object class. Available parameters depend on the preview generator implementation and can be retrieved from the layout endpoint's previewConfig.
 data_object_preview_by_id_success_response: Redirect to preview URL
-data_object_preview_by_id_summary: Preview data object by ID and site
+data_object_preview_by_id_summary: Preview data object by ID
 data_object_save_grid_configuration_description: |
   Save Data Object grid configuration for a specific Class ID <strong>{classId}</strong>
 data_object_save_grid_configuration_success_response: Data Object grid configuration saved successfully

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -1334,7 +1334,8 @@ data_object_list_saved_grid_configurations_description: |
 data_object_list_saved_grid_configurations_summary: List all saved grid configurations for data objects
 data_object_list_saved_grid_configurations_success_response: List of saved grid configurations for data objects
 data_object_preview_by_id_description: |
-    Preview data object by ID. Additional query parameters (e.g. locale, site) are forwarded to the preview generator configured on the data object class. Available parameters depend on the preview generator implementation and can be retrieved from the layout endpoint's previewConfig.
+  Preview data object by ID. Any additional query parameters (e.g. locale, site) are forwarded to the preview generator configured on the data object class. <br>
+  Available parameters depend on the preview generator implementation and can be retrieved from the layout endpoint's previewConfig.
 data_object_preview_by_id_success_response: Redirect to preview URL
 data_object_preview_by_id_summary: Preview data object by ID
 data_object_save_grid_configuration_description: |


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-ui-bundle/issues/3411

## Additional info
- add missing config data to the layout endpoint
- add possibility to add custom parameters to preview generation endpoint