### PR TITLE
Standardize spec sheet name with optional name

### DIFF
--- a/src/ExecutionEngine/Util/StepConfig.php
+++ b/src/ExecutionEngine/Util/StepConfig.php
@@ -33,6 +33,7 @@ enum StepConfig: string
     case CONFIG_FILTERS = 'filters';
     case SETTINGS_DELIMITER = 'delimiter';
     case SETTINGS_HEADER = 'header';
+    case SETTINGS_SHEET_NAME = 'sheetName';
     case SETTINGS_HEADER_NO_HEADER = 'no_header';
     case SETTINGS_HEADER_TITLE = 'title';
     case SETTINGS_HEADER_NAME = 'name';

--- a/src/Export/Attribute/Request/ExportDataRequestBody.php
+++ b/src/Export/Attribute/Request/ExportDataRequestBody.php
@@ -44,6 +44,12 @@ final class ExportDataRequestBody extends RequestBody
                 type: 'string',
                 example: ';'
             );
+        } else {
+            $configProperties[] = new Property(
+                property: StepConfig::SETTINGS_SHEET_NAME->value,
+                type: 'string',
+                example: 'Sheet1'
+            );
         }
         parent::__construct(
             content: new JsonContent(

--- a/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
+++ b/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
@@ -45,6 +45,12 @@ final class ExportFolderDataRequestBody extends RequestBody
                 type: 'string',
                 example: ';'
             );
+        } else {
+            $configProperties[] = new Property(
+                property: StepConfig::SETTINGS_SHEET_NAME->value,
+                type: 'string',
+                example: 'Sheet1'
+            );
         }
 
         parent::__construct(

--- a/src/Export/ExecutionEngine/AutomationAction/Messenger/Handler/XlsxCreationHandler.php
+++ b/src/Export/ExecutionEngine/AutomationAction/Messenger/Handler/XlsxCreationHandler.php
@@ -65,6 +65,7 @@ final class XlsxCreationHandler extends AbstractHandler
         $columns = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CONFIG_COLUMNS->value);
         $settings = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CONFIG_CONFIGURATION->value);
         $headers = $settings[StepConfig::SETTINGS_HEADER->value] ?? StepConfig::SETTINGS_HEADER_NO_HEADER->value;
+        $sheetName = $settings[StepConfig::SETTINGS_SHEET_NAME->value] ?? null;
 
         if (!isset($jobRun->getContext()[StepConfig::GRID_EXPORT_DATA->value])) {
             $this->abort($this->getAbortData(
@@ -86,7 +87,9 @@ final class XlsxCreationHandler extends AbstractHandler
                     $headers !== StepConfig::SETTINGS_HEADER_NO_HEADER->value,
                     $headers === StepConfig::SETTINGS_HEADER_NAME
                 ),
-                $user
+                $user,
+                null,
+                $sheetName
             );
         } catch (Exception $e) {
             $this->abort($this->getAbortData(

--- a/src/Export/Service/AbstractExportService.php
+++ b/src/Export/Service/AbstractExportService.php
@@ -47,6 +47,7 @@ abstract readonly class AbstractExportService implements ExportServiceInterface
         GridExportData $gridExportData,
         UserInterface $user,
         ?string $delimiter = null,
+        ?string $sheetName = null,
     ): void {
         $storage = $this->storageService->getTempStorage();
 
@@ -64,7 +65,7 @@ abstract readonly class AbstractExportService implements ExportServiceInterface
             );
         }
 
-        $this->generateExportFile($id, $storage, $headers, $gridExportData->getExportData(), $delimiter);
+        $this->generateExportFile($id, $storage, $headers, $gridExportData->getExportData(), $delimiter, $sheetName);
     }
 
     /**
@@ -89,7 +90,8 @@ abstract readonly class AbstractExportService implements ExportServiceInterface
         FilesystemOperator $storage,
         array $headers,
         array $exportData,
-        string $delimiter
+        string $delimiter,
+        ?string $sheetName = null,
     ): void;
 
     /**

--- a/src/Export/Service/CsvExportService.php
+++ b/src/Export/Service/CsvExportService.php
@@ -36,7 +36,8 @@ final readonly class CsvExportService extends AbstractExportService
         FilesystemOperator $storage,
         array $headers,
         array $exportData,
-        string $delimiter
+        string $delimiter,
+        ?string $sheetName = null,
     ): void {
 
         $data = [];

--- a/src/Export/Service/ExportServiceInterface.php
+++ b/src/Export/Service/ExportServiceInterface.php
@@ -27,6 +27,7 @@ interface ExportServiceInterface
         GridExportData $gridExportData,
         UserInterface $user,
         ?string $delimiter = null,
+        ?string $sheetName = null,
     ): void;
 
     /**

--- a/src/Export/Service/XlsxExportService.php
+++ b/src/Export/Service/XlsxExportService.php
@@ -35,13 +35,19 @@ final readonly class XlsxExportService extends AbstractExportService
         FilesystemOperator $storage,
         array $headers,
         array $exportData,
-        string $delimiter
+        string $delimiter,
+        ?string $sheetName = null,
     ): void {
         $csvReader = new Csv();
         $csvReader->setDelimiter($delimiter);
         $csvReader->setSheetIndex(0);
 
         $spreadsheet = $csvReader->loadSpreadsheetFromString($this->processData($delimiter, $headers, $exportData));
+
+        if ($sheetName !== null && $sheetName !== '') {
+            $spreadsheet->getActiveSheet()->setTitle($sheetName);
+        }
+
         $writer = new Xlsx($spreadsheet);
         $stream = fopen('php://temp', 'rb+');
         $writer->save($stream);


### PR DESCRIPTION
Companion to: https://github.com/pimcore/studio-ui-bundle/pull/3655

- Adds `SETTINGS_SHEET_NAME` to `StepConfig`
- Exposes `sheetName` in the OpenAPI request body for element and folder XLSX endpoints
- Threads `sheetName` from `XlsxCreationHandler` → `createExportFile` → `generateExportFile`
- Applies the name via PhpSpreadsheet's `setTitle()` in `XlsxExportService`
- `CsvExportService` signature updated but ignores the param — no behaviour change
