### PR TITLE
[Bug]: Explode returns a list of AdvancedValue.

### DIFF
--- a/src/Grid/Column/Transformer/Explode.php
+++ b/src/Grid/Column/Transformer/Explode.php
@@ -45,12 +45,15 @@ final class Explode implements TransformerInterface
             $fieldName = $val->getFieldName();
 
             if (!is_string($data)) {
-                $results[] = new AdvancedValue($val->getType(), $data, $fieldName);
+                $results[] = $val;
 
                 continue;
             }
 
-            $results[] = new AdvancedValue('array', explode($delimiter, $data), $fieldName);
+            $value = explode($delimiter, $data);
+            foreach ($value as $item) {
+                $results[] = new AdvancedValue('string', $item, $fieldName);
+            }
         }
 
         return $results;


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-ui-bundle/issues/3438

## Additional info
Explode returns a list of AdvancedValue not a single array. 