### PR TITLE
[Element Editor] Serialize edit-lock flag as isLocked to match OpenAPI schema

### DIFF
--- a/src/Element/Schema/EditLock.php
+++ b/src/Element/Schema/EditLock.php
@@ -47,7 +47,7 @@ final class EditLock implements AdditionalAttributesInterface
     ) {
     }
 
-    public function isLocked(): bool
+    public function getIsLocked(): bool
     {
         return $this->isLocked;
     }

--- a/tests/Unit/Element/Hydrator/EditLockHydratorTest.php
+++ b/tests/Unit/Element/Hydrator/EditLockHydratorTest.php
@@ -30,7 +30,7 @@ final class EditLockHydratorTest extends Unit
 
         $result = $hydrator->hydrateEditLock(null);
 
-        $this->assertFalse($result->isLocked());
+        $this->assertFalse($result->getIsLocked());
         $this->assertNull($result->getUserId());
         $this->assertNull($result->getDate());
         $this->assertNull($result->getUser());
@@ -51,7 +51,7 @@ final class EditLockHydratorTest extends Unit
 
         $result = $hydrator->hydrateEditLock($model);
 
-        $this->assertTrue($result->isLocked());
+        $this->assertTrue($result->getIsLocked());
         $this->assertSame(42, $result->getUserId());
         $this->assertSame(1700000000, $result->getDate());
         $this->assertNotNull($result->getUser());
@@ -70,7 +70,7 @@ final class EditLockHydratorTest extends Unit
 
         $result = $hydrator->hydrateEditLock($model);
 
-        $this->assertTrue($result->isLocked());
+        $this->assertTrue($result->getIsLocked());
         $this->assertSame(99, $result->getUserId());
         $this->assertSame(1700000000, $result->getDate());
         $this->assertNull($result->getUser());


### PR DESCRIPTION
## Changes in this pull request
Part of https://github.com/pimcore/studio-ui-bundle/issues/2318.

The `EditLock` schema documents its flag as `isLocked`, but the response serialised it as `locked` (the serializer strips the `is` prefix from the `isLocked()` getter). Renamed the getter to `getIsLocked()` so the JSON matches the spec.

## Additional info
Companion to the studio-ui-bundle frontend PR.
