### PR TITLE
[Data Object Grid] Save column widths in templates

### DIFF
--- a/src/Asset/Schema/Grid/ColumnSchema.php
+++ b/src/Asset/Schema/Grid/ColumnSchema.php
@@ -34,6 +34,8 @@ readonly class ColumnSchema
         private ?string $locale,
         #[Property(description: 'Define the group structure', type: 'object', example: ['system'])]
         private array $group,
+        #[Property(description: 'Width of the Column', type: 'integer', example: 200, nullable: true)]
+        private ?int $width = null,
     ) {
     }
 
@@ -52,12 +54,18 @@ readonly class ColumnSchema
         return $this->group;
     }
 
+    public function getWidth(): ?int
+    {
+        return $this->width;
+    }
+
     public function toArray(): array
     {
         return [
             'key' => $this->key,
             'locale' => $this->locale,
             'group' => $this->group,
+            'width' => $this->width,
         ];
     }
 }

--- a/src/Grid/Schema/Column.php
+++ b/src/Grid/Schema/Column.php
@@ -54,6 +54,8 @@ final readonly class Column
             ),
             example: ['key' => 'value'])]
         private array $config,
+        #[Property(description: 'Width of the Column', type: 'integer', example: 200, nullable: true)]
+        private ?int $width = null,
     ) {
     }
 
@@ -80,6 +82,11 @@ final readonly class Column
     public function getConfig(): array
     {
         return $this->config;
+    }
+
+    public function getWidth(): ?int
+    {
+        return $this->width;
     }
 
     public function getAdvancedColumnConfig(): AdvancedColumnConfig
@@ -155,6 +162,7 @@ final readonly class Column
             'type' => $this->getType(),
             'group' => $this->getGroup(),
             'config' => $this->getConfig(),
+            'width' => $this->getWidth(),
         ];
     }
 }

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -345,7 +345,8 @@ final class GridService implements GridServiceInterface
                     locale: $column['locale'] ?? null,
                     type: $column['type'],
                     group: $column['group'] ?? null,
-                    config: $column['config']
+                    config: $column['config'],
+                    width: $column['width'] ?? null
                 );
             } catch (Exception) {
                 throw new InvalidArgumentException('Invalid column configuration');
@@ -421,9 +422,10 @@ final class GridService implements GridServiceInterface
         }
 
         $data = [];
+        $columns = $this->getConfigurationFromArray($gridParameter->getColumns());
         foreach ($items as $item) {
             $data[] = $this->getGridDataForElement(
-                $this->getConfigurationFromArray($gridParameter->getColumns()),
+                $columns,
                 $item,
                 $elementType,
                 $item->getId()

--- a/tests/Unit/Asset/Schema/Grid/ColumnSchemaTest.php
+++ b/tests/Unit/Asset/Schema/Grid/ColumnSchemaTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Asset\Schema\Grid;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\Grid\ColumnSchema;
+
+/**
+ * @internal
+ */
+final class ColumnSchemaTest extends Unit
+{
+    public function testGettersReturnConstructorValues(): void
+    {
+        $column = new ColumnSchema('id', null, ['system'], 200);
+
+        $this->assertSame('id', $column->getKey());
+        $this->assertNull($column->getLocale());
+        $this->assertSame(['system'], $column->getGroup());
+        $this->assertSame(200, $column->getWidth());
+    }
+
+    public function testWidthDefaultsToNull(): void
+    {
+        $column = new ColumnSchema('id', 'de', ['system']);
+
+        $this->assertNull($column->getWidth());
+    }
+
+    public function testToArrayContainsAllFields(): void
+    {
+        $column = new ColumnSchema('id', 'de', ['system'], 150);
+
+        $this->assertSame(
+            [
+                'key' => 'id',
+                'locale' => 'de',
+                'group' => ['system'],
+                'width' => 150,
+            ],
+            $column->toArray()
+        );
+    }
+
+    public function testToArrayContainsNullWidthWhenNotProvided(): void
+    {
+        $column = new ColumnSchema('id', 'de', ['system']);
+
+        $result = $column->toArray();
+
+        $this->assertArrayHasKey('width', $result);
+        $this->assertNull($result['width']);
+    }
+}

--- a/tests/Unit/Grid/Schema/ColumnTest.php
+++ b/tests/Unit/Grid/Schema/ColumnTest.php
@@ -90,4 +90,37 @@ final class ColumnTest extends Unit
         $this->assertSame('manufacturer', $configs->getColumns()[0]->getRelation());
         $this->assertInstanceOf(RelationFieldConfig::class, $configs->getColumns()[0]);
     }
+
+    public function testWidthDefaultsToNull(): void
+    {
+        $column = new Column('id', 'en', 'system.id', ['system'], []);
+
+        $this->assertNull($column->getWidth());
+    }
+
+    public function testWidthIsSetWhenProvided(): void
+    {
+        $column = new Column('id', 'en', 'system.id', ['system'], [], 200);
+
+        $this->assertSame(200, $column->getWidth());
+    }
+
+    public function testToArrayContainsWidth(): void
+    {
+        $column = new Column('id', 'en', 'system.id', ['system'], [], 150);
+
+        $result = $column->toArray();
+
+        $this->assertSame(150, $result['width']);
+    }
+
+    public function testToArrayContainsNullWidthWhenNotProvided(): void
+    {
+        $column = new Column('id', 'en', 'system.id', ['system'], []);
+
+        $result = $column->toArray();
+
+        $this->assertArrayHasKey('width', $result);
+        $this->assertNull($result['width']);
+    }
 }

