### PR TITLE
[Workflow] Add WorkflowFilter to scope element grids by workflow place

### DIFF
--- a/config/data_index_filters.yaml
+++ b/config/data_index_filters.yaml
@@ -47,6 +47,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\MultipleIdFilter:
     tags: [ 'pimcore.studio_backend.search_index.filter' ]
 
+  Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\WorkflowFilter:
+    tags: [ 'pimcore.studio_backend.search_index.filter' ]
+
   Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\IntegerFilter:
     tags: [ 'pimcore.studio_backend.search_index.filter' ]
 

--- a/doc/01_Architecture_Overview/01_Grid.md
+++ b/doc/01_Architecture_Overview/01_Grid.md
@@ -136,6 +136,7 @@ Available filters are:
 |               crm.consent                |                  array                   |            `true` or `false`            |      true      |
 |           dataobject.relation            |                  array                   |    array of `type`, `ids` objects       |      true      |
 |          system.unreferenced             |                 boolean                  |  Asset grid only — unreferenced assets  |     false      |
+|                 workflow                 |              string or null              | place name; omit/`null` = all states of the workflow |      true      |
 
 
 ### Examples:
@@ -250,6 +251,23 @@ Filter unreferenced assets (asset grid only):
   {
     "type": "system.unreferenced",
     "filterValue": true
+  }
+]
+...
+```
+
+Filter by Workflow place:
+The `workflow` filter restricts an element grid to the elements currently in a given workflow place.
+The `key` is the workflow name and `filterValue` is the place name; omit `filterValue` (or send `null`)
+to include the elements in **all** states of the workflow. Folders are excluded, and the matching
+element ids are resolved server-side (asset and data-object grids).
+```json
+...
+"columnFilters" [
+  {
+    "key": "product_workflow",
+    "type": "workflow",
+    "filterValue": "in_review"
   }
 ]
 ...

--- a/src/DataIndex/Filter/WorkflowFilter.php
+++ b/src/DataIndex/Filter/WorkflowFilter.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter;
+
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\AssetQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\DataObjectQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\DocumentQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFilter;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFiltersParameterInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Bundle\StudioBackendBundle\Workflow\Repository\WorkflowElementsRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use function array_slice;
+use function count;
+use function is_string;
+
+/**
+ * Restricts an element grid query to the elements in a given workflow place. Reuses the
+ * workflow-state repository (folders already excluded) to resolve the matching element ids and
+ * applies the standard `searchByIds` modifier, so the native listing filters server-side without
+ * enumerating ids on the client.
+ *
+ * @internal
+ */
+final readonly class WorkflowFilter implements FilterInterface
+{
+    public const string FILTER_TYPE = 'workflow';
+
+    /**
+     * Upper bound on ids handed to the search index, guarding against the OpenSearch terms limit
+     * for pathologically large states. Realistic states stay far below this; if a state ever
+     * exceeds it the excess is dropped and a warning is logged (not surfaced to the user).
+     */
+    private const int MAX_IDS = 10000;
+
+    public function __construct(
+        private WorkflowElementsRepositoryInterface $elementsRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function apply(mixed $parameters, QueryInterface $query): QueryInterface
+    {
+        if (!$parameters instanceof ColumnFiltersParameterInterface) {
+            return $query;
+        }
+
+        $elementType = $this->resolveElementType($query);
+        if ($elementType === null) {
+            return $query;
+        }
+
+        foreach ($parameters->getColumnFilterByType(self::FILTER_TYPE) as $column) {
+            $query = $this->applyWorkflowFilter($column, $query, $elementType);
+        }
+
+        return $query;
+    }
+
+    private function applyWorkflowFilter(
+        ColumnFilter $column,
+        QueryInterface $query,
+        string $elementType
+    ): QueryInterface {
+        $workflowName = $column->getKeyWithOutLocale();
+        $place = $column->getFilterValue();
+
+        if ($workflowName === '') {
+            throw new InvalidArgumentException('Workflow filter requires a workflow name (key).');
+        }
+
+        // A specific place narrows to that state; a missing place means "any place in the
+        // workflow" (the widget's show-all action), resolved by passing a null state name.
+        $stateName = is_string($place) && $place !== '' ? $place : null;
+
+        $rows = $this->elementsRepository->fetchByWorkflowState($workflowName, $stateName, $elementType);
+
+        $ids = [];
+        foreach ($rows as $row) {
+            $cid = (int) $row['cid'];
+            // Skip orphaned/invalid workflow-state rows (e.g. cid 0): the search index's
+            // IdsFilter requires strictly positive ids and throws otherwise.
+            if ($cid > 0) {
+                $ids[] = $cid;
+            }
+        }
+
+        if (count($ids) > self::MAX_IDS) {
+            $this->logger->warning(
+                'Workflow drill-down id set exceeds the search cap and was truncated.',
+                ['workflow' => $workflowName, 'place' => $place, 'total' => count($ids), 'cap' => self::MAX_IDS]
+            );
+            $ids = array_slice($ids, 0, self::MAX_IDS);
+        }
+
+        // Empty id set intentionally matches nothing (rather than the whole index).
+        return $query->searchByIds($ids);
+    }
+
+    private function resolveElementType(QueryInterface $query): ?string
+    {
+        return match (true) {
+            $query instanceof DataObjectQueryInterface => ElementTypes::TYPE_DATA_OBJECT,
+            $query instanceof AssetQueryInterface => ElementTypes::TYPE_ASSET,
+            $query instanceof DocumentQueryInterface => ElementTypes::TYPE_DOCUMENT,
+            default => null,
+        };
+    }
+}

--- a/src/Workflow/Repository/WorkflowElementsRepository.php
+++ b/src/Workflow/Repository/WorkflowElementsRepository.php
@@ -49,6 +49,12 @@ final readonly class WorkflowElementsRepository implements WorkflowElementsRepos
                     'ews', 'documents', 'd', "ews.ctype = 'document' AND d.id = ews.cid"
                 )
                 ->where('ews.workflow = :workflow')
