### PR TITLE
Mcp token authentication

### DIFF
--- a/config/security.yaml
+++ b/config/security.yaml
@@ -42,6 +42,8 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp\SessionBridgeAuthenticator: ~
 
+  Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp\McpAccessTokenAuthenticator: ~
+
   Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp\PatAuthenticator:
     arguments:
       $tokenMap: '%pimcore_studio_backend.mcp.token_map%'

--- a/config/security.yaml
+++ b/config/security.yaml
@@ -57,3 +57,6 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\Security\Repository\McpAccessTokenRepositoryInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Security\Repository\McpAccessTokenRepository
+
+  Pimcore\Bundle\StudioBackendBundle\Security\Service\McpAccessTokenServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Security\Service\McpAccessTokenService

--- a/config/security.yaml
+++ b/config/security.yaml
@@ -62,3 +62,8 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\Security\Service\McpAccessTokenServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Security\Service\McpAccessTokenService
+
+  #Maintenance
+  Pimcore\Bundle\StudioBackendBundle\Security\Maintenance\McpAccessTokenGcTask:
+    tags:
+      - { name: pimcore.maintenance.task, type: studio_mcp_access_token_gc }

--- a/config/security.yaml
+++ b/config/security.yaml
@@ -54,3 +54,6 @@ services:
 
   Pimcore\Bundle\StudioBackendBundle\Security\Service\LayoutServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Security\Service\LayoutService
+
+  Pimcore\Bundle\StudioBackendBundle\Security\Repository\McpAccessTokenRepositoryInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Security\Repository\McpAccessTokenRepository

--- a/doc/04_Development_Details/08_MCP_Server.md
+++ b/doc/04_Development_Details/08_MCP_Server.md
@@ -47,8 +47,12 @@ Never reads the PHP session. On failure, returns `null` so the firewall falls th
 validated token's `reference` (chat session id) is stashed on the request attributes (`_mcp_token_reference`) so trusted
 downstream code can use it instead of any forge-able header.
 
-Tokens are issued, refreshed, and revoked by the consuming bundle (e.g. `pimcore-agent-bundle`); this authenticator only
-validates.
+The studio-backend bundle owns both the validation (`McpAccessTokenAuthenticator`) and the issuance/refresh/revoke
+primitives (`McpAccessTokenServiceInterface` → `McpAccessTokenService`, hashed-at-rest persistence via
+`McpAccessTokenRepository`, GC via the `studio_mcp_access_token_gc` maintenance task). Consuming bundles
+(e.g. `pimcore-agent-bundle`) layer their own policy on top — for example, *when* to mint a fresh token vs. extend an
+existing one, which `reference` to bind it to (typically a chat session id), and what TTL to apply — by calling
+`issue()` / `refresh()` / `revoke()` on the injected service.
 
 ### PSR-7/PSR-17 Bridge Services
 

--- a/doc/04_Development_Details/08_MCP_Server.md
+++ b/doc/04_Development_Details/08_MCP_Server.md
@@ -18,14 +18,15 @@ firewall is **stateless**  - each request authenticates independently, with no s
 It is separate from the `pimcore_studio` firewall to provide security isolation  - MCP authentication cannot leak to Studio
 Backend API routes and vice versa.
 
-The firewall supports two authenticators tried in order:
+The firewall supports three authenticators tried in order:
 
-| Authenticator                | Trigger                  | Use Case                                                  |
-|------------------------------|--------------------------|-----------------------------------------------------------|
-| `SessionBridgeAuthenticator` | Session cookie           | Internal: agent-server forwarding Pimcore Studio sessions |
-| `PatAuthenticator`           | `Authorization: Bearer`  | External: MCP clients (Claude Desktop, Cursor, etc.)      |
+| Authenticator                  | Trigger                          | Use Case                                                                              |
+|--------------------------------|----------------------------------|---------------------------------------------------------------------------------------|
+| `SessionBridgeAuthenticator`   | Session cookie                   | Internal: agent-server forwarding Pimcore Studio sessions                             |
+| `McpAccessTokenAuthenticator`  | `Authorization: Bearer pmcp_…`   | Internal: dynamically-issued, expiring, revocable per-chat-session tokens (Pimcore AI agent) |
+| `PatAuthenticator`             | `Authorization: Bearer`          | External: MCP clients (Claude Desktop, Cursor, etc.)                                  |
 