--- a/tests/Unit/Grid/Service/ConfigurationServiceTest.php
+++ b/tests/Unit/Grid/Service/ConfigurationServiceTest.php
@@ -1,0 +1,435 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Service;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Hydrator\ConfigurationHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Hydrator\DetailedConfigurationHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Repository\ConfigurationRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnConfigurationServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ConfigurationService;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\FavoriteServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\UserRoleShareServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+final class ConfigurationServiceTest extends Unit
+{
+    public function testBuildDefaultConfigurationMatchesPredefinedColumn(): void
+    {
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration('id', ['system']),
+        ];
+        $predefined = [
+            ['key' => 'id', 'group' => 'system'],
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, $predefined);
+
+        $columns = $result->getColumns();
+        $this->assertCount(1, $columns);
+        $this->assertSame('id', $columns[0]->getKey());
+        $this->assertSame(['system'], $columns[0]->getGroup());
+    }
+
+    public function testBuildDefaultConfigurationExcludesUnmatchedPredefinedColumn(): void
+    {
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration('id', ['system']),
+        ];
+        $predefined = [
+            ['key' => 'nonexistent', 'group' => 'system'],
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, $predefined);
+
+        $this->assertCount(0, $result->getColumns());
+    }
+
+    public function testBuildDefaultConfigurationExcludesDuplicateMatches(): void
+    {
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration('id', ['system'], 'en'),
+            $this->createColumnConfiguration('id', ['system'], 'de'),
+        ];
+        $predefined = [
+            ['key' => 'id', 'group' => 'system'],
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, $predefined);
+
+        $this->assertCount(0, $result->getColumns());
+    }
+
+    public function testBuildDefaultConfigurationMatchesMultiplePredefinedColumns(): void
+    {
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration('id', ['system']),
+            $this->createColumnConfiguration('fullpath', ['system']),
+            $this->createColumnConfiguration('creationDate', ['system']),
+        ];
+        $predefined = [
+            ['key' => 'id', 'group' => 'system'],
+            ['key' => 'fullpath', 'group' => 'system'],
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, $predefined);
+
+        $columns = $result->getColumns();
+        $this->assertCount(2, $columns);
+        $this->assertSame('id', $columns[0]->getKey());
+        $this->assertSame('fullpath', $columns[1]->getKey());
+    }
+
+    public function testBuildDefaultConfigurationExcludesHiddenGridColumn(): void
+    {
+        $classDefinition = new ClassDefinition();
+        $classDefinition->setPropertyVisibility([
+            'grid' => ['id' => false, 'path' => true],
+            'search' => ['id' => true, 'path' => true],
+        ]);
+
+        $service = $this->createService(
+            $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+                'getById' => $classDefinition,
+            ])
+        );
+
+        $available = [
+            $this->createColumnConfiguration('id', ['system']),
+        ];
+        $predefined = [
+            ['key' => 'id', 'group' => 'system'],
+        ];
+
+        $result = $service->buildDefaultConfiguration(
+            $available,
+            $predefined,
+            false,
+            true,
+            'CAR'
+        );
+
+        $this->assertCount(0, $result->getColumns());
+    }
+
+    public function testBuildDefaultConfigurationExcludesHiddenSearchColumn(): void
+    {
+        $classDefinition = new ClassDefinition();
+        $classDefinition->setPropertyVisibility([
+            'grid' => ['id' => true, 'path' => true],
+            'search' => ['id' => false, 'path' => true],
+        ]);
+
+        $service = $this->createService(
+            $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+                'getById' => $classDefinition,
+            ])
+        );
+
+        $available = [
+            $this->createColumnConfiguration('id', ['system']),
+        ];
+        $predefined = [
+            ['key' => 'id', 'group' => 'system'],
+        ];
+
+        $result = $service->buildDefaultConfiguration(
+            $available,
+            $predefined,
+            true,
+            false,
+            'CAR'
+        );
+
+        $this->assertCount(0, $result->getColumns());
+    }
+
+    public function testBuildDefaultConfigurationFullpathUsesPathVisibility(): void
+    {
+        $classDefinition = new ClassDefinition();
+        $classDefinition->setPropertyVisibility([
+            'grid' => ['fullpath' => true, 'path' => false],
+            'search' => [],
+        ]);
+
+        $service = $this->createService(
+            $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+                'getById' => $classDefinition,
+            ])
+        );
+
+        $available = [
+            $this->createColumnConfiguration('fullpath', ['system']),
+        ];
+        $predefined = [
+            ['key' => 'fullpath', 'group' => 'system'],
+        ];
+
+        $result = $service->buildDefaultConfiguration(
+            $available,
+            $predefined,
+            false,
+            true,
+            'CAR'
+        );
+
+        $this->assertCount(0, $result->getColumns());
+    }
+
+    public function testBuildDefaultConfigurationNoVisibilityFilteringWithoutClassId(): void
+    {
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration('id', ['system']),
+        ];
+        $predefined = [
+            ['key' => 'id', 'group' => 'system'],
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, $predefined);
+
+        $this->assertCount(1, $result->getColumns());
+    }
+
+    public function testBuildDefaultConfigurationResolverExceptionSkipsVisibilityFiltering(): void
+    {
+        $service = $this->createService(
+            $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+                'getById' => static function (): never {
+                    throw new Exception('Class not found');
+                },
+            ])
+        );
+
+        $available = [
+            $this->createColumnConfiguration('id', ['system']),
+        ];
+        $predefined = [
+            ['key' => 'id', 'group' => 'system'],
+        ];
+
+        $result = $service->buildDefaultConfiguration(
+            $available,
+            $predefined,
+            false,
+            false,
+            'NONEXISTENT'
+        );
+
+        $this->assertCount(1, $result->getColumns());
+    }
+
+    public function testBuildDefaultConfigurationAppendsVisibleSearchColumns(): void
+    {
+        $fieldDefinition = $this->makeEmpty(Data::class, [
+            'getVisibleSearch' => true,
+        ]);
+
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration(
+                'name',
+                ['data_object'],
+                null,
+                ['fieldDefinition' => $fieldDefinition]
+            ),
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, [], true);
+
+        $columns = $result->getColumns();
+        $this->assertCount(1, $columns);
+        $this->assertSame('name', $columns[0]->getKey());
+    }
+
+    public function testBuildDefaultConfigurationAppendsVisibleGridViewColumns(): void
+    {
+        $fieldDefinition = $this->makeEmpty(Data::class, [
+            'getVisibleGridView' => true,
+        ]);
+
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration(
+                'name',
+                ['data_object'],
+                null,
+                ['fieldDefinition' => $fieldDefinition]
+            ),
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, [], false, true);
+
+        $columns = $result->getColumns();
+        $this->assertCount(1, $columns);
+        $this->assertSame('name', $columns[0]->getKey());
+    }
+
+    public function testBuildDefaultConfigurationSkipsNonVisibleSearchColumns(): void
+    {
+        $fieldDefinition = $this->makeEmpty(Data::class, [
+            'getVisibleSearch' => false,
+        ]);
+
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration(
+                'name',
+                ['data_object'],
+                null,
+                ['fieldDefinition' => $fieldDefinition]
+            ),
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, [], true);
+
+        $this->assertCount(0, $result->getColumns());
+    }
+
+    public function testBuildDefaultConfigurationSkipsColumnsWithoutFieldDefinition(): void
+    {
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration('id', ['system'], null, []),
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, [], true, true);
+
+        $this->assertCount(0, $result->getColumns());
+    }
+
+    public function testBuildDefaultConfigurationCombinesPredefinedAndSearchColumns(): void
+    {
+        $fieldDefinition = $this->makeEmpty(Data::class, [
+            'getVisibleSearch' => true,
+        ]);
+
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration('id', ['system']),
+            $this->createColumnConfiguration(
+                'name',
+                ['data_object'],
+                null,
+                ['fieldDefinition' => $fieldDefinition]
+            ),
+        ];
+        $predefined = [
+            ['key' => 'id', 'group' => 'system'],
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, $predefined, true);
+
+        $columns = $result->getColumns();
+        $this->assertCount(2, $columns);
+        $this->assertSame('id', $columns[0]->getKey());
+        $this->assertSame('name', $columns[1]->getKey());
+    }
+
+    public function testBuildDefaultConfigurationPreservesLocale(): void
+    {
+        $service = $this->createService();
+
+        $available = [
+            $this->createColumnConfiguration('name', ['data_object'], 'de'),
+        ];
+        $predefined = [
+            ['key' => 'name', 'group' => 'data_object'],
+        ];
+
+        $result = $service->buildDefaultConfiguration($available, $predefined);
+
+        $this->assertSame('de', $result->getColumns()[0]->getLocale());
+    }
+
+    public function testBuildDefaultConfigurationReturnsDefaultMetadata(): void
+    {
+        $service = $this->createService();
+
+        $result = $service->buildDefaultConfiguration([], []);
+
+        $this->assertSame('Predefined', $result->getName());
+        $this->assertSame('Default Grid Configuration', $result->getDescription());
+        $this->assertFalse($result->isShareGlobal());
+        $this->assertFalse($result->isSaveFilter());
+        $this->assertFalse($result->isSetAsFavorite());
+        $this->assertSame([], $result->getSharedUsers());
+        $this->assertSame([], $result->getSharedRoles());
+        $this->assertSame([], $result->getFilter());
+    }
+
+    private function createService(
+        ?ClassDefinitionResolverInterface $classDefinitionResolver = null,
+    ): ConfigurationService {
+        return new ConfigurationService(
+            $this->makeEmpty(ColumnConfigurationServiceInterface::class),
+            $this->makeEmpty(ConfigurationRepositoryInterface::class),
+            $this->makeEmpty(ConfigurationHydratorInterface::class),
+            $this->makeEmpty(UserRoleShareServiceInterface::class),
+            $this->makeEmpty(SecurityServiceInterface::class),
+            $this->makeEmpty(EventDispatcherInterface::class),
+            $this->makeEmpty(DetailedConfigurationHydratorInterface::class),
+            $this->makeEmpty(FavoriteServiceInterface::class),
+            $classDefinitionResolver ?? $this->makeEmpty(ClassDefinitionResolverInterface::class),
+            [],
+            [],
+            [],
+            [],
+        );
+    }
+
+    private function createColumnConfiguration(
+        string $key,
+        array $group,
+        ?string $locale = null,
+        array $config = [],
+    ): ColumnConfiguration {
+        return new ColumnConfiguration(
+            $key,
+            $group,
+            false,
+            false,
+            false,
+            false,
+            false,
+            $locale,
+            'string',
+            'string',
+            $config,
+        );
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-ui-bundle/issues/1431

## Additional info
- extend the schemas and add possibility to store width in the grid config