### PR TITLE
[Search] Add elementType to saved searches

### DIFF
--- a/src/Entity/Search/SavedSearchConfiguration.php
+++ b/src/Entity/Search/SavedSearchConfiguration.php
@@ -50,6 +50,9 @@ class SavedSearchConfiguration implements ShareableConfigurationInterface
     #[ORM\Column(type: 'string', length: 50, nullable: true)]
     private ?string $classId = null;
 
+    #[ORM\Column(type: 'string', length: 50, nullable: true)]
+    private ?string $elementType = null;
+
     #[ORM\Column(type: 'boolean')]
     private bool $createMenuShortcut = false;
 
@@ -104,6 +107,11 @@ class SavedSearchConfiguration implements ShareableConfigurationInterface
     public function getClassId(): ?string
     {
         return $this->classId;
+    }
+
+    public function getElementType(): ?string
+    {
+        return $this->elementType;
     }
 
     public function isCreateMenuShortcut(): bool
@@ -164,6 +172,11 @@ class SavedSearchConfiguration implements ShareableConfigurationInterface
     public function setClassId(?string $classId): void
     {
         $this->classId = $classId;
+    }
+
+    public function setElementType(?string $elementType): void
+    {
+        $this->elementType = $elementType;
     }
 
     public function setCreateMenuShortcut(bool $createMenuShortcut): void

--- a/src/Migrations/Version20260625090000.php
+++ b/src/Migrations/Version20260625090000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Search\SavedSearchConfiguration;
+
+/**
+ * @internal
+ */
+final class Version20260625090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add elementType column to the saved search configuration table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable(SavedSearchConfiguration::TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schema->getTable(SavedSearchConfiguration::TABLE_NAME);
+        if (!$table->hasColumn('elementType')) {
+            $table->addColumn('elementType', 'string', ['notnull' => false, 'length' => 50]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable(SavedSearchConfiguration::TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schema->getTable(SavedSearchConfiguration::TABLE_NAME);
+        if ($table->hasColumn('elementType')) {
+            $table->dropColumn('elementType');
+        }
+    }
+}

--- a/src/Search/Attribute/Request/SavedSearchRequestBody.php
+++ b/src/Search/Attribute/Request/SavedSearchRequestBody.php
@@ -42,6 +42,7 @@ final class SavedSearchRequestBody extends RequestBody
                     new SingleString('name'),
                     new SingleString('description'),
                     new SingleString('classId'),
+                    new SingleString('elementType'),
                     new SingleBoolean('shareGlobal'),
                     new SingleBoolean('createMenuShortcut'),
                     new SingleString('menuShortcutGroup'),

--- a/src/Search/Hydrator/DetailedConfigurationHydrator.php
+++ b/src/Search/Hydrator/DetailedConfigurationHydrator.php
@@ -37,6 +37,7 @@ final readonly class DetailedConfigurationHydrator implements DetailedConfigurat
             createMenuShortcut: $data->isCreateMenuShortcut(),
             menuShortcutGroup: $data->getMenuShortcutGroup(),
             classId: $data->getClassId(),
+            elementType: $data->getElementType(),
             columns: $data->getColumns(),
             filter: $data->getFilter(),
             modificationDate: $data->getModificationDate()->getTimestamp(),

--- a/src/Search/Hydrator/ListItemHydrator.php
+++ b/src/Search/Hydrator/ListItemHydrator.php
@@ -31,6 +31,7 @@ final readonly class ListItemHydrator implements ListItemHydratorInterface
             modificationDate: $data->getModificationDate()->getTimestamp(),
             creationDate: $data->getCreationDate()->getTimestamp(),
             menuShortcutGroup: $data->getMenuShortcutGroup(),
+            elementType: $data->getElementType(),
         );
     }
 }

--- a/src/Search/MappedParameter/SavedSearchParameter.php
+++ b/src/Search/MappedParameter/SavedSearchParameter.php
@@ -34,6 +34,7 @@ final readonly class SavedSearchParameter implements ShareOptionsInterface
         private ?Filter $filter = null,
         private ?string $description = null,
         private ?string $classId = null,