+                // Folders share their element's ctype but are never workflow subjects the widgets
+                // should list. Exclude only rows that positively resolve to a folder; the IS NULL
+                // guard keeps non-matching joins and orphaned states (element deleted) unaffected.
+                ->andWhere("(a.type IS NULL OR a.type != 'folder')")
+                ->andWhere("(o.type IS NULL OR o.type != 'folder')")
+                ->andWhere("(d.type IS NULL OR d.type != 'folder')")
                 ->setParameter('workflow', $workflowName)
                 ->orderBy('modificationDate', 'ASC')
                 ->addOrderBy('ews.cid', 'ASC')

--- a/tests/Unit/DataIndex/Filter/WorkflowFilterTest.php
+++ b/tests/Unit/DataIndex/Filter/WorkflowFilterTest.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataIndex\Filter;
+
+use Codeception\Test\Unit;
+use PHPUnit\Framework\MockObject\MockObject;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\WorkflowFilter;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\AssetQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\DataObjectQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFilter;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFiltersParameterInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Bundle\StudioBackendBundle\Workflow\Repository\WorkflowElementsRepositoryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @internal
+ */
+final class WorkflowFilterTest extends Unit
+{
+    private MockObject|WorkflowElementsRepositoryInterface $repository;
+
+    private WorkflowFilter $filter;
+
+    protected function _before(): void
+    {
+        $this->repository = $this->createMock(WorkflowElementsRepositoryInterface::class);
+        $this->filter = new WorkflowFilter($this->repository, $this->createMock(LoggerInterface::class));
+    }
+
+    public function testItIgnoresParametersThatAreNotColumnFilters(): void
+    {
+        $query = $this->createMock(DataObjectQueryInterface::class);
+        $query->expects($this->never())->method('searchByIds');
+        $this->repository->expects($this->never())->method('fetchByWorkflowState');
+
+        self::assertSame($query, $this->filter->apply(new \stdClass(), $query));
+    }
+
+    public function testItResolvesObjectIdsForTheWorkflowPlaceAndSearchesByThem(): void
+    {
+        $query = $this->createMock(DataObjectQueryInterface::class);
+
+        // Data-object query -> element type 'data-object' passed to the repository.
+        $this->repository->expects($this->once())
+            ->method('fetchByWorkflowState')
+            ->with('product_workflow', 'in_review', ElementTypes::TYPE_DATA_OBJECT)
+            ->willReturn([
+                ['cid' => 3, 'ctype' => 'object'],
+                ['cid' => 7, 'ctype' => 'object'],
+            ]);
+
+        $query->expects($this->once())->method('searchByIds')->with([3, 7])->willReturnSelf();
+
+        $result = $this->filter->apply($this->parametersWith('product_workflow', 'in_review'), $query);
+
+        self::assertSame($query, $result);
+    }
+
+    public function testItSkipsOrphanedNonPositiveIds(): void
+    {
+        $query = $this->createMock(DataObjectQueryInterface::class);
+
+        // Orphaned element_workflow_state rows can carry cid 0; the search index's IdsFilter
+        // requires strictly positive ids, so they must be dropped before searchByIds.
+        $this->repository->method('fetchByWorkflowState')->willReturn([
+            ['cid' => 0, 'ctype' => 'object'],
+            ['cid' => 7, 'ctype' => 'object'],
+        ]);
+
+        $query->expects($this->once())->method('searchByIds')->with([7])->willReturnSelf();
+
+        $this->filter->apply($this->parametersWith('product_workflow', 'in_review'), $query);
+    }
+
+    public function testItUsesAssetElementTypeForAssetQueries(): void
+    {
+        $query = $this->createMock(AssetQueryInterface::class);
+
+        $this->repository->expects($this->once())
+            ->method('fetchByWorkflowState')
+            ->with('asset_workflow', 'to_review', ElementTypes::TYPE_ASSET)
+            ->willReturn([['cid' => 42, 'ctype' => 'asset']]);
+
+        $query->expects($this->once())->method('searchByIds')->with([42])->willReturnSelf();
+
+        $this->filter->apply($this->parametersWith('asset_workflow', 'to_review'), $query);
+    }
+
+    public function testItResolvesAllPlacesWhenNoPlaceIsGiven(): void
+    {
+        $query = $this->createMock(DataObjectQueryInterface::class);
+
+        // No place -> null state name -> the whole workflow (the widget's show-all action).
+        $this->repository->expects($this->once())
+            ->method('fetchByWorkflowState')
+            ->with('product_workflow', null, ElementTypes::TYPE_DATA_OBJECT)
+            ->willReturn([['cid' => 5, 'ctype' => 'object']]);
+
+        $query->expects($this->once())->method('searchByIds')->with([5])->willReturnSelf();
+
+        $this->filter->apply($this->parametersWith('product_workflow', null), $query);
+    }
+
+    public function testItSearchesByAnEmptyIdSetWhenNoElementsMatch(): void
+    {
+        $query = $this->createMock(DataObjectQueryInterface::class);
+
+        $this->repository->method('fetchByWorkflowState')->willReturn([]);
+        // Empty id set -> the grid shows nothing (rather than everything).
+        $query->expects($this->once())->method('searchByIds')->with([])->willReturnSelf();
+
+        $this->filter->apply($this->parametersWith('product_workflow', 'in_review'), $query);
+    }
+
+    private function parametersWith(string $workflow, ?string $place): ColumnFiltersParameterInterface&MockObject
+    {
+        // ColumnFilter is a final readonly value object -> construct it, never mock it.
+        $columnFilter = new ColumnFilter($workflow, WorkflowFilter::FILTER_TYPE, $place);
+
+        $parameters = $this->createMock(ColumnFiltersParameterInterface::class);
+        $parameters->method('getColumnFilterByType')
+            ->with(WorkflowFilter::FILTER_TYPE)
+            ->willReturn([$columnFilter]);
+
+        return $parameters;
+    }
+}

