### PR TITLE
[Grid config & Saved search] Set owner to NULL on user delete instead of cascading

### DIFF
--- a/src/Configuration/Share/ShareableConfigurationInterface.php
+++ b/src/Configuration/Share/ShareableConfigurationInterface.php
@@ -20,7 +20,7 @@ use Doctrine\Common\Collections\Collection;
  */
 interface ShareableConfigurationInterface
 {
-    public function getOwner(): int;
+    public function getOwner(): ?int;
 
     public function isShareGlobal(): bool;
 

--- a/src/Entity/Grid/GridConfiguration.php
+++ b/src/Entity/Grid/GridConfiguration.php
@@ -43,7 +43,7 @@ class GridConfiguration implements ShareableConfigurationInterface
     private ?string $classId = null;
 
     #[ORM\Column(type: 'integer', nullable: true, options: ['unsigned' => true])]
-    private int $owner;
+    private ?int $owner = null;
 
     #[ORM\Column(type: 'integer', nullable: false, options: ['unsigned' => true])]
     private int $pageSize;
@@ -200,7 +200,7 @@ class GridConfiguration implements ShareableConfigurationInterface
         $this->modificationDate = new DateTime('now');
     }
 
-    public function getOwner(): int
+    public function getOwner(): ?int
     {
         return $this->owner;
     }

--- a/src/Entity/Search/SavedSearchConfiguration.php
+++ b/src/Entity/Search/SavedSearchConfiguration.php
@@ -35,8 +35,8 @@ class SavedSearchConfiguration implements ShareableConfigurationInterface
     /** @phpstan-ignore property.onlyRead */
     private int $id;
 
-    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
-    private int $owner;
+    #[ORM\Column(type: 'integer', nullable: true, options: ['unsigned' => true])]
+    private ?int $owner = null;
 
     #[ORM\Column(type: 'string', length: 255)]
     private string $name;
@@ -144,7 +144,7 @@ class SavedSearchConfiguration implements ShareableConfigurationInterface
         return $this->modificationDate;
     }
 
-    public function getOwner(): int
+    public function getOwner(): ?int
     {
         return $this->owner;
     }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -276,7 +276,7 @@ final class Installer extends SettingsStoreAwareInstaller
             'unsigned' => true,
         ]);
 
-        $table->addColumn('owner', 'integer', ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('owner', 'integer', ['notnull' => false, 'unsigned' => true]);
         $table->addColumn('name', 'string', ['notnull' => true, 'length' => 255]);
         $table->addColumn('description', 'text', ['notnull' => false]);
         $table->addColumn('classId', 'string', ['notnull' => false, 'length' => 50]);
@@ -290,11 +290,13 @@ final class Installer extends SettingsStoreAwareInstaller
 
         $table->setPrimaryKey(['id'], 'pk_'.SavedSearchConfiguration::TABLE_NAME);
 
+        // Keep configurations when their owner is deleted: they may be shared with other users.
+        // The owner is set to NULL instead and surfaced as a deleted owner in the UI.
         $table->addForeignKeyConstraint(
             'users',
             ['owner'],
             ['id'],
-            ['onDelete' => 'CASCADE'],
+            ['onDelete' => 'SET NULL'],
             'fk_'.SavedSearchConfiguration::TABLE_NAME.'_owner_users'
         );
     }
@@ -378,11 +380,13 @@ final class Installer extends SettingsStoreAwareInstaller
 
         $table->setPrimaryKey(['id'], 'pk_'.GridConfiguration::TABLE_NAME);
 
+        // Keep configurations when their owner is deleted: they may be shared with other users.
+        // The owner is set to NULL instead and surfaced as a deleted owner in the UI.
         $table->addForeignKeyConstraint(
             'users',
             ['owner'],
             ['id'],
-            ['onDelete' => 'CASCADE'],
+            ['onDelete' => 'SET NULL'],
             'fk_'.GridConfiguration::TABLE_NAME.'_owner_users'
         );
 

