### PR TITLE
[BUG] Children Grid Template button is dimmed  

### DIFF
--- a/doc/02_Installation_and_Configuration/05_Upgrade.md
+++ b/doc/02_Installation_and_Configuration/05_Upgrade.md
@@ -1,0 +1,11 @@
+# Upgrade Information
+
+The following steps are necessary during updating to newer versions.
+
+## Upgrade to 2025.4.5
+- [Grid Configuration] Fixed: Changed the length of `classId` column in `bundle_studio_grid_configurations` and `bundle_studio_grid_configuration_favorites` tables from 10 to 50 characters to support longer class IDs.
+
+### Migration execution required
+After upgrading, please execute the migration to apply the necessary database changes.
+
+> **Note:** Grid configurations that were previously saved with a class ID longer than 10 characters have a truncated `classId` value in the database and will not be recovered by this migration. These configurations need to be deleted and re-saved after upgrading.

--- a/src/Entity/Grid/GridConfiguration.php
+++ b/src/Entity/Grid/GridConfiguration.php
@@ -37,7 +37,7 @@ class GridConfiguration
     #[ORM\Column(type: 'integer', nullable: true, options: ['unsigned' => true])]
     private ?int $assetFolderId = null;
 
-    #[ORM\Column(type: 'string', nullable: true, length: 10)]
+    #[ORM\Column(type: 'string', length: 50, nullable: true)]
     private ?string $classId = null;
 
     #[ORM\Column(type: 'integer', nullable: true, options: ['unsigned' => true])]

--- a/src/Entity/Grid/GridConfigurationFavorite.php
+++ b/src/Entity/Grid/GridConfigurationFavorite.php
@@ -37,7 +37,7 @@ class GridConfigurationFavorite
     #[ORM\Id]
     private int $folder;
 
-    #[ORM\Column(type: 'string', nullable: true, length: 10)]
+    #[ORM\Column(type: 'string', length: 50, nullable: true)]
     private ?string $classId = null;
 
     public function getUser(): int

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -184,7 +184,7 @@ final class Installer extends SettingsStoreAwareInstaller
 
         $table->addColumn('classId', 'string', [
             'notnull' => false,
-            'length' => 10,
+            'length' => 50,
         ]);
 
         $table->addForeignKeyConstraint(
@@ -269,7 +269,7 @@ final class Installer extends SettingsStoreAwareInstaller
             'unsigned' => true,
         ]);
 
-        $table->addColumn('classId', 'string', ['notnull' => false, 'length' => 10]);
+        $table->addColumn('classId', 'string', ['notnull' => false, 'length' => 50]);
 
         $table->addColumn(
             'owner',

--- a/src/Migrations/Version20260601120000.php
+++ b/src/Migrations/Version20260601120000.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfiguration;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfigurationFavorite;
+
+/**
+ * @internal
+ */
+final class Version20260601120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Increase classId column length from 10 to 50 '.
+            'in grid configuration and grid configuration favorite tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->increaseClassIdLength($schema, GridConfiguration::TABLE_NAME);
+        $this->increaseClassIdLength($schema, GridConfigurationFavorite::TABLE_NAME);
+    }
+
+    private function increaseClassIdLength(Schema $schema, string $tableName): void
+    {
+        if (!$schema->hasTable($tableName)) {
+            return;
+        }
+
+        $table = $schema->getTable($tableName);
+        $column = $table->getColumn('classId');
+        $column->setLength(50);
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/studio-backend-bundle/issues/1863

## Additional info
- the class name columns are too short in the grid tables - should be extended to avoid truncation
- added migration