### PR TITLE
[Bug] Round system.datetime grid filter to whole day

### DIFF
--- a/src/DataIndex/Filter/DateTimeFilter.php
+++ b/src/DataIndex/Filter/DateTimeFilter.php
@@ -32,8 +32,9 @@ final class DateTimeFilter implements FilterInterface
             return $query;
         }
 
+        // Date-only filter UI — match whole days, not exact instants.
         foreach ($parameters->getColumnFilterByType(ColumnType::SYSTEM_DATETIME->value) as $column) {
-            $query = $this->applySystemDatetimeFilter($column, $query, false);
+            $query = $this->applySystemDatetimeFilter($column, $query, true);
         }
 
         return $query;


### PR DESCRIPTION
`DateTimeFilter::apply` passes `roundToDay=false`, so GDI collapses `gte`/`lte` to the same instant for `on` queries and never matches a stored datetime with a non-zero time component. The filter UI is date-only, so whole-day match is the right semantic — `DateFilter` (for `system.date`) already does this.

Companion to the timezone-handling fix in pimcore/studio-ui-bundle#3646.