-Both authenticators resolve to a Pimcore `User` object. All existing Pimcore permissions (workspace ACLs, user/role
+All three authenticators resolve to a Pimcore `User` object. All existing Pimcore permissions (workspace ACLs, user/role
 permissions) apply automatically.
 
 ### SessionBridgeAuthenticator
@@ -38,6 +39,16 @@ to resolve the authenticated Pimcore user. It validates that the user exists and
 
 This authenticator returns `null` on failure (rather than an error response), allowing the next authenticator in the chain
 (PAT) to try.
+
+### McpAccessTokenAuthenticator
+
+Validates a `pmcp_`-prefixed bearer token via `McpAccessTokenService` (DB-backed, hashed at rest, TTL-bounded, revocable).
+Never reads the PHP session. On failure, returns `null` so the firewall falls through to `PatAuthenticator`. On success, the
+validated token's `reference` (chat session id) is stashed on the request attributes (`_mcp_token_reference`) so trusted
+downstream code can use it instead of any forge-able header.
+
+Tokens are issued, refreshed, and revoked by the consuming bundle (e.g. `pimcore-agent-bundle`); this authenticator only
+validates.
 
 ### PSR-7/PSR-17 Bridge Services
 
@@ -247,3 +258,13 @@ final readonly class MyTool
 ```
 
 Or use `SecurityServiceInterface::getCurrentUser()` which works with both session and PAT auth.
+
+### Operational notes
+
+- **Transport security.** Dynamic MCP access tokens (`Bearer pmcp_…`) are credentials. Serve Studio over HTTPS in production;
+  over plain HTTP these tokens are sniffable on the wire.
+- **Log redaction.** Tools that log raw request headers must redact `Authorization`. See `pimcore-agent-bundle` for the
+  Fastify (agent-server) and Symfony (bundle) configuration.
+- **Token lifecycle.** Tokens expire after the consuming bundle's configured TTL (default 2h for `pimcore-agent-bundle`).
+  Expired rows are removed by the `studio_mcp_access_token_gc` maintenance task. Tokens are revoked at the DB layer by an
+  `ON DELETE CASCADE` FK on `users` — deleting a Pimcore user atomically clears their tokens.

--- a/src/DependencyInjection/PimcoreStudioBackendExtension.php
+++ b/src/DependencyInjection/PimcoreStudioBackendExtension.php
@@ -263,6 +263,7 @@ class PimcoreStudioBackendExtension extends Extension implements PrependExtensio
                 'stateless' => true,
                 'custom_authenticators' => [
                     'Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp\SessionBridgeAuthenticator',
+                    'Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp\McpAccessTokenAuthenticator',
                     'Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp\PatAuthenticator',
                 ],
             ]);

--- a/src/Entity/Mcp/McpAccessToken.php
+++ b/src/Entity/Mcp/McpAccessToken.php
@@ -39,10 +39,10 @@ class McpAccessToken
     private string $reference;
 
     #[ORM\Column(name: 'expires_at', type: 'bigint', options: ['unsigned' => true])]
-    private int $expiresAt;
+    private string $expiresAt;
 
     #[ORM\Column(name: 'created_at', type: 'bigint', options: ['unsigned' => true])]
-    private int $createdAt;
+    private string $createdAt;
 
     public function __construct(
         string $tokenHash,
@@ -54,8 +54,8 @@ class McpAccessToken
         $this->tokenHash = $tokenHash;
         $this->userId = $userId;
         $this->reference = $reference;
-        $this->expiresAt = $expiresAt;
-        $this->createdAt = $createdAt;
+        $this->expiresAt = (string) $expiresAt;
+        $this->createdAt = (string) $createdAt;
     }
 
     public function getTokenHash(): string
@@ -80,7 +80,7 @@ class McpAccessToken
 
     public function setExpiresAt(int $expiresAt): void
     {
-        $this->expiresAt = $expiresAt;
+        $this->expiresAt = (string) $expiresAt;
     }
 
     public function getCreatedAt(): int

--- a/src/Entity/Mcp/McpAccessToken.php
+++ b/src/Entity/Mcp/McpAccessToken.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Entity\Mcp;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @internal
+ */
+#[ORM\Entity]
+#[ORM\Table(name: McpAccessToken::TABLE_NAME)]
+#[ORM\Index(columns: ['reference'], name: 'idx_mcp_token_reference')]
+#[ORM\Index(columns: ['user_id'], name: 'idx_mcp_token_user')]
+#[ORM\Index(columns: ['expires_at'], name: 'idx_mcp_token_expires')]
+class McpAccessToken
+{
+    public const string TABLE_NAME = 'bundle_studio_mcp_access_token';
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'token_hash', type: 'string', length: 64)]
+    private string $tokenHash;
+
+    #[ORM\Column(name: 'user_id', type: 'integer', options: ['unsigned' => true])]
+    private int $userId;
+
+    #[ORM\Column(name: 'reference', type: 'string', length: 255)]
+    private string $reference;
+
+    #[ORM\Column(name: 'expires_at', type: 'bigint', options: ['unsigned' => true])]
+    private int $expiresAt;
+
+    #[ORM\Column(name: 'created_at', type: 'bigint', options: ['unsigned' => true])]
+    private int $createdAt;
+
+    public function __construct(
+        string $tokenHash,
+        int $userId,
+        string $reference,
+        int $expiresAt,
+        int $createdAt,
+    ) {
+        $this->tokenHash = $tokenHash;
+        $this->userId = $userId;
+        $this->reference = $reference;
+        $this->expiresAt = $expiresAt;
+        $this->createdAt = $createdAt;
+    }
+
+    public function getTokenHash(): string
+    {
+        return $this->tokenHash;
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    public function getReference(): string
+    {
+        return $this->reference;
+    }
+
+    public function getExpiresAt(): int
+    {
+        return (int) $this->expiresAt;
+    }
+
+    public function setExpiresAt(int $expiresAt): void
+    {
+        $this->expiresAt = $expiresAt;
+    }
+
+    public function getCreatedAt(): int
+    {
+        return (int) $this->createdAt;
+    }
+}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -23,6 +23,7 @@ use Pimcore\Bundle\StudioBackendBundle\Entity\ExecutionEngine\JobRunHidden;
 use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfigurationFavorite;
 use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfigurationShare;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Mcp\McpAccessToken;
 use Pimcore\Bundle\StudioBackendBundle\Entity\Perspective\UserPerspectiveData;
 use Pimcore\Bundle\StudioBackendBundle\Translation\Service\TranslatorServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
@@ -59,6 +60,7 @@ final class Installer extends SettingsStoreAwareInstaller
         $this->createGridConfigurationFavoritesTable($schema);
         $this->createUserPerspectivesTable($schema);
         $this->createJobRunHiddenTable($schema);
+        $this->createMcpAccessTokenTable($schema);
         $this->addUserPermission($schema);
         $this->executeDiffSql($schema);
 
@@ -91,6 +93,10 @@ final class Installer extends SettingsStoreAwareInstaller
 
         if ($schema->hasTable(JobRunHidden::TABLE_NAME)) {
             $schema->dropTable(JobRunHidden::TABLE_NAME);
+        }
+
+        if ($schema->hasTable(McpAccessToken::TABLE_NAME)) {
+            $schema->dropTable(McpAccessToken::TABLE_NAME);
         }
 
         $this->removeUserPermission($schema);
@@ -374,6 +380,37 @@ final class Installer extends SettingsStoreAwareInstaller
         );
 
         $table->setPrimaryKey(['jobRunId'], 'pk_' . JobRunHidden::TABLE_NAME);
+    }
+
+    /**
+     * @throws SchemaException
+     */
+    private function createMcpAccessTokenTable(Schema $schema): void
+    {
+        if ($schema->hasTable(McpAccessToken::TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schema->createTable(McpAccessToken::TABLE_NAME);
+
+        $table->addColumn('token_hash', 'string', ['notnull' => true, 'length' => 64]);
+        $table->addColumn('user_id', 'integer', ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('reference', 'string', ['notnull' => true, 'length' => 255]);
+        $table->addColumn('expires_at', 'bigint', ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('created_at', 'bigint', ['notnull' => true, 'unsigned' => true]);
+
+        $table->setPrimaryKey(['token_hash'], 'pk_' . McpAccessToken::TABLE_NAME);
+        $table->addIndex(['reference'], 'idx_mcp_token_reference');
+        $table->addIndex(['user_id'], 'idx_mcp_token_user');
+        $table->addIndex(['expires_at'], 'idx_mcp_token_expires');
+
+        $table->addForeignKeyConstraint(
+            'users',
+            ['user_id'],
+            ['id'],
+            ['onDelete' => 'CASCADE'],
+            'fk_' . McpAccessToken::TABLE_NAME . '_users'
+        );
     }
 
     /**

--- a/src/Migrations/Version20260519120000.php
+++ b/src/Migrations/Version20260519120000.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Mcp\McpAccessToken;
+
+/**
+ * @internal
+ */
+final class Version20260519120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create the MCP access token table';
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+            CREATE TABLE IF NOT EXISTS ' . McpAccessToken::TABLE_NAME . ' (
+                token_hash VARCHAR(64) NOT NULL,
+                user_id INT UNSIGNED NOT NULL,
+                reference VARCHAR(255) NOT NULL,
+                expires_at BIGINT UNSIGNED NOT NULL,
+                created_at BIGINT UNSIGNED NOT NULL,
+                PRIMARY KEY (token_hash),
+                INDEX idx_mcp_token_reference (reference),
+                INDEX idx_mcp_token_user (user_id),
+                INDEX idx_mcp_token_expires (expires_at),
+                CONSTRAINT fk_' . McpAccessToken::TABLE_NAME . '_users
+                    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+            ) DEFAULT CHARSET=utf8mb4
+        ');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS ' . McpAccessToken::TABLE_NAME);
+    }
+}

--- a/src/Security/Authenticator/Mcp/McpAccessTokenAuthenticator.php
+++ b/src/Security/Authenticator/Mcp/McpAccessTokenAuthenticator.php
@@ -54,7 +54,7 @@ final class McpAccessTokenAuthenticator extends AbstractAuthenticator
     ) {
     }
 
-    public function supports(Request $request): ?bool
+    public function supports(Request $request): bool
     {
         $header = $request->headers->get(self::AUTH_HEADER, '');
 

--- a/src/Security/Authenticator/Mcp/McpAccessTokenAuthenticator.php
+++ b/src/Security/Authenticator/Mcp/McpAccessTokenAuthenticator.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp;
+
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\McpAccessTokenService;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\McpAccessTokenServiceInterface;
+use Pimcore\Model\User;
+use Pimcore\Security\User\User as SecurityUser;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+/**
+ * Authenticates MCP requests carrying a dynamically-issued bearer token
+ * (`Authorization: Bearer pmcp_…`). Never touches the PHP session.
+ *
+ * On success, the validated token's `reference` (chat session id) is stashed on the
+ * request attributes (`_mcp_token_reference`) so downstream code (notably the
+ * `HasChatSession` trait in the agent bundle) can trust it instead of the
+ * spoofable `X-Chat-Session-Id` header.
+ *
+ * @internal
+ */
+final class McpAccessTokenAuthenticator extends AbstractAuthenticator
+{
+    public const string REQUEST_ATTR_REFERENCE = '_mcp_token_reference';
+
+    private const string AUTH_HEADER = 'Authorization';
+
+    private const string BEARER_PREFIX = 'Bearer ';
+
+    public function __construct(
+        private readonly McpAccessTokenServiceInterface $accessTokenService,
+    ) {
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        $header = $request->headers->get(self::AUTH_HEADER, '');
+
+        return str_starts_with($header, self::BEARER_PREFIX . McpAccessTokenService::TOKEN_PREFIX);
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $token = substr($request->headers->get(self::AUTH_HEADER, ''), strlen(self::BEARER_PREFIX));
+        $validated = $this->accessTokenService->validate($token);
+
+        if ($validated === null) {
+            throw new AuthenticationException('Invalid or expired MCP access token.');
+        }
+
+        $user = $validated->user;
+        if (!$user instanceof User) {
+            throw new AuthenticationException('Invalid or expired MCP access token.');
+        }
+
+        $request->attributes->set(self::REQUEST_ATTR_REFERENCE, $validated->reference);
+
+        return new SelfValidatingPassport(
+            new UserBadge($user->getUsername(), static fn () => new SecurityUser($user)),
+        );
+    }
+
+    public function onAuthenticationSuccess(
+        Request $request,
+        TokenInterface $token,
+        string $firewallName,
+    ): ?Response {
+        return null;
+    }
+
+    public function onAuthenticationFailure(
+        Request $request,
+        AuthenticationException $exception,
+    ): ?Response {
+        // Return null so the next authenticator (PatAuthenticator) can try.
+        return null;
+    }
+}

--- a/src/Security/Authenticator/Mcp/PatAuthenticator.php
+++ b/src/Security/Authenticator/Mcp/PatAuthenticator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp;
 
 use Pimcore\Bundle\StaticResolverBundle\Lib\Tools\Authentication\AuthenticationResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\McpAccessTokenService;
 use Pimcore\Model\User;
 use Pimcore\Security\User\User as SecurityUser;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -57,7 +58,19 @@ class PatAuthenticator extends AbstractAuthenticator
     {
         $authHeader = $request->headers->get(self::AUTH_HEADER, '');
 
-        return str_starts_with($authHeader, self::BEARER_PREFIX);
+        if (!str_starts_with($authHeader, self::BEARER_PREFIX)) {
+            return false;
+        }
+
+        // Bearer tokens prefixed with the MCP access-token prefix are handled by
+        // McpAccessTokenAuthenticator. Returning false here ensures Symfony's
+        // authenticator chain does not run PAT validation in parallel — which
+        // would override McpAccessTokenAuthenticator's success with a 401.
+        if (str_starts_with($authHeader, self::BEARER_PREFIX . McpAccessTokenService::TOKEN_PREFIX)) {
+            return false;
+        }
+
+        return true;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Security/Dto/ValidatedAccessToken.php
+++ b/src/Security/Dto/ValidatedAccessToken.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Security\Dto;
+
+use Pimcore\Model\UserInterface;
+
+/**
+ * Outcome of a successful MCP access token validation: the bound user and the
+ * `reference` (chat session id) the token was minted for.
+ *
+ * @internal
+ */
+final readonly class ValidatedAccessToken
+{
+    public function __construct(
+        public UserInterface $user,
+        public string $reference,
+    ) {
+    }
+}

--- a/src/Security/Exception/McpTokenUserInvalidException.php
+++ b/src/Security/Exception/McpTokenUserInvalidException.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Security\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when a token is issued/refreshed for a user that no longer exists or is disabled.
+ *
+ * @internal
+ */
+final class McpTokenUserInvalidException extends RuntimeException
+{
+}

--- a/src/Security/Maintenance/McpAccessTokenGcTask.php
+++ b/src/Security/Maintenance/McpAccessTokenGcTask.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Security\Maintenance;
+
+use Pimcore\Bundle\StudioBackendBundle\Security\Repository\McpAccessTokenRepositoryInterface;
+use Pimcore\Maintenance\TaskInterface;
+use function time;
+
+/**
+ * Deletes expired MCP access tokens. Cheap single DELETE — safe to run every cycle.
+ *
+ * @internal
+ */
+final readonly class McpAccessTokenGcTask implements TaskInterface
+{
+    public function __construct(private McpAccessTokenRepositoryInterface $repository)
+    {
+    }
+
+    public function execute(): void
+    {
+        $this->repository->deleteExpired(time());
+    }
+}

--- a/src/Security/Repository/McpAccessTokenRepository.php
+++ b/src/Security/Repository/McpAccessTokenRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Security\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Mcp\McpAccessToken;
+
+/**
+ * @internal
+ */
+final readonly class McpAccessTokenRepository implements McpAccessTokenRepositoryInterface
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    public function findByHash(string $tokenHash): ?McpAccessToken
+    {
+        return $this->entityManager->getRepository(McpAccessToken::class)->find($tokenHash);
+    }
+
+    public function findOneByReference(string $reference): ?McpAccessToken
+    {
+        return $this->entityManager->getRepository(McpAccessToken::class)
+            ->findOneBy(['reference' => $reference]);
+    }
+
+    public function save(McpAccessToken $token): void
+    {
+        $this->entityManager->persist($token);
+        $this->entityManager->flush();
+    }
+
+    public function deleteByReference(string $reference): void
+    {
+        $this->entityManager->createQuery(
+            'DELETE FROM ' . McpAccessToken::class . ' t WHERE t.reference = :reference'
+        )->setParameter('reference', $reference)->execute();
+    }
+
+    public function deleteByUserId(int $userId): void
+    {
+        $this->entityManager->createQuery(
+            'DELETE FROM ' . McpAccessToken::class . ' t WHERE t.userId = :userId'
+        )->setParameter('userId', $userId)->execute();
+    }
+
+    public function deleteExpired(int $now): int
+    {
+        return (int) $this->entityManager->createQuery(
+            'DELETE FROM ' . McpAccessToken::class . ' t WHERE t.expiresAt < :now'
+        )->setParameter('now', $now)->execute();
+    }
+}

--- a/src/Security/Repository/McpAccessTokenRepositoryInterface.php
+++ b/src/Security/Repository/McpAccessTokenRepositoryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Security\Repository;
+
+use Pimcore\Bundle\StudioBackendBundle\Entity\Mcp\McpAccessToken;
+
+/**
+ * @internal
+ */
+interface McpAccessTokenRepositoryInterface
+{
+    public function findByHash(string $tokenHash): ?McpAccessToken;
+
+    public function findOneByReference(string $reference): ?McpAccessToken;
+
+    public function save(McpAccessToken $token): void;
+
+    public function deleteByReference(string $reference): void;
+
+    public function deleteByUserId(int $userId): void;
+
+    /** @return int number of rows deleted */
+    public function deleteExpired(int $now): int;
+}

--- a/src/Security/Service/McpAccessTokenService.php
+++ b/src/Security/Service/McpAccessTokenService.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Security\Service;
+
+use Closure;
+use Pimcore\Bundle\StaticResolverBundle\Lib\Tools\Authentication\AuthenticationResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Mcp\McpAccessToken;
+use Pimcore\Bundle\StudioBackendBundle\Security\Dto\ValidatedAccessToken;
+use Pimcore\Bundle\StudioBackendBundle\Security\Exception\McpTokenUserInvalidException;
+use Pimcore\Bundle\StudioBackendBundle\Security\Repository\McpAccessTokenRepositoryInterface;
+use Pimcore\Model\User;
+use function bin2hex;
+use function hash;
+use function random_bytes;
+use function str_starts_with;
+use function time;
+
+/**
+ * @internal
+ */
+final readonly class McpAccessTokenService implements McpAccessTokenServiceInterface
+{
+    public const string TOKEN_PREFIX = 'pmcp_';
+
+    /** @var Closure(int): ?User */
+    private Closure $userLoader;
+
+    /**
+     * @param Closure(int): ?User|null $userLoader injection seam for tests; defaults to User::getById
+     */
+    public function __construct(
+        private McpAccessTokenRepositoryInterface $repository,
+        private AuthenticationResolverInterface $authenticationResolver,
+        ?Closure $userLoader = null,
+    ) {
+        $this->userLoader = $userLoader ?? static fn (int $id): ?User => User::getById($id);
+    }
+
+    public function issue(int $userId, int $ttlSeconds, string $reference): string
+    {
+        if (!$this->isUserValid($userId)) {
+            throw new McpTokenUserInvalidException(
+                'Cannot issue MCP token: user ' . $userId . ' is missing or disabled.'
+            );
+        }
+
+        // Enforce exactly-one-live-token-per-reference: if a prior token row exists
+        // for the same chat session (e.g. a re-mint after a failed refresh, or a
+        // duplicate issue), wipe it so the old plaintext value can no longer be used.
+        $this->repository->deleteByReference($reference);
+
+        $token = self::TOKEN_PREFIX . bin2hex(random_bytes(32));
+        $now = time();
+        $this->repository->save(new McpAccessToken(
+            hash('sha256', $token),
+            $userId,
+            $reference,
+            $now + $ttlSeconds,
+            $now,
+        ));
+
+        return $token;
+    }
+
+    public function refresh(string $reference, int $ttlSeconds): bool
+    {
+        $token = $this->repository->findOneByReference($reference);
+        if ($token === null || $token->getExpiresAt() < time()) {
+            return false;
+        }
+
+        if (!$this->isUserValid($token->getUserId())) {
+            $this->repository->deleteByReference($reference);
+
+            return false;
+        }
+
+        $token->setExpiresAt(time() + $ttlSeconds);
+        $this->repository->save($token);
+
+        return true;
+    }
+
+    public function revoke(string $reference): void
+    {
+        $this->repository->deleteByReference($reference);
+    }
+
+    public function revokeByUser(int $userId): void
+    {
+        $this->repository->deleteByUserId($userId);
+    }
+
+    public function validate(string $token): ?ValidatedAccessToken
+    {
+        if (!str_starts_with($token, self::TOKEN_PREFIX)) {
+            return null;
+        }
+
+        $row = $this->repository->findByHash(hash('sha256', $token));
+        if ($row === null || $row->getExpiresAt() < time()) {
+            return null;
+        }
+
+        $user = ($this->userLoader)($row->getUserId());
+        if (!$this->authenticationResolver->isValidUser($user)) {
+            return null;
+        }
+
+        return new ValidatedAccessToken($user, $row->getReference());
+    }
+
+    private function isUserValid(int $userId): bool
+    {
+        return $this->authenticationResolver->isValidUser(($this->userLoader)($userId));
+    }
+}

--- a/src/Security/Service/McpAccessTokenService.php
+++ b/src/Security/Service/McpAccessTokenService.php
@@ -47,6 +47,14 @@ final readonly class McpAccessTokenService implements McpAccessTokenServiceInter
         $this->userLoader = $userLoader ?? static fn (int $id): ?User => User::getById($id);
     }
 
+    /**
+     * Mints a fresh token bound to `$userId` and `$reference`. Any existing token for the
+     * same `$reference` is removed first.
+     *
+     * Throws `McpTokenUserInvalidException` defensively when `$userId` is missing or
+     * disabled. In normal flows the caller passes the currently-authenticated user, so
+     * the check serves as an internal invariant guard rather than a user-facing path.
+     */
     public function issue(int $userId, int $ttlSeconds, string $reference): string
     {
         if (!$this->isUserValid($userId)) {

--- a/src/Security/Service/McpAccessTokenServiceInterface.php
+++ b/src/Security/Service/McpAccessTokenServiceInterface.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Security\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Security\Dto\ValidatedAccessToken;
+
+/**
+ * Issues, refreshes, revokes and validates dynamic MCP access tokens.
+ * `issue()` and `refresh()` resolve identity server-side; never expose to HTTP callers
+ * a way to pass an arbitrary userId.
+ *
+ * @internal
+ */
+interface McpAccessTokenServiceInterface
+{
+    /**
+     * Mint a fresh token bound to $userId, return the plaintext value (returned only here).
+     * Replaces any existing token row for the same `$reference` to enforce
+     * exactly-one-live-token-per-chat-session.
+     *
+     * @throws \Pimcore\Bundle\StudioBackendBundle\Security\Exception\McpTokenUserInvalidException
+     */
+    public function issue(int $userId, int $ttlSeconds, string $reference): string;
+
+    /**
+     * Extend the expiry of the live token for $reference (value unchanged).
+     * Returns false if no live, user-valid token exists (caller should re-issue).
+     * Revokes the row if the bound user is no longer valid.
+     */
+    public function refresh(string $reference, int $ttlSeconds): bool;
+
+    public function revoke(string $reference): void;
+
+    public function revokeByUser(int $userId): void;
+
+    /** Resolve a plaintext token to its user + reference, or null if invalid/expired. */
+    public function validate(string $token): ?ValidatedAccessToken;
+}

--- a/tests/Unit/Security/Authenticator/Mcp/McpAccessTokenAuthenticatorTest.php
+++ b/tests/Unit/Security/Authenticator/Mcp/McpAccessTokenAuthenticatorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Security\Authenticator\Mcp;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp\McpAccessTokenAuthenticator;
+use Pimcore\Bundle\StudioBackendBundle\Security\Dto\ValidatedAccessToken;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\McpAccessTokenServiceInterface;
+use Pimcore\Model\User;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+final class McpAccessTokenAuthenticatorTest extends Unit
+{
+    public function testSupportsOnlyBearerWithMcpPrefix(): void
+    {
+        $auth = $this->makeAuthenticator(null);
+        $this->assertTrue($auth->supports($this->requestWith('Bearer pmcp_abc')));
+        $this->assertFalse((bool) $auth->supports($this->requestWith('Bearer static-pat')));
+        $this->assertFalse((bool) $auth->supports($this->requestWith('')));
+    }
+
+    public function testAuthenticateBuildsPassportAndBindsReferenceForValidToken(): void
+    {
+        $user = new User();
+        $user->setUsername('agent-user');
+        $validated = new ValidatedAccessToken($user, 'chat-1');
+        $auth = $this->makeAuthenticator($validated);
+
+        $request = $this->requestWith('Bearer pmcp_valid');
+        $passport = $auth->authenticate($request);
+
+        $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
+        // Binds the token's reference on the request so downstream code (HasChatSession
+        // trait) can trust it and ignore any forged X-Chat-Session-Id header.
+        $this->assertSame('chat-1', $request->attributes->get('_mcp_token_reference'));
+    }
+
+    public function testAuthenticateThrowsForInvalidToken(): void
+    {
+        $auth = $this->makeAuthenticator(null);
+        $this->expectException(AuthenticationException::class);
+        $auth->authenticate($this->requestWith('Bearer pmcp_invalid'));
+    }
+
+    public function testFailureReturnsNullToFallThrough(): void
+    {
+        $auth = $this->makeAuthenticator(null);
+        $this->assertNull($auth->onAuthenticationFailure(
+            $this->requestWith('Bearer pmcp_x'),
+            new AuthenticationException('nope'),
+        ));
+    }
+
+    private function makeAuthenticator(?ValidatedAccessToken $validated): McpAccessTokenAuthenticator
+    {
+        return new McpAccessTokenAuthenticator(
+            $this->makeEmpty(McpAccessTokenServiceInterface::class, [
+                'validate' => $validated,
+            ]),
+        );
+    }
+
+    private function requestWith(string $authHeader): Request
+    {
+        $request = new Request();
+        if ($authHeader !== '') {
+            $request->headers->set('Authorization', $authHeader);
+        }
+
+        return $request;
+    }
+}

--- a/tests/Unit/Security/Service/McpAccessTokenServiceTest.php
+++ b/tests/Unit/Security/Service/McpAccessTokenServiceTest.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Security\Service;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StaticResolverBundle\Lib\Tools\Authentication\AuthenticationResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Mcp\McpAccessToken;
+use Pimcore\Bundle\StudioBackendBundle\Security\Exception\McpTokenUserInvalidException;
+use Pimcore\Bundle\StudioBackendBundle\Security\Repository\McpAccessTokenRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\McpAccessTokenService;
+use Pimcore\Model\User;
+
+final class McpAccessTokenServiceTest extends Unit
+{
+    private const TOKEN_PREFIX = 'pmcp_';
+
+    public function testIssueDeletesPriorTokenAndPersistsFreshHash(): void
+    {
+        $deletedRef = null;
+        $saved = null;
+        $service = $this->makeService(
+            userValid: true,
+            repoOverrides: [
+                'deleteByReference' => function (string $r) use (&$deletedRef): void { $deletedRef = $r; },
+                'save' => function (McpAccessToken $t) use (&$saved): void { $saved = $t; },
+            ],
+        );
+
+        $token = $service->issue(42, 7200, 'chat-1');
+
+        // exactly-one-live-token-per-reference: prior row(s) for the reference are cleared first
+        $this->assertSame('chat-1', $deletedRef);
+        $this->assertStringStartsWith(self::TOKEN_PREFIX, $token);
+        $this->assertInstanceOf(McpAccessToken::class, $saved);
+        $this->assertSame(hash('sha256', $token), $saved->getTokenHash());
+        $this->assertSame(42, $saved->getUserId());
+        $this->assertSame('chat-1', $saved->getReference());
+    }
+
+    public function testIssueThrowsWhenUserInvalid(): void
+    {
+        $service = $this->makeService(userValid: false);
+        $this->expectException(McpTokenUserInvalidException::class);
+        $service->issue(42, 7200, 'chat-1');
+    }
+
+    public function testValidateReturnsNullForExpiredToken(): void
+    {
+        $service = $this->makeService(
+            userValid: true,
+            repoOverrides: ['findByHash' => fn () => new McpAccessToken('h', 42, 'chat-1', 1, 1)],
+        );
+        $this->assertNull($service->validate('pmcp_whatever'));
+    }
+
+    public function testValidateReturnsUserAndReferenceForLiveToken(): void
+    {
+        $service = $this->makeService(
+            userValid: true,
+            repoOverrides: [
+                'findByHash' => fn () => new McpAccessToken('h', 42, 'chat-7', time() + 3600, time()),
+            ],
+        );
+        $result = $service->validate('pmcp_live');
+
+        $this->assertNotNull($result);
+        $this->assertSame('chat-7', $result->reference);
+        $this->assertSame('agent-user', $result->user->getUsername());
+    }
+
+    public function testRefreshReturnsFalseWhenNoTokenForReference(): void
+    {
+        $service = $this->makeService(
+            userValid: true,
+            repoOverrides: ['findOneByReference' => fn () => null],
+        );
+        $this->assertFalse($service->refresh('chat-unknown', 7200));
+    }
+
+    /**
+     * @param array<string, callable> $repoOverrides
+     */
+    private function makeService(bool $userValid, array $repoOverrides = []): McpAccessTokenService
+    {
+        $user = new User();
+        $user->setId(42);
+        $user->setUsername('agent-user');
+
+        $repo = $this->makeEmpty(McpAccessTokenRepositoryInterface::class, $repoOverrides);
+        $auth = $this->makeEmpty(AuthenticationResolverInterface::class, [
+            'isValidUser' => $userValid,
+        ]);
+
+        return new McpAccessTokenService($repo, $auth, fn (int $id) => $userValid ? $user : null);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new, secure authentication mechanism for the MCP server: dynamically-issued, expiring, and revocable access tokens (`pmcp_…`). It adds all necessary infrastructure for validating, storing, and cleaning up these tokens, including database schema changes, a new authenticator, service wiring, and documentation. This enables per-chat-session authentication for internal agent integrations, with strong operational and security guarantees.

The most important changes are:

**Authentication Infrastructure:**

* Added `McpAccessTokenAuthenticator` to the firewall, enabling authentication via `Authorization: Bearer pmcp_…` tokens, and ensured correct ordering and exclusivity with existing authenticators. (`config/security.yaml` [[1]](diffhunk://#diff-af6be5d9315e56573c90f5f6d0d6c1317cbbd6fe1bd444162e806c5b09428358R45-R46) [[2]](diffhunk://#diff-825b71e27d9349579a33081a13b9ea4ec7bba657b0402468dff454c1c0a667ddR266); `src/Security/Authenticator/Mcp/McpAccessTokenAuthenticator.php` [[3]](diffhunk://#diff-8132069ae04884d3ce538c9b1697123139baeea5cee6dcca16c7d2cada80e034R1-R100); `src/Security/Authenticator/Mcp/PatAuthenticator.php` [[4]](diffhunk://#diff-8573258d7e15c8e966ec810e3b65be328e5559fccbd4bb6d05631e10ebd9c2aaR17) [[5]](diffhunk://#diff-8573258d7e15c8e966ec810e3b65be328e5559fccbd4bb6d05631e10ebd9c2aaL60-R73)
* Introduced the `ValidatedAccessToken` DTO and `McpTokenUserInvalidException` for robust token validation and error handling. (`src/Security/Dto/ValidatedAccessToken.php` [[1]](diffhunk://#diff-22f034dfa7fffa932bfff933960783510c4cf7d8f53133cdad487c755c3f32cdR1-R31); `src/Security/Exception/McpTokenUserInvalidException.php` [[2]](diffhunk://#diff-4b121343269152c9d61212defe7d564e37ac23e4f15ce4e82a934bc26ca8fc34R1-R25)

**Persistence and Maintenance:**

* Added the `McpAccessToken` entity and database table, with migration, installer/uninstaller logic, and foreign key constraints for automatic cleanup on user deletion. (`src/Entity/Mcp/McpAccessToken.php` [[1]](diffhunk://#diff-b1d13b2e3d9fe3c8c145479d9fdaf540b60062a41db0ca2aece53a20ac6c6029R1-R90); `src/Installer.php` [[2]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR26) [[3]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR63) [[4]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR98-R101) [[5]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR385-R415); `src/Migrations/Version20260519120000.php` [[6]](diffhunk://#diff-c9e405fc612434c666d81e49b946a5edf7a5e025348291360b1fe57a1035cb1bR1-R58)
* Registered repository and service layers for token management, and a maintenance task (`McpAccessTokenGcTask`) to delete expired tokens. (`config/security.yaml` [[1]](diffhunk://#diff-af6be5d9315e56573c90f5f6d0d6c1317cbbd6fe1bd444162e806c5b09428358R59-R69); `src/Security/Maintenance/McpAccessTokenGcTask.php` [[2]](diffhunk://#diff-0db30ef6e0a44a4e4872bc2768d1564d8d6d553bfb087f1b5e40f4c3c065c959R1-R36)

**Documentation and Operational Guidance:**

* Updated and expanded documentation to describe the new authenticator, token lifecycle, operational security considerations, and maintenance procedures. (`doc/04_Development_Details/08_MCP_Server.md` [[1]](diffhunk://#diff-7ab35f364b162fb4b9fc9e0195b97b4e893115f8a1358805a27f945df39ce2cdL21-R29) [[2]](diffhunk://#diff-7ab35f364b162fb4b9fc9e0195b97b4e893115f8a1358805a27f945df39ce2cdR43-R52) [[3]](diffhunk://#diff-7ab35f364b162fb4b9fc9e0195b97b4e893115f8a1358805a27f945df39ce2cdR261-R270)

These changes collectively enable secure, revocable, and auditable access for internal MCP agent integrations, while maintaining compatibility and isolation with other authentication methods.