### PR TITLE
[Workflow] Exclude folders from workflow element queries

### DIFF
--- a/src/Workflow/Repository/WorkflowElementsRepository.php
+++ b/src/Workflow/Repository/WorkflowElementsRepository.php
@@ -49,6 +49,12 @@ final readonly class WorkflowElementsRepository implements WorkflowElementsRepos
                     'ews', 'documents', 'd', "ews.ctype = 'document' AND d.id = ews.cid"
                 )
                 ->where('ews.workflow = :workflow')
+                // Folders share their element's ctype but are never workflow subjects the widgets
+                // should list. Exclude only rows that positively resolve to a folder; the IS NULL
+                // guard keeps non-matching joins and orphaned states (element deleted) unaffected.
+                ->andWhere("(a.type IS NULL OR a.type != 'folder')")
+                ->andWhere("(o.type IS NULL OR o.type != 'folder')")
+                ->andWhere("(d.type IS NULL OR d.type != 'folder')")
                 ->setParameter('workflow', $workflowName)
                 ->orderBy('modificationDate', 'ASC')
                 ->addOrderBy('ews.cid', 'ASC')

--- a/tests/Unit/Workflow/Repository/WorkflowElementsRepositoryTest.php
+++ b/tests/Unit/Workflow/Repository/WorkflowElementsRepositoryTest.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Workflow\Repository;
+
+use Codeception\Test\Unit;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use Pimcore\Bundle\StaticResolverBundle\Db\DbResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Workflow\Repository\WorkflowElementsRepository;
+
+/**
+ * @internal
+ */
+final class WorkflowElementsRepositoryTest extends Unit
+{
+    private MockObject|DbResolverInterface $dbResolver;
+
+    private MockObject|Connection $connection;
+
+    private WorkflowElementsRepository $repository;
+
+    protected function _before(): void
+    {
+        $this->dbResolver = $this->createMock(DbResolverInterface::class);
+        $this->connection = $this->createMock(Connection::class);
+        $this->repository = new WorkflowElementsRepository($this->dbResolver);
+    }
+
+    public function testFetchByWorkflowStateExcludesFolders(): void
+    {
+        $joins = [];
+        $wheres = [];
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        foreach (['select', 'addSelect', 'from', 'where', 'setParameter', 'orderBy', 'addOrderBy'] as $method) {
+            $queryBuilder->method($method)->willReturnSelf();
+        }
+        $queryBuilder->method('leftJoin')->willReturnCallback(
+            function (string $fromAlias, string $join, string $alias, string $condition) use (&$joins, $queryBuilder) {
+                $joins[$alias] = $condition;
+
+                return $queryBuilder;
+            }
+        );
+        $queryBuilder->method('andWhere')->willReturnCallback(
+            function (string $condition) use (&$wheres, $queryBuilder) {
+                $wheres[] = $condition;
+
+                return $queryBuilder;
+            }
+        );
+        $queryBuilder->method('fetchAllAssociative')->willReturn([]);
+
+        $this->connection->method('createQueryBuilder')->willReturn($queryBuilder);
+        $this->dbResolver->method('get')->willReturn($this->connection);
+
+        $this->repository->fetchByWorkflowState('product_workflow');
+
+        // The subtype tables are joined so their type can be inspected...
+        $this->assertArrayHasKey('a', $joins);
+        $this->assertArrayHasKey('o', $joins);
+        $this->assertArrayHasKey('d', $joins);
+        // ...and folder rows are filtered out in SQL for every element type. The IS NULL guard
+        // is essential: a plain "type != 'folder'" would drop every non-matching LEFT JOIN row
+        // (NULL type) via three-valued logic, emptying the result.
+        $this->assertContains("(a.type IS NULL OR a.type != 'folder')", $wheres);
+        $this->assertContains("(o.type IS NULL OR o.type != 'folder')", $wheres);
+        $this->assertContains("(d.type IS NULL OR d.type != 'folder')", $wheres);
+    }
+}

--- a/tests/Unit/Workflow/Repository/WorkflowElementsRepositoryTest.php
+++ b/tests/Unit/Workflow/Repository/WorkflowElementsRepositoryTest.php
@@ -40,19 +40,13 @@ final class WorkflowElementsRepositoryTest extends Unit
 
     public function testFetchByWorkflowStateExcludesFolders(): void
     {
-        $joins = [];
         $wheres = [];
         $queryBuilder = $this->createMock(QueryBuilder::class);
         foreach (['select', 'addSelect', 'from', 'where', 'setParameter', 'orderBy', 'addOrderBy'] as $method) {
             $queryBuilder->method($method)->willReturnSelf();
         }
-        $queryBuilder->method('leftJoin')->willReturnCallback(
-            function (string $fromAlias, string $join, string $alias, string $condition) use (&$joins, $queryBuilder) {
-                $joins[$alias] = $condition;
-
-                return $queryBuilder;
-            }
-        );
+        // The asset/object/document subtype tables are joined so their type can be inspected.
+        $queryBuilder->expects($this->exactly(3))->method('leftJoin')->willReturnSelf();
         $queryBuilder->method('andWhere')->willReturnCallback(
             function (string $condition) use (&$wheres, $queryBuilder) {
                 $wheres[] = $condition;
@@ -67,12 +61,8 @@ final class WorkflowElementsRepositoryTest extends Unit
 
         $this->repository->fetchByWorkflowState('product_workflow');
 
-        // The subtype tables are joined so their type can be inspected...
-        $this->assertArrayHasKey('a', $joins);
-        $this->assertArrayHasKey('o', $joins);
-        $this->assertArrayHasKey('d', $joins);
-        // ...and folder rows are filtered out in SQL for every element type. The IS NULL guard
-        // is essential: a plain "type != 'folder'" would drop every non-matching LEFT JOIN row
+        // Folder rows are filtered out in SQL for every element type. The IS NULL guard is
+        // essential: a plain "type != 'folder'" would drop every non-matching LEFT JOIN row
         // (NULL type) via three-valued logic, emptying the result.
         $this->assertContains("(a.type IS NULL OR a.type != 'folder')", $wheres);
         $this->assertContains("(o.type IS NULL OR o.type != 'folder')", $wheres);


### PR DESCRIPTION
## What

`fetchByWorkflowState` lists asset folders alongside real assets. Folders share their element's `ctype` (`asset`/`object`/`document`) in `element_workflow_state`, and the query filtered by `ctype` only. This affects the **workflow pending-items widget** and the **`workflow_get_elements` click-through list**.

Related: pimcore/studio-dashboards-bundle#301 (the donut widget is fixed in the companion PR pimcore/studio-dashboards-bundle for `WorkflowStateDistributionResolver`).

## Fix

Filter out folder subtypes in SQL using the already-present `assets`/`objects`/`documents` joins:

```sql
AND (a.type IS NULL OR a.type != 'folder')
AND (o.type IS NULL OR o.type != 'folder')
AND (d.type IS NULL OR d.type != 'folder')
```

The `IS NULL` guard per table is **required**: a plain `type != 'folder'` drops every non-matching LEFT JOIN row (NULL type) via SQL three-valued logic, which would empty the result. Orphaned states (element deleted) are preserved unchanged.

## Verification

Validated against a real dataset (`simple_asset_workflow`: 10 folders + 35 images): result goes 46 → 36 (folders removed, images + 1 orphaned row preserved). Added `WorkflowElementsRepositoryTest` guarding the query construction.

⚠️ Codeception suite to be validated by CI (dev-deps not installed in the authoring environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)