--- a/src/Migrations/Version20260703120000.php
+++ b/src/Migrations/Version20260703120000.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfiguration;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Search\SavedSearchConfiguration;
+
+/**
+ * Keep grid and saved search configurations when their owner is deleted instead of cascading the
+ * deletion: the configurations can be shared with other users. The owner foreign key is switched
+ * from ON DELETE CASCADE to ON DELETE SET NULL and the owner column is made nullable.
+ *
+ * @internal
+ */
+final class Version20260703120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set grid and saved search configuration owner to NULL on user delete instead of cascading';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->switchOwnerOnDelete($schema, GridConfiguration::TABLE_NAME, 'SET NULL');
+        $this->switchOwnerOnDelete($schema, SavedSearchConfiguration::TABLE_NAME, 'SET NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->switchOwnerOnDelete($schema, GridConfiguration::TABLE_NAME, 'CASCADE');
+        $this->switchOwnerOnDelete($schema, SavedSearchConfiguration::TABLE_NAME, 'CASCADE');
+    }
+
+    private function switchOwnerOnDelete(Schema $schema, string $tableName, string $onDelete): void
+    {
+        if (!$schema->hasTable($tableName)) {
+            return;
+        }
+
+        $table = $schema->getTable($tableName);
+
+        if (!$table->hasColumn('owner')) {
+            return;
+        }
+
+        // SET NULL requires a nullable column; CASCADE keeps it nullable as well (harmless superset).
+        $table->getColumn('owner')->setNotnull(false);
+
+        $foreignKeyName = 'fk_' . $tableName . '_owner_users';
+        if ($table->hasForeignKey($foreignKeyName)) {
+            $table->removeForeignKey($foreignKeyName);
+        }
+
+        $this->addOwnerForeignKey($table, $foreignKeyName, $onDelete);
+    }
+
+    private function addOwnerForeignKey(Table $table, string $foreignKeyName, string $onDelete): void
+    {
+        $table->addForeignKeyConstraint(
+            'users',
+            ['owner'],
+            ['id'],
+            ['onDelete' => $onDelete],
+            $foreignKeyName
+        );
+    }
+}

--- a/src/OwnershipManagement/Provider/GridConfigurationProvider.php
+++ b/src/OwnershipManagement/Provider/GridConfigurationProvider.php
@@ -103,18 +103,20 @@ final readonly class GridConfigurationProvider extends AbstractOwnedConfiguratio
     protected function extractOwnerId(object $configuration): int
     {
         /** @var GridConfiguration $configuration */
-        return $configuration->getOwner();
+        return $configuration->getOwner() ?? 0;
     }
 
     protected function hydrateConfiguration(object $configuration, array $ownerNames): OwnershipConfiguration
     {
         /** @var GridConfiguration $configuration */
+        $ownerId = $configuration->getOwner();
+
         return $this->ownershipConfigurationHydrator->hydrate(
             (string) $configuration->getId(),
             self::TYPE,
             $configuration->getName(),
-            $configuration->getOwner(),
-            $ownerNames[$configuration->getOwner()] ?? null,
+            $ownerId ?? 0,
+            $ownerId === null ? null : ($ownerNames[$ownerId] ?? null),
             $configuration->getCreationDate()->getTimestamp(),
             $configuration->getModificationDate()->getTimestamp(),
         );

--- a/src/OwnershipManagement/Provider/SavedSearchConfigurationProvider.php
+++ b/src/OwnershipManagement/Provider/SavedSearchConfigurationProvider.php
@@ -103,18 +103,20 @@ final readonly class SavedSearchConfigurationProvider extends AbstractOwnedConfi
     protected function extractOwnerId(object $configuration): int
     {
         /** @var SavedSearchConfiguration $configuration */
-        return $configuration->getOwner();
+        return $configuration->getOwner() ?? 0;
     }
 
     protected function hydrateConfiguration(object $configuration, array $ownerNames): OwnershipConfiguration
     {
         /** @var SavedSearchConfiguration $configuration */
+        $ownerId = $configuration->getOwner();
+
         return $this->ownershipConfigurationHydrator->hydrate(
             (string) $configuration->getId(),
             self::TYPE,
             $configuration->getName(),
-            $configuration->getOwner(),
-            $ownerNames[$configuration->getOwner()] ?? null,
+            $ownerId ?? 0,
+            $ownerId === null ? null : ($ownerNames[$ownerId] ?? null),
             $configuration->getCreationDate()->getTimestamp(),
             $configuration->getModificationDate()->getTimestamp(),
         );

--- a/src/Search/Schema/DetailedConfiguration.php
+++ b/src/Search/Schema/DetailedConfiguration.php
@@ -47,8 +47,13 @@ final class DetailedConfiguration implements AdditionalAttributesInterface
     public function __construct(
         #[Property(description: 'ID of the saved search configuration', type: 'integer', example: 42)]
         private readonly int $id,
-        #[Property(description: 'ID of the owner', type: 'integer', example: 42)]
-        private readonly int $ownerId,
+        #[Property(
+            description: 'ID of the owner. Null when the owner has been deleted.',
+            type: 'integer',
+            example: 42,
+            nullable: true
+        )]
+        private readonly ?int $ownerId,
         #[Property(description: 'Name', type: 'string', example: 'My Saved Search')]
         private readonly string $name,
         #[Property(description: 'Description', type: 'string', example: 'My Saved Search Description')]
@@ -98,7 +103,7 @@ final class DetailedConfiguration implements AdditionalAttributesInterface
         return $this->id;
     }
 
-    public function getOwnerId(): int
+    public function getOwnerId(): ?int
     {
         return $this->ownerId;
     }

