### PR TITLE
[Performance] Improve performance for a large translation collection

### DIFF
--- a/src/ClassificationStore/Repository/CollectionConfigRepository.php
+++ b/src/ClassificationStore/Repository/CollectionConfigRepository.php
@@ -49,9 +49,7 @@ final class CollectionConfigRepository implements CollectionConfigRepositoryInte
             $this->applyCollectionIdsFilter($list, $collectionIds);
         }
 
-        if ($searchTerm !== null) {
-            $this->searchHelperService->applySearchTermFilter($list, $searchTerm);
-        }
+        $this->searchHelperService->applySearchTermFilter($list, $searchTerm);
 
         return $list->load();
     }

--- a/src/ClassificationStore/Repository/Configuration/CollectionRepository.php
+++ b/src/ClassificationStore/Repository/Configuration/CollectionRepository.php
@@ -135,10 +135,6 @@ final readonly class CollectionRepository implements CollectionRepositoryInterfa
             return;
         }
 
-        if ($searchFilter->getFilterValue() === '' || $searchFilter->getFilterValue() === null) {
-            return;
-        }
-
         $this->searchHelperService->applySearchTermFilter($listing, $searchFilter->getFilterValue());
     }
 }

--- a/src/ClassificationStore/Repository/Configuration/GroupRepository.php
+++ b/src/ClassificationStore/Repository/Configuration/GroupRepository.php
@@ -130,10 +130,6 @@ final readonly class GroupRepository implements GroupRepositoryInterface
             return;
         }
 
-        if ($searchFilter->getFilterValue() === '' || $searchFilter->getFilterValue() === null) {
-            return;
-        }
-
         $this->searchHelperService->applySearchTermFilter($listing, $searchFilter->getFilterValue());
     }
 }

--- a/src/ClassificationStore/Repository/Configuration/KeyRepository.php
+++ b/src/ClassificationStore/Repository/Configuration/KeyRepository.php
@@ -227,10 +227,6 @@ final readonly class KeyRepository implements KeyRepositoryInterface
             return;
         }
 
-        if ($searchFilter->getFilterValue() === '' || $searchFilter->getFilterValue() === null) {
-            return;
-        }
-
         $this->searchHelperService->applyKeySearchFilter($listing, $searchFilter->getFilterValue());
     }
 }

--- a/src/ClassificationStore/Repository/GroupConfigRepository.php
+++ b/src/ClassificationStore/Repository/GroupConfigRepository.php
@@ -47,9 +47,7 @@ final class GroupConfigRepository implements GroupConfigRepositoryInterface
         $listing->setOrderKey('id');
         $listing->setCondition('storeId = ?', $storeId);
 
-        if ($searchTerm !== null) {
-            $this->searchHelperService->applySearchTermFilter($listing, $searchTerm);
-        }
+        $this->searchHelperService->applySearchTermFilter($listing, $searchTerm);
 
         if ($groupIds !== null) {
             $this->applyGroupIdsFilter($listing, $groupIds);

--- a/src/ClassificationStore/Repository/KeyGroupRelationRepository.php
+++ b/src/ClassificationStore/Repository/KeyGroupRelationRepository.php
@@ -96,9 +96,7 @@ final readonly class KeyGroupRelationRepository implements KeyGroupRelationRepos
         $listing->setOrderKey('sorter');
         $this->applyGroupIdsFilter($listing, $groupIds);
 
-        if ($searchTerm !== null && $searchTerm !== '') {
-            $this->searchHelperService->applyKeyGroupRelationSearchFilter($listing, $searchTerm);
-        }
+        $this->searchHelperService->applyKeyGroupRelationSearchFilter($listing, $searchTerm);
 
         return $listing;
     }

