### PR TITLE
[Grid] Fix 404 when grid search is anchored on the root folder

### DIFF
--- a/src/DataIndex/Grid/GridSearch.php
+++ b/src/DataIndex/Grid/GridSearch.php
@@ -35,6 +35,8 @@ use Pimcore\Bundle\StudioBackendBundle\Filter\Service\FilterServiceProviderInter
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
 use Pimcore\Bundle\StudioBackendBundle\Response\StudioElementInterface;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementFolderIds;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementFolderPaths;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\UserInterface;
 
@@ -163,6 +165,15 @@ final readonly class GridSearch implements GridSearchInterface
         int $folderId,
         ?UserInterface $user
     ): FilterParameter {
+        // The root folder is not necessarily visible in the search index (restricted user
+        // workspaces exclude "/"); its path is fixed, so no lookup is needed. Results stay
+        // permission-filtered by the search query itself.
+        if ($folderId === ElementFolderIds::ROOT->value) {
+            $filter->setPath(ElementFolderPaths::ROOT->value);
+
+            return $filter;
+        }
+
         $folder = match($type) {
             ElementTypes::TYPE_ASSET => $this->assetSearchService->getAssetById($folderId, $user),
             ElementTypes::TYPE_DATA_OBJECT => $this->dataObjectSearchService->getDataObjectById($folderId, $user),

--- a/tests/Unit/DataIndex/Grid/GridSearchTest.php
+++ b/tests/Unit/DataIndex/Grid/GridSearchTest.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataIndex\Grid;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\DataObjectSearchResult;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Grid\GridSearch;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\DataObjectQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\SearchIndexFilterInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\AssetSearchServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\DataObjectSearchServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\DocumentSearchServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\DataObjectPermissions;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\Type\DataObjectFolder;
+use Pimcore\Bundle\StudioBackendBundle\Factory\QueryFactoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
+use Pimcore\Bundle\StudioBackendBundle\Filter\Service\FilterServiceProviderInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
+use Pimcore\Bundle\StudioBackendBundle\Response\ElementIcon;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementIconTypes;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+final class GridSearchTest extends Unit
+{
+    private const ROOT_FOLDER_ID = 1;
+
+    /**
+     * The root folder may be invisible to the search index lookup (restricted user
+     * workspaces exclude "/", or the index misses the root document). A grid search
+     * anchored on the root folder must not depend on that lookup: its path is "/" by
+     * definition. Regression test for the data-quality drill-down 404
+     * ("DataObject with ID: 1 not found").
+     */
+    public function testRootFolderSearchSkipsIndexLookupAndFiltersByRootPath(): void
+    {
+        $capturedFilter = null;
+
+        $gridSearch = $this->createGridSearch(
+            $this->makeEmpty(DataObjectSearchServiceInterface::class, [
+                'getDataObjectById' => Expected::never(),
+                'searchDataObjects' => new DataObjectSearchResult([], 1, 50, 0),
+            ]),
+            $capturedFilter
+        );
+
+        $gridSearch->searchDataObjects(new GridParameter(self::ROOT_FOLDER_ID, [], null));
+
+        $this->assertInstanceOf(FilterParameter::class, $capturedFilter);
+        $this->assertSame('/', $capturedFilter->getPath());
+    }
+
+    public function testNonRootFolderSearchResolvesFolderPathFromIndex(): void
+    {
+        $folderId = 42;
+        $capturedFilter = null;
+
+        $gridSearch = $this->createGridSearch(
+            $this->makeEmpty(DataObjectSearchServiceInterface::class, [
+                'getDataObjectById' => Expected::once($this->createFolder($folderId, '/Cars')),
+                'searchDataObjects' => new DataObjectSearchResult([], 1, 50, 0),
+            ]),
+            $capturedFilter
+        );
+
+        $gridSearch->searchDataObjects(new GridParameter($folderId, [], null));
+
+        $this->assertInstanceOf(FilterParameter::class, $capturedFilter);
+        $this->assertSame('/Cars', $capturedFilter->getPath());
+    }
+
+    private function createGridSearch(
+        DataObjectSearchServiceInterface $dataObjectSearchService,
+        mixed &$capturedFilter
+    ): GridSearch {
+        $filterService = $this->makeEmpty(SearchIndexFilterInterface::class, [
+            'applyFilters' => function ($query, $parameters, $type) use (&$capturedFilter) {
+                $capturedFilter = $parameters;
+
+                return $query;
+            },
+        ]);
+
+        return new GridSearch(
+            $this->makeEmpty(AssetSearchServiceInterface::class),
+            $dataObjectSearchService,
+            $this->makeEmpty(DocumentSearchServiceInterface::class),
+            $this->makeEmpty(FilterServiceProviderInterface::class, ['create' => $filterService]),
+            $this->makeEmpty(QueryFactoryInterface::class, [
+                'create' => $this->makeEmpty(DataObjectQueryInterface::class),
+            ]),
+            $this->makeEmpty(SecurityServiceInterface::class, [
+                'getCurrentUser' => $this->makeEmpty(UserInterface::class),
+            ])
+        );
+    }
+
+    private function createFolder(int $id, string $fullPath): DataObjectFolder
+    {
+        return new DataObjectFolder(
+            key: ltrim($fullPath, '/'),
+            className: 'folder',
+            type: 'folder',
+            published: true,
+            hasChildren: true,
+            hasWorkflowWithPermissions: false,
+            fullPath: $fullPath,
+            permissions: new DataObjectPermissions(),
+            index: 0,
+            childrenSortBy: 'key',
+            childrenSortOrder: 'asc',
+            allowVariants: null,
+            id: $id,
+            parentId: 1,
+            path: '/',
+            icon: new ElementIcon(ElementIconTypes::NAME->value, 'folder'),
+            userOwner: 1,
+            userModification: null,
+            locked: null,
+            isLocked: false,
+            creationDate: null,
+            modificationDate: null
+        );
+    }
+}


### PR DESCRIPTION
## Problem

On studionightly, clicking a bar in the **data quality score widget** (drill-through) fails:

```
POST /pimcore-studio/api/data-objects/grid/CAR → 404
{"message": "DataObject with ID: 1 not found", "errorKey": "error_element_not_found"}
```

## Root cause

The DQ drill-down grid is class-scoped, not folder-scoped, so the frontend anchors it on the root folder and sends `folderId: 1` (which is also the only option — `folderId` is a required field of the grid request body).

`GridSearch::setFilterPath()` resolves that `folderId` **through the permission-aware search index** (`getDataObjectById(1, $user)` → GDI `byId()` with `PermissionTypes::VIEW` + the user's workspace query) purely to derive the path filter.

The root folder is not reliably visible through that lookup:

- **Restricted users:** the workspace query only matches elements under the user's allowed paths. For a user whose workspace starts below the root (e.g. read on `/Product Data` only), the root's path `/` matches nothing → `null` → `NotFoundException('DataObject', 1)` → the observed 404.
- **Index state:** a rebuilt/lagging index that misses the root document fails the same way.

This is why it worked in dev (admin user, root indexed) and broke in production.

## Fix

The root folder always exists and its full path is `/` by definition — no lookup is needed. `setFilterPath()` now short-circuits for `folderId === ElementFolderIds::ROOT->value` and sets the path filter to `/` directly. This applies to all three element types (asset/object/document roots are all id 1).

**Security note:** the removed lookup acted as an implicit "can you see this folder" gate — but only for the root. The path filter `/` is pure scoping (matches everything); the result set is still filtered by the user's workspace query inside the search itself, so restricted users see exactly what they are allowed to see and nothing more. A user with no workspace gets an empty grid, not a 404.

## Regression test

`tests/Unit/DataIndex/Grid/GridSearchTest.php`:
- `folderId = 1` must **not** call the index lookup and must produce a `/` path filter (red before the fix — failed on the exact `getDataObjectById(1, …)` call from the production stack trace).
- `folderId ≠ 1` still resolves the folder path through the index (pins existing behavior).

Verified: bundle unit suite green (418 tests, 966 assertions), PHPStan clean.

## Propagation

`setFilterPath()` is byte-identical on `2025.4`, `2026.1`, `2026.2` and `2026.x` — this needs the usual forward-merge up the chain (studionightly runs the newest line).

No frontend change needed: the DQ widget's `ROOT_FOLDER_ID = 1` anchor becomes legitimate once the backend stops requiring root visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)