### PR TITLE
[Data Object Tree]: Filter out class definition collection based on widget id

### DIFF
--- a/src/Class/Controller/CreatableCollectionController.php
+++ b/src/Class/Controller/CreatableCollectionController.php
@@ -17,6 +17,7 @@ use OpenApi\Attributes\Get;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinitionList;
 use Pimcore\Bundle\StudioBackendBundle\Class\Service\ClassDefinitionServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\StringParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\GenericCollection;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\CollectionJson;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
@@ -59,12 +60,21 @@ final class CreatableCollectionController extends AbstractApiController
         description: 'class_definition_collection_creatable_success_response',
         content: new CollectionJson(new GenericCollection(ClassDefinitionList::class))
     )]
+    #[StringParameter(
+        name: 'widgetId',
+        example: 'object_tree',
+        description: 'class_definition_collection_creatable_widget_id_description',
+        required: false,
+    )]
     #[DefaultResponses([
         HttpResponseCodes::UNAUTHORIZED,
     ])]
-    public function listClasses(): JsonResponse
+    public function listClasses(?string $widgetId = null): JsonResponse
     {
-        $items = $this->classDefinitionService->getClassDefinitionCollection(true);
+        $items = $this->classDefinitionService->getClassDefinitionCollection(
+            creatableOnly: true,
+            widgetId: $widgetId,
+        );
 
         return $this->getPaginatedCollection(
             $this->serializer,

--- a/src/Class/Service/ClassDefinitionService.php
+++ b/src/Class/Service/ClassDefinitionService.php
@@ -24,11 +24,15 @@ use Pimcore\Bundle\StudioBackendBundle\Class\MappedParameter\UpdateParameters;
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinition;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Schema\JsonExport;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\ElementTreeWidgetConfig;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Service\WidgetServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\WidgetTypes;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Model\DataObject\ClassDefinition as CoreClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function in_array;
 
 /**
  * @internal
@@ -41,6 +45,7 @@ final readonly class ClassDefinitionService implements ClassDefinitionServiceInt
         private ClassDefinitionListHydratorInterface $classDefinitionListHydrator,
         private EventDispatcherInterface $eventDispatcher,
         private SecurityServiceInterface $securityService,
+        private WidgetServiceInterface $widgetService,
     ) {
     }
 
@@ -106,9 +111,20 @@ final readonly class ClassDefinitionService implements ClassDefinitionServiceInt
      * {@inheritdoc}
      */
     public function getClassDefinitionCollection(
-        bool $creatableOnly = false
+        bool $creatableOnly = false,
+        ?string $widgetId = null,
     ): array {
-        return $this->hydrateClassDefinitionList($this->getClassDefinitions($creatableOnly));
+        $classDefinitions = $this->getClassDefinitions($creatableOnly);
+        $widgetClasses = $this->resolveWidgetClasses($widgetId);
+
+        if (!empty($widgetClasses)) {
+            $classDefinitions = array_filter(
+                $classDefinitions,
+                static fn (CoreClassDefinition $cd): bool => in_array($cd->getId(), $widgetClasses, true)
+            );
+        }
+
+        return $this->hydrateClassDefinitionList($classDefinitions);
     }
 
     /**
@@ -238,5 +254,23 @@ final readonly class ClassDefinitionService implements ClassDefinitionServiceInt
         );
 
         return $cd;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveWidgetClasses(?string $widgetId): array
+    {
+        if ($widgetId === null) {
+            return [];
+        }
+
+        $widget = $this->widgetService->getWidgetConfigData(WidgetTypes::ELEMENT_TREE->value, $widgetId);
+
+        if ($widget instanceof ElementTreeWidgetConfig) {
+            return $widget->getClasses();
+        }
+
+        return [];
     }
 }

--- a/src/Class/Service/ClassDefinitionServiceInterface.php
+++ b/src/Class/Service/ClassDefinitionServiceInterface.php
@@ -62,7 +62,8 @@ interface ClassDefinitionServiceInterface
      * @return ClassDefinitionList[]
      */
     public function getClassDefinitionCollection(
-        bool $creatableOnly = false
+        bool $creatableOnly = false,
+        ?string $widgetId = null,
     ): array;
 
     /**

--- a/tests/Unit/Class/Service/ClassDefinitionServiceTest.php
+++ b/tests/Unit/Class/Service/ClassDefinitionServiceTest.php
@@ -1,0 +1,237 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Class\Service;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\ClassDefinitionHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\Class\Hydrator\ClassDefinitionListHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Class\Schema\ClassDefinitionList;
+use Pimcore\Bundle\StudioBackendBundle\Class\Service\ClassDefinitionService;
+use Pimcore\Bundle\StudioBackendBundle\Element\Schema\RelatedElementData;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\ElementTreeWidgetConfig;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\WidgetConfig;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Service\WidgetServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Response\ElementIcon;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementIconTypes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Model\DataObject\ClassDefinition as CoreClassDefinition;
+use Pimcore\Model\UserInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+final class ClassDefinitionServiceTest extends Unit
+{
+    /**
+     * @throws Exception
+     */
+    public function testGetCollectionReturnsAll(): void
+    {
+        $service = $this->createService(
+            classDefinitions: $this->createCoreClassDefinitions(['Car', 'News', 'Event']),
+        );
+
+        $result = $service->getClassDefinitionCollection();
+
+        $this->assertCount(3, $result);
+        $this->assertResultContainsIds(['Car', 'News', 'Event'], $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetCollectionFiltersByWidgetClasses(): void
+    {
+        $widget = $this->createElementTreeWidget(['Car', 'Event']);
+
+        $service = $this->createService(
+            classDefinitions: $this->createCoreClassDefinitions(['Car', 'News', 'Event']),
+            widgetConfig: $widget,
+        );
+
+        $result = $service->getClassDefinitionCollection(widgetId: 'test_widget');
+
+        $this->assertCount(2, $result);
+        $this->assertResultContainsIds(['Car', 'Event'], $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetCollectionWithEmptyWidgets(): void
+    {
+        $widget = $this->createElementTreeWidget([]);
+
+        $service = $this->createService(
+            classDefinitions: $this->createCoreClassDefinitions(['Car', 'News']),
+            widgetConfig: $widget,
+        );
+
+        $result = $service->getClassDefinitionCollection(widgetId: 'test_widget');
+
+        $this->assertCount(2, $result);
+        $this->assertResultContainsIds(['Car', 'News'], $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetCollectionCombine(): void
+    {
+        $widget = $this->createElementTreeWidget(['Car', 'News']);
+
+        $currentUser = $this->makeEmpty(UserInterface::class, [
+            'isAllowed' => function (string $classId): bool {
+                return $classId === 'Car' || $classId === 'Event';
+            },
+        ]);
+
+        $service = $this->createService(
+            classDefinitions: $this->createCoreClassDefinitions(['Car', 'News', 'Event']),
+            widgetConfig: $widget,
+            currentUser: $currentUser,
+        );
+
+        $result = $service->getClassDefinitionCollection(creatableOnly: true, widgetId: 'test_widget');
+
+        $this->assertCount(1, $result);
+        $this->assertResultContainsIds(['Car'], $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetCollectionWithNonElementTreeWidgetReturnsAll(): void
+    {
+        $icon = new ElementIcon(ElementIconTypes::PATH->value, '/icon.svg');
+        $baseWidget = new WidgetConfig('test_widget', 'Test', 'some_other_type', $icon);
+
+        $service = $this->createService(
+            classDefinitions: $this->createCoreClassDefinitions(['Car', 'News']),
+            widgetConfig: $baseWidget,
+        );
+
+        $result = $service->getClassDefinitionCollection(widgetId: 'test_widget');
+
+        $this->assertCount(2, $result);
+        $this->assertResultContainsIds(['Car', 'News'], $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetCollectionCreatableOnlyFiltersWithoutWidget(): void
+    {
+        $currentUser = $this->makeEmpty(UserInterface::class, [
+            'isAllowed' => function (string $classId): bool {
+                return $classId === 'News';
+            },
+        ]);
+
+        $service = $this->createService(
+            classDefinitions: $this->createCoreClassDefinitions(['Car', 'News', 'Event']),
+            currentUser: $currentUser,
+        );
+
+        $result = $service->getClassDefinitionCollection(creatableOnly: true);
+
+        $this->assertCount(1, $result);
+        $this->assertResultContainsIds(['News'], $result);
+    }
+
+    /**
+     * @return CoreClassDefinition[]
+     */
+    private function createCoreClassDefinitions(array $ids): array
+    {
+        return array_map(static function (string $id): CoreClassDefinition {
+            $cd = new CoreClassDefinition();
+            $cd->setId($id);
+            $cd->setName($id);
+
+            return $cd;
+        }, $ids);
+    }
+
+    private function createElementTreeWidget(array $classes): ElementTreeWidgetConfig
+    {
+        $icon = new ElementIcon(ElementIconTypes::PATH->value, '/icon.svg');
+
+        return new ElementTreeWidgetConfig(
+            'test_widget',
+            'Test Widget',
+            [],
+            $icon,
+            ElementTypes::TYPE_DATA_OBJECT,
+            new RelatedElementData(
+                1,
+                ElementTypes::TYPE_OBJECT,
+                ElementTypes::TYPE_FOLDER,
+                '/',
+                null
+            ),
+            false,
+            $classes,
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createService(
+        array $classDefinitions = [],
+        ?WidgetConfig $widgetConfig = null,
+        ?UserInterface $currentUser = null,
+    ): ClassDefinitionService {
+        $icon = new ElementIcon(ElementIconTypes::PATH->value, '/icon.svg');
+
+        $listHydrator = $this->makeEmpty(ClassDefinitionListHydratorInterface::class, [
+            'hydrate' => function (CoreClassDefinition $cd) use ($icon): ClassDefinitionList {
+                return new ClassDefinitionList($cd->getId(), $cd->getName(), $cd->getName(), $icon);
+            },
+        ]);
+
+        $widgetService = $this->makeEmpty(WidgetServiceInterface::class, [
+            'getWidgetConfigData' => $widgetConfig,
+        ]);
+
+        return new ClassDefinitionService(
+            $this->makeEmpty(ClassDefinitionRepositoryInterface::class, [
+                'getClassDefinitions' => $classDefinitions,
+            ]),
+            $this->makeEmpty(ClassDefinitionHydratorInterface::class),
+            $listHydrator,
+            $this->makeEmpty(EventDispatcherInterface::class),
+            $this->makeEmpty(SecurityServiceInterface::class, [
+                'getCurrentUser' => $currentUser ?? $this->makeEmpty(UserInterface::class),
+            ]),
+            $widgetService,
+        );
+    }
+
+    /**
+     * @param ClassDefinitionList[] $result
+     */
+    private function assertResultContainsIds(array $expectedIds, array $result): void
+    {
+        $resultIds = array_map(static fn (ClassDefinitionList $item): string => $item->getId(), $result);
+        sort($expectedIds);
+        sort($resultIds);
+        $this->assertSame($expectedIds, $resultIds);
+    }
+}

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -1650,6 +1650,7 @@ tag_export_description: Export
 class_definition_collection_description: Get collection of all class definitions
 class_definition_collection_summary: Get class definitions collection
 class_definition_collection_success_response: List of class definitions
+class_definition_collection_creatable_widget_id_description: Optional element tree widget ID to filter classes by the widget's allowed classes configuration
 class_definition_create_description: |
   Create a new class definition configuration with the given <strong>{name}</strong> and unique ID <strong>{uid}</strong> <br>
   The <strong>{uid}</strong> must be unique and not already exist.


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-ui-bundle/issues/3740

## Additional info
- add option to filter out class definitions based on provided widget ID as widget can have limited class definitions