--- a/tests/Unit/Workflow/Repository/WorkflowElementsRepositoryTest.php
+++ b/tests/Unit/Workflow/Repository/WorkflowElementsRepositoryTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Workflow\Repository;
+
+use Codeception\Test\Unit;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use Pimcore\Bundle\StaticResolverBundle\Db\DbResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Workflow\Repository\WorkflowElementsRepository;
+
+/**
+ * @internal
+ */
+final class WorkflowElementsRepositoryTest extends Unit
+{
+    private MockObject|DbResolverInterface $dbResolver;
+
+    private MockObject|Connection $connection;
+
+    private WorkflowElementsRepository $repository;
+
+    protected function _before(): void
+    {
+        $this->dbResolver = $this->createMock(DbResolverInterface::class);
+        $this->connection = $this->createMock(Connection::class);
+        $this->repository = new WorkflowElementsRepository($this->dbResolver);
+    }
+
+    public function testFetchByWorkflowStateExcludesFolders(): void
+    {
+        $wheres = [];
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        foreach (['select', 'addSelect', 'from', 'where', 'setParameter', 'orderBy', 'addOrderBy'] as $method) {
+            $queryBuilder->method($method)->willReturnSelf();
+        }
+        // The asset/object/document subtype tables are joined so their type can be inspected.
+        $queryBuilder->expects($this->exactly(3))->method('leftJoin')->willReturnSelf();
+        $queryBuilder->method('andWhere')->willReturnCallback(
+            function (string $condition) use (&$wheres, $queryBuilder) {
+                $wheres[] = $condition;
+
+                return $queryBuilder;
+            }
+        );
+        $queryBuilder->method('fetchAllAssociative')->willReturn([]);
+
+        $this->connection->method('createQueryBuilder')->willReturn($queryBuilder);
+        $this->dbResolver->method('get')->willReturn($this->connection);
+
+        $this->repository->fetchByWorkflowState('product_workflow');
+
+        // Folder rows are filtered out in SQL for every element type. The IS NULL guard is
+        // essential: a plain "type != 'folder'" would drop every non-matching LEFT JOIN row
+        // (NULL type) via three-valued logic, emptying the result.
+        $this->assertContains("(a.type IS NULL OR a.type != 'folder')", $wheres);
+        $this->assertContains("(o.type IS NULL OR o.type != 'folder')", $wheres);
+        $this->assertContains("(d.type IS NULL OR d.type != 'folder')", $wheres);
+    }
+}