--- a/src/ClassificationStore/Service/SearchHelperService.php
+++ b/src/ClassificationStore/Service/SearchHelperService.php
@@ -36,6 +36,10 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
 
     public function applySearchTermFilter(GroupConfigListing|CollectionConfigListing $list, string $searchTerm): void
     {
+        if ('' === trim($searchTerm)) {
+            return;
+        }
+
         $searchTerms = $this->getTranslatedSearchFilterTerms($searchTerm);
 
         $conditions = [];
@@ -51,6 +55,10 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
 
     public function applyKeySearchFilter(KeyConfigListing $listing, string $searchTerm): void
     {
+        if ('' === trim($searchTerm)) {
+            return;
+        }
+
         $listing->addConditionParam(
             '(name LIKE ? OR description LIKE ?)',
             ['%' . $searchTerm . '%', '%' . $searchTerm . '%']
@@ -61,6 +69,10 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
         KeyGroupRelationListing $listing,
         string $searchTerm,
     ): void {
+        if ('' === trim($searchTerm)) {
+            return;
+        }
+
         $searchTerms = $this->getTranslatedSearchFilterTerms($searchTerm);
         $searchFilterConditions = [];
 
@@ -79,6 +91,10 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
 
     public function getTranslatedSearchFilterTerms(string $searchTerm): array
     {
+        if ('' === trim($searchTerm)) {
+            return [$searchTerm];
+        }
+
         try {
             $user = $this->securityService->getCurrentUser();
 

--- a/src/ClassificationStore/Service/SearchHelperService.php
+++ b/src/ClassificationStore/Service/SearchHelperService.php
@@ -36,7 +36,7 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
 
     public function applySearchTermFilter(GroupConfigListing|CollectionConfigListing $list, string $searchTerm): void
     {
-        if ('' === trim($searchTerm)) {
+        if (trim($searchTerm) === '') {
             return;
         }
 
@@ -55,7 +55,7 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
 
     public function applyKeySearchFilter(KeyConfigListing $listing, string $searchTerm): void
     {
-        if ('' === trim($searchTerm)) {
+        if (trim($searchTerm) === '') {
             return;
         }
 
@@ -69,7 +69,7 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
         KeyGroupRelationListing $listing,
         string $searchTerm,
     ): void {
-        if ('' === trim($searchTerm)) {
+        if (trim($searchTerm) === '') {
             return;
         }
 
@@ -91,7 +91,7 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
 
     public function getTranslatedSearchFilterTerms(string $searchTerm): array
     {
-        if ('' === trim($searchTerm)) {
+        if (trim($searchTerm) === '') {
             return [$searchTerm];
         }
 

--- a/src/ClassificationStore/Service/SearchHelperService.php
+++ b/src/ClassificationStore/Service/SearchHelperService.php
@@ -34,9 +34,9 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
     ) {
     }
 
-    public function applySearchTermFilter(GroupConfigListing|CollectionConfigListing $list, string $searchTerm): void
+    public function applySearchTermFilter(GroupConfigListing|CollectionConfigListing $list, ?string $searchTerm): void
     {
-        if (trim($searchTerm) === '') {
+        if ($searchTerm === null || trim($searchTerm) === '') {
             return;
         }
 
@@ -53,9 +53,9 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
         $list->addConditionParam('(' . implode(' OR ', $conditions) . ')', $preparedSearchTerms);
     }
 
-    public function applyKeySearchFilter(KeyConfigListing $listing, string $searchTerm): void
+    public function applyKeySearchFilter(KeyConfigListing $listing, ?string $searchTerm): void
     {
-        if (trim($searchTerm) === '') {
+        if ($searchTerm === null || trim($searchTerm) === '') {
             return;
         }
 
@@ -67,9 +67,9 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
 
     public function applyKeyGroupRelationSearchFilter(
         KeyGroupRelationListing $listing,
-        string $searchTerm,
+        ?string $searchTerm,
     ): void {
-        if (trim($searchTerm) === '') {
+        if ($searchTerm === null || trim($searchTerm) === '') {
             return;
         }
 
@@ -91,10 +91,6 @@ final readonly class SearchHelperService implements SearchHelperServiceInterface
 
     public function getTranslatedSearchFilterTerms(string $searchTerm): array
     {
-        if (trim($searchTerm) === '') {
-            return [$searchTerm];
-        }
-
         try {
             $user = $this->securityService->getCurrentUser();
 

--- a/src/ClassificationStore/Service/SearchHelperServiceInterface.php
+++ b/src/ClassificationStore/Service/SearchHelperServiceInterface.php
@@ -23,13 +23,13 @@ use Pimcore\Model\DataObject\Classificationstore\KeyGroupRelation\Listing as Key
  */
 interface SearchHelperServiceInterface
 {
-    public function applySearchTermFilter(GroupConfigListing|CollectionConfigListing $list, string $searchTerm): void;
+    public function applySearchTermFilter(GroupConfigListing|CollectionConfigListing $list, ?string $searchTerm): void;
 
-    public function applyKeySearchFilter(KeyConfigListing $listing, string $searchTerm): void;
+    public function applyKeySearchFilter(KeyConfigListing $listing, ?string $searchTerm): void;
 
     public function applyKeyGroupRelationSearchFilter(
         KeyGroupRelationListing $listing,
-        string $searchTerm,
+        ?string $searchTerm,
     ): void;
 
     public function getTranslatedSearchFilterTerms(string $searchTerm): array;


### PR DESCRIPTION
This pull request improves the robustness of the search filter methods in SearchHelperService.php by introducing early return checks for empty or whitespace-only search terms. This prevents unnecessary processing and avoids potential issues caused by invalid input.
In addition, this change significantly improves performance for large datasets. When working with large translation catalogs (e.g., more than 100,000 entries), search requests previously took 5-6 seconds or longer due to the LIKE %% query logic being executed unnecessarily.
With this fix in place, such requests are short-circuited early, reducing response times dramatically to under 100 ms.

Input validation improvements:

* Added early return checks to `applySearchTermFilter`, `applyKeySearchFilter`, and `applyKeyGroupRelationSearchFilter` methods to exit immediately if the `searchTerm` is empty or contains only whitespace. [[1]](diffhunk://#diff-6992d9d5c8928d3eed5ab6beb5b5ccdd0cf023778215638a1ff9a38327db0f8bR39-R42) [[2]](diffhunk://#diff-6992d9d5c8928d3eed5ab6beb5b5ccdd0cf023778215638a1ff9a38327db0f8bR58-R61) [[3]](diffhunk://#diff-6992d9d5c8928d3eed5ab6beb5b5ccdd0cf023778215638a1ff9a38327db0f8bR72-R75)
* Updated `getTranslatedSearchFilterTerms` to return the original (possibly empty) search term in an array if the input is empty or whitespace, preventing further processing.
* Refactoring: Enforce SRP and single source of truth for search term validation