### PR TITLE
[Bugfix] Setter adapters drop range/quantity/geo values when a component is empty #18144

### DIFF
--- a/src/DataObject/Data/Adapter/GeoBoundsAdapter.php
+++ b/src/DataObject/Data/Adapter/GeoBoundsAdapter.php
@@ -72,7 +72,7 @@ final readonly class GeoBoundsAdapter implements SetterDataInterface
             }
 
             foreach (Coordinates::values() as $coordinate) {
-                if (empty($data[$direction][$coordinate])) {
+                if (!isset($data[$direction][$coordinate])) {
                     return false;
                 }
             }

--- a/src/DataObject/Data/Adapter/InputQuantityValueAdapter.php
+++ b/src/DataObject/Data/Adapter/InputQuantityValueAdapter.php
@@ -40,7 +40,7 @@ final readonly class InputQuantityValueAdapter implements SetterDataInterface
         $value = $data[$key]['value'] ?? null;
         $unit = $data[$key]['unitId'] ?? null;
 
-        if (!$value) {
+        if ($value === null || $value === '') {
             return null;
         }
 

--- a/src/DataObject/Data/Adapter/NumericRangeAdapter.php
+++ b/src/DataObject/Data/Adapter/NumericRangeAdapter.php
@@ -39,10 +39,17 @@ final readonly class NumericRangeAdapter implements SetterDataInterface
         bool $isPatch = false
     ): ?NumericRange {
         $numericRangeData = $data[$key] ?? null;
-        if (!isset($numericRangeData['minimum'], $numericRangeData['maximum']) || !is_array($numericRangeData)) {
+        if (!is_array($numericRangeData)) {
             return null;
         }
 
-        return new NumericRange($numericRangeData['minimum'], $numericRangeData['maximum']);
+        $minimum = $numericRangeData['minimum'] ?? null;
+        $maximum = $numericRangeData['maximum'] ?? null;
+
+        if ($minimum === null && $maximum === null) {
+            return null;
+        }
+
+        return new NumericRange($minimum, $maximum);
     }
 }

--- a/src/DataObject/Data/Adapter/QuantityValueAdapter.php
+++ b/src/DataObject/Data/Adapter/QuantityValueAdapter.php
@@ -44,7 +44,7 @@ final readonly class QuantityValueAdapter implements SetterDataInterface
             $unit = null;
         }
 