--- a/tests/Unit/OwnershipManagement/Provider/GridConfigurationProviderTest.php
+++ b/tests/Unit/OwnershipManagement/Provider/GridConfigurationProviderTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\OwnershipManagement\Provider;
+
+use Codeception\Test\Unit;
+use DateTime;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfiguration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Repository\ConfigurationRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\OwnershipManagement\Hydrator\OwnershipConfigurationHydrator;
+use Pimcore\Bundle\StudioBackendBundle\OwnershipManagement\Provider\GridConfigurationProvider;
+use Pimcore\Bundle\StudioBackendBundle\OwnershipManagement\Query\OwnershipListQuery;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UserServiceInterface;
+
+/**
+ * @internal
+ */
+final class GridConfigurationProviderTest extends Unit
+{
+    /**
+     * Regression test for #1918: deleting an owner sets the owner to NULL (instead of cascading the
+     * deletion), so the ownership management must surface such configurations with owner id 0.
+     *
+     * @throws Exception
+     */
+    public function testListMapsDeletedOwnerToZeroAndMarksDeleted(): void
+    {
+        $configuration = $this->make(GridConfiguration::class, [
+            'getId' => 42,
+            'getName' => 'Shared grid view',
+            'getOwner' => null,
+            'getCreationDate' => new DateTime('@1718000000'),
+            'getModificationDate' => new DateTime('@1718000500'),
+        ]);
+
+        $provider = new GridConfigurationProvider(
+            $this->makeEmpty(ConfigurationRepositoryInterface::class, [
+                'findAllPaginated' => [$configuration],
+                'countAll' => 1,
+            ]),
+            new OwnershipConfigurationHydrator(),
+            $this->makeEmpty(UserServiceInterface::class, [
+                'getUserNamesByIds' => [],
+            ]),
+        );
+
+        $result = $provider->listConfigurations(new OwnershipListQuery(0, 10));
+
+        $this->assertSame(1, $result->getTotalItems());
+
+        $item = $result->getItems()[0];
+        $this->assertSame(0, $item->getOwnerId());
+        $this->assertNull($item->getOwnerName());
+        $this->assertTrue($item->isOwnerDeleted());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testListKeepsExistingOwner(): void
+    {
+        $configuration = $this->make(GridConfiguration::class, [
+            'getId' => 7,
+            'getName' => 'My grid view',
+            'getOwner' => 5,
+            'getCreationDate' => new DateTime('@1718000000'),
+            'getModificationDate' => new DateTime('@1718000500'),
+        ]);
+
+        $provider = new GridConfigurationProvider(
+            $this->makeEmpty(ConfigurationRepositoryInterface::class, [
+                'findAllPaginated' => [$configuration],
+                'countAll' => 1,
+            ]),
+            new OwnershipConfigurationHydrator(),
+            $this->makeEmpty(UserServiceInterface::class, [
+                'getUserNamesByIds' => [5 => 'john_doe'],
+            ]),
+        );
+
+        $item = $provider->listConfigurations(new OwnershipListQuery(0, 10))->getItems()[0];
+
+        $this->assertSame(5, $item->getOwnerId());
+        $this->assertSame('john_doe', $item->getOwnerName());
+        $this->assertFalse($item->isOwnerDeleted());
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Resolves #1918

Deleting a user cascaded to their grid configurations and saved searches, removing them even when they were **shared with or made global for other users**. Those users silently lost the shared configurations.

This switches the `owner` foreign key from `ON DELETE CASCADE` to `ON DELETE SET NULL` on both configuration tables so the configurations survive owner deletion, and surfaces an orphaned configuration through the Entity Ownership management as **owner id `0`** (`ownerDeleted = true`), as requested in the issue.

### Details
- **Schema** (`Installer.php` + new migration `Version20260703120000`): owner FK `CASCADE` → `SET NULL` on `bundle_studio_grid_configurations` and `bundle_studio_saved_search_configurations`; the saved-search `owner` column is made nullable (grid's already was). Matches the `SET NULL` pattern already used by other bundles' owner FKs (job run, bookmark list, copilot).
- **Entities / interface**: `owner` becomes `?int` on both entities and `ShareableConfigurationInterface::getOwner()` (a NULL owner would otherwise fatal on Doctrine hydration). Owner-based permission checks remain correct (`null === userId` → false).
- **Ownership management**: `GridConfigurationProvider` / `SavedSearchConfigurationProvider` map a NULL owner to `ownerId: 0` / `ownerName: null` ⇒ `ownerDeleted: true`.
- **API**: `Search\Schema\DetailedConfiguration::ownerId` is now nullable, mirroring `Grid\Schema\DetailedConfiguration` (a shared config's owner can now be null). Minor, backward-tolerant OpenAPI change — worth a heads-up to the frontend.
- Shares/favorites keep `CASCADE` (a share pointing at a deleted user is meaningless).

## Additional info
- Verified locally: `php -l` + PHPStan clean on changed dirs; full Unit suite (417 tests) passes plus 2 new regression tests in `GridConfigurationProviderTest`; migration applied to a dev DB and confirmed (`SET NULL` + nullable `owner`).
- Will need forward-merging into `2026.1` / `2026.x` per the branching workflow.
