### PR TITLE
[DataObject] Resolve nested field definitions for dynamic select options

### DIFF
--- a/src/DataObject/Service/SelectOptionsService.php
+++ b/src/DataObject/Service/SelectOptionsService.php
@@ -24,6 +24,7 @@ use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\SelectOption;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\FieldDefinition\Parser\DotNotationParserInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Multiselect;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Select;
 use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\SelectOptionsProviderInterface;
@@ -42,7 +43,7 @@ final readonly class SelectOptionsService implements SelectOptionsServiceInterfa
         private OptionsProviderResolverInterface $optionsProviderResolver,
         private SelectOptionHydratorInterface $selectOptionHydrator,
         private EventDispatcherInterface $eventDispatcher,
-
+        private DotNotationParserInterface $dotNotationParser,
     ) {
     }
 
@@ -133,7 +134,9 @@ final readonly class SelectOptionsService implements SelectOptionsServiceInterfa
         Concrete $object
     ): Select|Multiselect {
         try {
-            $fieldDefinition = $object->getClass()->getFieldDefinition($selectOptionsParameter->getFieldName());
+            $fieldDefinition = $this->dotNotationParser
+                ->parse($object, $selectOptionsParameter->getFieldName())
+                ->getFieldDefinition();
         } catch (Exception) {
             throw new NotFoundException('class', $object->getClassId());
         }


### PR DESCRIPTION
## Changes in this pull request

The `/data-objects/select-options` endpoint resolved the field definition via `$object->getClass()->getFieldDefinition($fieldName)`, which only finds **top-level** fields. As a result, dynamic select/multiselect options providers on fields nested in **localized fields, blocks, field collections or object bricks** could not be resolved (the endpoint returned not-found).

This change resolves the field definition through the existing `DotNotationParser` (the same parser `PathFormatterService` uses), so nested dot-notation field names resolve correctly. The options-provider context is additionally enriched with the resolved container context (`containerType`, leaf `fieldname`, `subContainerType`, `subContainerKey`), mirroring `PathFormatterService::convert()`.

Companion to the studio-ui-bundle change for dynamic select options providers ([#1034](https://github.com/pimcore/studio-ui-bundle/issues/1034)). Top-level dynamic selects already worked; this adds nested-field support.
