### PR TITLE
Serialize select option value as string (#3322)

### DIFF
--- a/src/DataObject/Hydrator/SelectOptionHydrator.php
+++ b/src/DataObject/Hydrator/SelectOptionHydrator.php
@@ -22,9 +22,14 @@ final readonly class SelectOptionHydrator implements SelectOptionHydratorInterfa
 {
     public function hydrate(array $data): SelectOption
     {
+        // Options providers may return non-string values (e.g. an element id typed as int).
+        // Pimcore persists select/multiselect values as strings, so the option value must be
+        // serialized as a string as well; otherwise Studio UI cannot match the reloaded
+        // string value against a numeric option value and shows the raw value instead of the
+        // label. See https://github.com/pimcore/studio-ui-bundle/issues/3322
         return new SelectOption(
             key: $data['key'],
-            value: $data['value']
+            value: (string) $data['value']
         );
     }
 }

--- a/src/DataObject/Schema/SelectOption.php
+++ b/src/DataObject/Schema/SelectOption.php
@@ -34,7 +34,7 @@ class SelectOption implements AdditionalAttributesInterface
         #[Property(description: 'Key', type: 'string', example: 'key')]
         private readonly string $key,
         #[Property(description: 'Value', type: 'string', example: 'value')]
-        private readonly int|string $value,
+        private readonly string $value,
     ) {
     }
 
@@ -43,7 +43,7 @@ class SelectOption implements AdditionalAttributesInterface
         return $this->key;
     }
 
-    public function getValue(): string|int
+    public function getValue(): string
     {
         return $this->value;
     }


### PR DESCRIPTION
Related to pimcore/studio-ui-bundle#3322

Options providers may return non-string values (e.g. an int element id). Pimcore persists select/multiselect values as strings, so the select-options endpoint now serializes the option value as a string to match. Aligns the runtime with the already-documented OpenAPI `type: string`.