### PR TITLE
Add type check for DataObjectSearchResultItem

### DIFF
--- a/src/Icon/Service/IconService.php
+++ b/src/Icon/Service/IconService.php
@@ -159,7 +159,7 @@ final readonly class IconService implements IconServiceInterface
             }
         }
 
-        if ($dataObject->getClassDefinitionIcon() !== null) {
+        if ($dataObject instanceof DataObjectSearchResultItem && $dataObject->getClassDefinitionIcon() !== null) {
             return new ElementIcon(
                 $this->guessIconType($dataObject->getClassDefinitionIcon()),
                 $dataObject->getClassDefinitionIcon()


### PR DESCRIPTION
### Pull Request Overview

This PR fixes an issue in `IconService::getClassIcon()` where `getClassDefinitionIcon()` could be called on objects that do not support the method.

### Changes

* Added an `instanceof DataObjectSearchResultItem` check before accessing `getClassDefinitionIcon()`.
* Ensures the icon is only resolved for supported object types.
* Prevents potential runtime errors caused by calling `getClassDefinitionIcon()` on unsupported objects.

### Before

```php
if ($dataObject->getClassDefinitionIcon() !== null) {
```

### After

```php
if (
    $dataObject instanceof DataObjectSearchResultItem &&
    $dataObject->getClassDefinitionIcon() !== null
) {
```

### Why?

`getClassIcon()` may receive different object types, but `getClassDefinitionIcon()` is only available on `DataObjectSearchResultItem`. This guard ensures the method is invoked only when supported, making the service more robust and preventing unexpected errors.