### PR DESCRIPTION
## What

Adds a `workflow` search-index filter so the native Studio element grid can be restricted to the elements in a given workflow place. This is the backend half of the **state-distribution donut drill-down → native grid** feature (frontend: pimcore/studio-dashboards-bundle `workflow-state-drilldown`).

## How

`WorkflowFilter` (tagged `pimcore.studio_backend.search_index.filter`, modeled on `MarkFilter`/`MultipleIdFilter`):
- Reads `columnFilters` of type `workflow` (key = workflow name, value = place; **no place = all states**, for the widget's show-all action).
- Resolves matching element ids via `WorkflowElementsRepositoryInterface::fetchByWorkflowState(...)` and applies the existing `searchByIds()`.
- Element type derived from the query (`DataObjectQueryInterface` / `AssetQueryInterface` / `DocumentQueryInterface`).
- **Skips non-positive cids** (orphaned `element_workflow_state` rows, e.g. `cid=0`) — the search index's `IdsFilter` requires strictly positive ids.
- `MAX_IDS` ceiling guards the OpenSearch terms limit (logged, not user-facing). Permissions are enforced by the native grid query downstream (not duplicated here).

`@internal`, `final readonly`, DI against interfaces, no Pimcore statics — follows `pimcore-studio-backend-architecture`.

## Tests

`WorkflowFilterTest` (Codeception unit): per-place resolution, all-places (null), asset element type, empty-set, and the orphaned-`cid=0` regression. Verified `php -l`; Codeception runs in CI.

## Notes

- Base is `2025.4` per request (runs in the current dev env). Happy to retarget to `2026.x` if this should land as a feature there first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)