### PR TITLE
[Search] Add sorting to the saved search list endpoint

### DIFF
--- a/src/Search/Controller/SavedSearch/ListConfigurationsController.php
+++ b/src/Search/Controller/SavedSearch/ListConfigurationsController.php
@@ -18,6 +18,8 @@ use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\CollectionParameters;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\PageParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\PageSizeParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\SortByParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\SortOrderParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Query\TextFieldParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Property\GenericCollection;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\CollectionJson;
@@ -72,6 +74,8 @@ final class ListConfigurationsController extends AbstractApiController
         description: 'Optional term to filter the saved search configurations by name.',
         required: false
     )]
+    #[SortByParameter(enum: ['name', 'modificationDate'])]
+    #[SortOrderParameter]
     #[SuccessResponse(
         description: 'saved_search_get_configurations_success_response',
         content: new CollectionJson(new GenericCollection(ConfigurationListItem::class))
@@ -81,11 +85,15 @@ final class ListConfigurationsController extends AbstractApiController
     ])]
     public function getSavedSearchConfigurations(
         #[MapQueryParameter] ?string $searchTerm = null,
+        #[MapQueryParameter] ?string $sortBy = null,
+        #[MapQueryParameter] ?string $sortOrder = null,
         #[MapQueryString] CollectionParameters $parameters = new CollectionParameters(),
     ): JsonResponse {
         $collection = $this->savedSearchConfigurationService->listConfigurations(
             $parameters,
-            $searchTerm
+            $searchTerm,
+            $sortBy,
+            $sortOrder
         );
 
         return $this->getPaginatedCollection(

--- a/src/Search/Repository/SavedSearchConfigurationRepository.php
+++ b/src/Search/Repository/SavedSearchConfigurationRepository.php
@@ -42,12 +42,20 @@ final readonly class SavedSearchConfigurationRepository implements SavedSearchCo
         return $configuration;
     }
 
-    public function getList(?string $searchTerm): array
+    public function getList(?string $searchTerm, ?string $sortBy = null, ?string $sortOrder = null): array
     {
+        // Whitelist the sortable fields to keep the ORDER BY safe; default to newest first.
+        $sortField = match ($sortBy) {
+            'name' => 'c.name',
+            'modificationDate' => 'c.modificationDate',
+            default => 'c.modificationDate',
+        };
+        $direction = strtoupper((string) $sortOrder) === 'ASC' ? 'ASC' : 'DESC';
+
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('c')
             ->from(SavedSearchConfiguration::class, 'c')
-            ->orderBy('c.modificationDate', 'DESC');
+            ->orderBy($sortField, $direction);
 
         $searchTerm = $searchTerm !== null ? trim($searchTerm) : null;
         if ($searchTerm !== null && $searchTerm !== '') {

--- a/src/Search/Repository/SavedSearchConfigurationRepositoryInterface.php
+++ b/src/Search/Repository/SavedSearchConfigurationRepositoryInterface.php
@@ -29,7 +29,7 @@ interface SavedSearchConfigurationRepositoryInterface
     /**
      * @return SavedSearchConfiguration[]
      */
-    public function getList(?string $searchTerm): array;
+    public function getList(?string $searchTerm, ?string $sortBy = null, ?string $sortOrder = null): array;
 
     /**
      * @return SavedSearchConfiguration[]

--- a/src/Search/Service/SavedSearchConfigurationService.php
+++ b/src/Search/Service/SavedSearchConfigurationService.php
@@ -53,14 +53,19 @@ final readonly class SavedSearchConfigurationService implements SavedSearchConfi
     ) {
     }
 
-    public function listConfigurations(CollectionParameters $parameters, ?string $searchTerm): Collection
-    {
+    public function listConfigurations(
+        CollectionParameters $parameters,
+        ?string $searchTerm,
+        ?string $sortBy = null,
+        ?string $sortOrder = null,
+    ): Collection {
         $currentUser = $this->securityService->getCurrentUser();
         $userId = $currentUser->getId();
 
+        // The repository applies the ORDER BY; the share filter below preserves that order.
         $accessibleConfigurations = array_values(
             array_filter(
-                $this->repository->getList($searchTerm),
+                $this->repository->getList($searchTerm, $sortBy, $sortOrder),
                 fn (SavedSearchConfiguration $configuration): bool => $this->shareService
                     ->isConfigurationSharedWithUser($configuration, $currentUser)
             )

--- a/src/Search/Service/SavedSearchConfigurationServiceInterface.php
+++ b/src/Search/Service/SavedSearchConfigurationServiceInterface.php
@@ -31,7 +31,12 @@ interface SavedSearchConfigurationServiceInterface
     /**
      * @return Collection<ConfigurationListItem>
      */
-    public function listConfigurations(CollectionParameters $parameters, ?string $searchTerm): Collection;
+    public function listConfigurations(
+        CollectionParameters $parameters,
+        ?string $searchTerm,
+        ?string $sortBy = null,
+        ?string $sortOrder = null,
+    ): Collection;
 
     /**
      * @return Collection<ConfigurationListItem>


### PR DESCRIPTION
## Changes in this pull request

Adds `sortBy` (`name` | `modificationDate`) and `sortOrder` (`ASC` | `DESC`) query params to the saved search list endpoint (`GET /search/saved/configuration`). The accessible configurations are sorted in the service before pagination; without these params the existing default order (modification date, newest first) is kept.

Companion to pimcore/studio-ui-bundle#3781 (Saved Search) — the list grid uses this for column sorting on Name / Modification date.