-        if (!$value) {
+        if ($value === null || $value === '') {
             return null;
         }
 

--- a/src/DataObject/Data/Adapter/QuantityValueRangeAdapter.php
+++ b/src/DataObject/Data/Adapter/QuantityValueRangeAdapter.php
@@ -37,11 +37,11 @@ final readonly class QuantityValueRangeAdapter implements SetterDataInterface
         ?FieldContextData $contextData = null,
         bool $isPatch = false
     ): ?QuantityValueRange {
-        $min = empty($data[$key]['minimum']) ? null : $data[$key]['minimum'];
-        $max = empty($data[$key]['maximum']) ? null : $data[$key]['maximum'];
+        $min = $data[$key]['minimum'] ?? null;
+        $max = $data[$key]['maximum'] ?? null;
         $unit = $data[$key]['unitId'] ?? null;
 
-        if (!$min && !$max) {
+        if ($min === null && $max === null) {
             return null;
         }
 

--- a/tests/Unit/DataObject/Data/Adapter/GeoBoundsAdapterTest.php
+++ b/tests/Unit/DataObject/Data/Adapter/GeoBoundsAdapterTest.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataObject\Data\Adapter;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Adapter\GeoBoundsAdapter;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Geobounds as GeoboundsDefinition;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Data\Geobounds;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ *
+ * @see https://github.com/pimcore/pimcore/issues/18144
+ */
+final class GeoBoundsAdapterTest extends Unit
+{
+    private const NORTH_EAST = ['latitude' => 52.0, 'longitude' => 13.0];
+
+    private const SOUTH_WEST = ['latitude' => 51.0, 'longitude' => 12.0];
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterWithCoordinates(): void
+    {
+        $result = $this->callAdapter(['bounds' => ['northEast' => self::NORTH_EAST, 'southWest' => self::SOUTH_WEST]]);
+
+        $this->assertInstanceOf(Geobounds::class, $result);
+        $this->assertSame(52.0, $result->getNorthEast()->getLatitude());
+        $this->assertSame(12.0, $result->getSouthWest()->getLongitude());
+    }
+
+    /**
+     * Regression test for #18144: a coordinate of 0 must not drop the whole bounds value.
+     *
+     * @throws Exception
+     */
+    public function testGetDataForSetterKeepsZeroCoordinates(): void
+    {
+        $zero = ['latitude' => 0.0, 'longitude' => 0.0];
+
+        $result = $this->callAdapter(['bounds' => ['northEast' => $zero, 'southWest' => $zero]]);
+
+        $this->assertInstanceOf(Geobounds::class, $result);
+        $this->assertSame(0.0, $result->getNorthEast()->getLatitude());
+        $this->assertSame(0.0, $result->getSouthWest()->getLongitude());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterReturnsNullWhenCoordinateNull(): void
+    {
+        $result = $this->callAdapter([
+            'bounds' => [
+                'northEast' => ['latitude' => null, 'longitude' => 13.0],
+                'southWest' => self::SOUTH_WEST,
+            ],
+        ]);
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterReturnsNullWhenDirectionMissing(): void
+    {
+        $this->assertNull($this->callAdapter(['bounds' => ['northEast' => self::NORTH_EAST]]));
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function callAdapter(array $data): ?Geobounds
+    {
+        return (new GeoBoundsAdapter())->getDataForSetter(
+            $this->makeEmpty(Concrete::class),
+            $this->makeEmpty(GeoboundsDefinition::class),
+            'bounds',
+            $data,
+            $this->makeEmpty(UserInterface::class)
+        );
+    }
+}

--- a/tests/Unit/DataObject/Data/Adapter/InputQuantityValueAdapterTest.php
+++ b/tests/Unit/DataObject/Data/Adapter/InputQuantityValueAdapterTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataObject\Data\Adapter;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Adapter\InputQuantityValueAdapter;
+use Pimcore\Model\DataObject\ClassDefinition\Data\InputQuantityValue as InputQuantityValueDefinition;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Data\InputQuantityValue;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ *
+ * @see https://github.com/pimcore/pimcore/issues/18144
+ */
+final class InputQuantityValueAdapterTest extends Unit
+{
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterWithValue(): void
+    {
+        $result = $this->callAdapter(['quantity' => ['value' => 'abc', 'unitId' => null]]);
+
+        $this->assertInstanceOf(InputQuantityValue::class, $result);
+        $this->assertSame('abc', $result->getValue());
+    }
+
+    /**
+     * Regression test for #18144: the string "0" is a valid input value and must be persisted.
+     *
+     * @throws Exception
+     */
+    public function testGetDataForSetterKeepsZeroStringValue(): void
+    {
+        $result = $this->callAdapter(['quantity' => ['value' => '0', 'unitId' => null]]);
+
+        $this->assertInstanceOf(InputQuantityValue::class, $result);
+        $this->assertSame('0', $result->getValue());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterReturnsNullWhenValueNull(): void
+    {
+        $this->assertNull($this->callAdapter(['quantity' => ['value' => null, 'unitId' => null]]));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterReturnsNullWhenValueEmptyString(): void
+    {
+        $this->assertNull($this->callAdapter(['quantity' => ['value' => '', 'unitId' => null]]));
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function callAdapter(array $data): ?InputQuantityValue
+    {
+        return (new InputQuantityValueAdapter())->getDataForSetter(
+            $this->makeEmpty(Concrete::class),
+            $this->makeEmpty(InputQuantityValueDefinition::class),
+            'quantity',
+            $data,
+            $this->makeEmpty(UserInterface::class)
+        );
+    }
+}

--- a/tests/Unit/DataObject/Data/Adapter/NumericRangeAdapterTest.php
+++ b/tests/Unit/DataObject/Data/Adapter/NumericRangeAdapterTest.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataObject\Data\Adapter;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Adapter\NumericRangeAdapter;
+use Pimcore\Model\DataObject\ClassDefinition\Data\NumericRange as NumericRangeDefinition;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Data\NumericRange;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ *
+ * @see https://github.com/pimcore/pimcore/issues/18144
+ */
+final class NumericRangeAdapterTest extends Unit
+{
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterWithBothBounds(): void
+    {
+        $result = $this->callAdapter(['range' => ['minimum' => 5, 'maximum' => 10]]);
+
+        $this->assertInstanceOf(NumericRange::class, $result);
+        $this->assertSame(5, $result->getMinimum());
+        $this->assertSame(10, $result->getMaximum());
+    }
+
+    /**
+     * Regression test for #18144: a range with only the minimum set must be persisted.
+     *
+     * @throws Exception
+     */
+    public function testGetDataForSetterWithMinimumOnly(): void
+    {
+        $result = $this->callAdapter(['range' => ['minimum' => 5, 'maximum' => null]]);
+
+        $this->assertInstanceOf(NumericRange::class, $result);
+        $this->assertSame(5, $result->getMinimum());
+        $this->assertNull($result->getMaximum());
+    }
+
+    /**
+     * Regression test for #18144: a range with only the maximum set must be persisted.
+     *
+     * @throws Exception
+     */
+    public function testGetDataForSetterWithMaximumOnly(): void
+    {
+        $result = $this->callAdapter(['range' => ['maximum' => 10]]);
+
+        $this->assertInstanceOf(NumericRange::class, $result);
+        $this->assertNull($result->getMinimum());
+        $this->assertSame(10, $result->getMaximum());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterKeepsZeroBound(): void
+    {
+        $result = $this->callAdapter(['range' => ['minimum' => 0, 'maximum' => null]]);
+
+        $this->assertInstanceOf(NumericRange::class, $result);
+        $this->assertSame(0, $result->getMinimum());
+        $this->assertNull($result->getMaximum());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterReturnsNullWhenBothBoundsNull(): void
+    {
+        $this->assertNull($this->callAdapter(['range' => ['minimum' => null, 'maximum' => null]]));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterReturnsNullWhenValueIsNotAnArray(): void
+    {
+        $this->assertNull($this->callAdapter(['range' => null]));
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function callAdapter(array $data): ?NumericRange
+    {
+        $adapter = new NumericRangeAdapter();
+
+        return $adapter->getDataForSetter(
+            $this->makeEmpty(Concrete::class),
+            $this->makeEmpty(NumericRangeDefinition::class),
+            'range',
+            $data,
+            $this->makeEmpty(UserInterface::class)
+        );
+    }
+}

--- a/tests/Unit/DataObject/Data/Adapter/QuantityValueAdapterTest.php
+++ b/tests/Unit/DataObject/Data/Adapter/QuantityValueAdapterTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataObject\Data\Adapter;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Adapter\QuantityValueAdapter;
+use Pimcore\Model\DataObject\ClassDefinition\Data\QuantityValue as QuantityValueDefinition;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Data\QuantityValue;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ *
+ * @see https://github.com/pimcore/pimcore/issues/18144
+ */
+final class QuantityValueAdapterTest extends Unit
+{
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterWithValue(): void
+    {
+        $result = $this->callAdapter(['quantity' => ['value' => 5, 'unitId' => null]]);
+
+        $this->assertInstanceOf(QuantityValue::class, $result);
+        $this->assertSame(5, $result->getValue());
+    }
+
+    /**
+     * Regression test for #18144: a value of 0 must be persisted, not treated as empty.
+     *
+     * @throws Exception
+     */
+    public function testGetDataForSetterKeepsZeroValue(): void
+    {
+        $result = $this->callAdapter(['quantity' => ['value' => 0, 'unitId' => null]]);
+
+        $this->assertInstanceOf(QuantityValue::class, $result);
+        $this->assertSame(0, $result->getValue());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterReturnsNullWhenValueNull(): void
+    {
+        $this->assertNull($this->callAdapter(['quantity' => ['value' => null, 'unitId' => null]]));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterReturnsNullWhenValueEmptyString(): void
+    {
+        $this->assertNull($this->callAdapter(['quantity' => ['value' => '', 'unitId' => null]]));
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function callAdapter(array $data): ?QuantityValue
+    {
+        return (new QuantityValueAdapter())->getDataForSetter(
+            $this->makeEmpty(Concrete::class),
+            $this->makeEmpty(QuantityValueDefinition::class),
+            'quantity',
+            $data,
+            $this->makeEmpty(UserInterface::class)
+        );
+    }
+}

--- a/tests/Unit/DataObject/Data/Adapter/QuantityValueRangeAdapterTest.php
+++ b/tests/Unit/DataObject/Data/Adapter/QuantityValueRangeAdapterTest.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataObject\Data\Adapter;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Adapter\QuantityValueRangeAdapter;
+use Pimcore\Model\DataObject\ClassDefinition\Data\QuantityValueRange as QuantityValueRangeDefinition;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Data\QuantityValueRange;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ *
+ * @see https://github.com/pimcore/pimcore/issues/18144
+ */
+final class QuantityValueRangeAdapterTest extends Unit
+{
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterWithBothBounds(): void
+    {
+        $result = $this->callAdapter(['range' => ['minimum' => 5, 'maximum' => 10, 'unitId' => null]]);
+
+        $this->assertInstanceOf(QuantityValueRange::class, $result);
+        $this->assertSame(5, $result->getMinimum());
+        $this->assertSame(10, $result->getMaximum());
+    }
+
+    /**
+     * Regression test for #18144: a single bound (incl. 0) must be persisted.
+     *
+     * @throws Exception
+     */
+    public function testGetDataForSetterKeepsZeroMinimumOnly(): void
+    {
+        $result = $this->callAdapter(['range' => ['minimum' => 0, 'maximum' => null, 'unitId' => null]]);
+
+        $this->assertInstanceOf(QuantityValueRange::class, $result);
+        $this->assertSame(0, $result->getMinimum());
+        $this->assertNull($result->getMaximum());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterWithMaximumOnly(): void
+    {
+        $result = $this->callAdapter(['range' => ['minimum' => null, 'maximum' => 10, 'unitId' => null]]);
+
+        $this->assertInstanceOf(QuantityValueRange::class, $result);
+        $this->assertNull($result->getMinimum());
+        $this->assertSame(10, $result->getMaximum());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterReturnsNullWhenBothBoundsNull(): void
+    {
+        $this->assertNull($this->callAdapter(['range' => ['minimum' => null, 'maximum' => null, 'unitId' => null]]));
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function callAdapter(array $data): ?QuantityValueRange
+    {
+        return (new QuantityValueRangeAdapter())->getDataForSetter(
+            $this->makeEmpty(Concrete::class),
+            $this->makeEmpty(QuantityValueRangeDefinition::class),
+            'range',
+            $data,
+            $this->makeEmpty(UserInterface::class)
+        );
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Several `getDataForSetter()` adapters discarded the **whole** value before saving when one component was `NULL` or `0`. This is the Studio write-path counterpart to the core read-path fix in https://github.com/pimcore/pimcore/pull/19197.

- **NumericRangeAdapter** — used `isset()` on both bounds, so a range with only a minimum or only a maximum was dropped. Now keeps a single provided bound; returns `NULL` only when neither is set. Explicit `=== null` checks also preserve a legitimate `0` bound.
- **QuantityValueAdapter / InputQuantityValueAdapter** — used `if (!$value)`, dropping a value of `0` (resp. the string `"0"`). Now reject only `null`/empty-string.
- **QuantityValueRangeAdapter** — used `empty()` on the bounds, dropping a `0` minimum/maximum. Now null-aware (`0`-safe), keeps a single bound.
- **GeoBoundsAdapter::validateBounds()** — used `empty()` per coordinate, dropping bounds containing a `0` latitude/longitude. Now uses `isset()` (null-aware, `0`-safe).

Unit tests added for each adapter (single component / `0` / null cases).

### How to reproduce
In Studio, on an unpublished object: set only the minimum of a `NumericRange` (or a `0` value on a `QuantityValue`, or a `0` coordinate on a `Geobounds`), save, reload → the value was gone.

## Additional info
- Reported issue: https://github.com/pimcore/pimcore/issues/18144
- Core (read-path) fix, targeting `12.3`: https://github.com/pimcore/pimcore/pull/19197
- Cross-repo: this issue lives in pimcore/pimcore, so it is closed by the core PR above rather than auto-closed here.

Related to https://github.com/pimcore/pimcore/issues/18144