+        private ?string $elementType = null,
         private bool $shareGlobal = false,
         private bool $createMenuShortcut = false,
         private ?string $menuShortcutGroup = null,
@@ -68,6 +69,11 @@ final readonly class SavedSearchParameter implements ShareOptionsInterface
     public function getClassId(): ?string
     {
         return $this->classId;
+    }
+
+    public function getElementType(): ?string
+    {
+        return $this->elementType;
     }
 
     public function shareGlobal(): bool

--- a/src/Search/Schema/ConfigurationListItem.php
+++ b/src/Search/Schema/ConfigurationListItem.php
@@ -55,6 +55,13 @@ final class ConfigurationListItem implements AdditionalAttributesInterface
             nullable: true
         )]
         private readonly ?string $menuShortcutGroup = null,
+        #[Property(
+            description: 'Element type the search targets (asset or data-object)',
+            type: 'string',
+            example: 'asset',
+            nullable: true
+        )]
+        private readonly ?string $elementType = null,
     ) {
     }
 
@@ -91,5 +98,10 @@ final class ConfigurationListItem implements AdditionalAttributesInterface
     public function getMenuShortcutGroup(): ?string
     {
         return $this->menuShortcutGroup;
+    }
+
+    public function getElementType(): ?string
+    {
+        return $this->elementType;
     }
 }

--- a/src/Search/Schema/DetailedConfiguration.php
+++ b/src/Search/Schema/DetailedConfiguration.php
@@ -70,6 +70,13 @@ final class DetailedConfiguration implements AdditionalAttributesInterface
         private readonly ?string $menuShortcutGroup,
         #[Property(description: 'Class ID for data object searches', type: 'string', example: 'car', nullable: true)]
         private readonly ?string $classId,
+        #[Property(
+            description: 'Element type the search targets (asset or data-object)',
+            type: 'string',
+            example: 'asset',
+            nullable: true
+        )]
+        private readonly ?string $elementType,
         #[Property(description: 'Grid display columns', type: 'array', items: new Items(
             anyOf: [
                 new Schema(ref: AssetColumnSchema::class),
@@ -134,6 +141,11 @@ final class DetailedConfiguration implements AdditionalAttributesInterface
     public function getClassId(): ?string
     {
         return $this->classId;
+    }
+
+    public function getElementType(): ?string
+    {
+        return $this->elementType;
     }
 
     public function getColumns(): array

--- a/src/Search/Service/SavedSearchConfigurationService.php
+++ b/src/Search/Service/SavedSearchConfigurationService.php
@@ -158,6 +158,7 @@ final readonly class SavedSearchConfigurationService implements SavedSearchConfi
         $configuration->setDescription($parameter->getDescription());
         $configuration->setOwner($this->securityService->getCurrentUser()->getId());
         $configuration->setClassId($parameter->getClassId());
+        $configuration->setElementType($parameter->getElementType());
         $configuration->setColumns($parameter->getColumnsAsArray());
         $configuration->setFilter($parameter->getFilter()?->toArray());
         $configuration->setCreateMenuShortcut($parameter->createMenuShortcut());
@@ -195,6 +196,7 @@ final readonly class SavedSearchConfigurationService implements SavedSearchConfi
         $configuration->setName($parameter->getName());
         $configuration->setDescription($parameter->getDescription());
         $configuration->setClassId($parameter->getClassId());
+        $configuration->setElementType($parameter->getElementType());
         $configuration->setColumns($parameter->getColumnsAsArray());
         $configuration->setFilter($parameter->getFilter()?->toArray());
         $configuration->setCreateMenuShortcut($parameter->createMenuShortcut());


### PR DESCRIPTION
## Changes in this pull request

Persist an explicit **`elementType`** (e.g. `asset`, `data-object`, `document`) on saved search configurations.

**Why:** a data-object saved search without a selected class has no `classId`, so it was indistinguishable from an asset search and opened as an asset in the Studio UI. An explicit `elementType` removes the ambiguity.

Touches the entity (+ migration `Version20260625090000`), the save parameter/request body, the detailed + list schemas and hydrators, and the service (create + update). The column is nullable, so existing rows keep working (the UI defaults to asset).

Companion to pimcore/studio-ui-bundle#3781.
