### PR TITLE
fix: prevent invalid getClassDefinitionIcon() method call

### DIFF
--- a/src/Icon/Service/IconService.php
+++ b/src/Icon/Service/IconService.php
@@ -159,7 +159,7 @@ final readonly class IconService implements IconServiceInterface
             }
         }
 
-        if ($dataObject->getClassDefinitionIcon() !== null) {
+        if ($dataObject instanceof DataObjectSearchResultItem && $dataObject->getClassDefinitionIcon() !== null) {
             return new ElementIcon(
                 $this->guessIconType($dataObject->getClassDefinitionIcon()),
                 $dataObject->getClassDefinitionIcon()


### PR DESCRIPTION
Summary

This change prevents calling "getClassDefinitionIcon()" on objects that are not instances of "DataObjectSearchResultItem".

Changes

- Added an "instanceof DataObjectSearchResultItem" check before calling "getClassDefinitionIcon()".
- Prevents potential "Call to undefined method" errors when a "DataObject" instance is passed to "getClassIcon()".

This change is limited to adding the necessary type guard and does not alter the existing behavior for valid "DataObjectSearchResultItem" instances.