### PR TITLE
[Notes] Fix "Between" date filter and user search

### DIFF
--- a/src/Note/Service/FilterService.php
+++ b/src/Note/Service/FilterService.php
@@ -52,7 +52,7 @@ final readonly class FilterService implements FilterServiceInterface
 
             $propertyKey = 'field';
 
-            foreach ($parameters->getFieldFiltersArray() as $filter) {
+            foreach ($parameters->getFieldFiltersArray() as $index => $filter) {
                 $operator = $this->findOperator($filter['type'], $filter['operator']);
                 $value = $this->prepareValue($filter['type'], $filter['operator'], $filter['value']);
 
@@ -60,22 +60,31 @@ final readonly class FilterService implements FilterServiceInterface
                     $value = '%' . $value . '%';
                 }
 
-                if ($filter[$propertyKey] === 'user') {
+                // Use index to ensure unique bind parameters for fields with multiple
+                // usages (e.g. a date "between" range sends `gt` and `lt` on `date`)
+                $parameterName = 'filter_' . $index;
+
+                if ($filter[$propertyKey] === 'userName') {
                     $list->addConditionParam(
-                        '`user` IN (SELECT `id` FROM `users` WHERE `name` ' . $operator . ' :user)',
-                        ['user' => $value]
+                        '`user` IN (SELECT `id` FROM `users` WHERE `name` ' . $operator . ' :' . $parameterName . ')',
+                        [$parameterName => $value]
                     );
+
+                    continue;
                 }
 
                 $quotedField = $this->dbResolver->get()->quoteIdentifier($filter[$propertyKey]);
                 if ($filter['type'] === 'date' && $filter['operator'] === 'eq') {
                     $maxTime = $value + (86400 - 1);
-                    $dateCondition = $quotedField . ' BETWEEN :minTime AND :maxTime';
-                    $list->addConditionParam($dateCondition, ['minTime' => $value, 'maxTime' => $maxTime]);
+                    $dateCondition = $quotedField . ' BETWEEN :minTime_' . $index . ' AND :maxTime_' . $index;
+                    $list->addConditionParam(
+                        $dateCondition,
+                        ['minTime_' . $index => $value, 'maxTime_' . $index => $maxTime]
+                    );
                 } else {
                     $list->addConditionParam(
-                        $quotedField . ' ' . $operator . ' :' . $filter[$propertyKey],
-                        [$filter[$propertyKey] => $value]
+                        $quotedField . ' ' . $operator . ' :' . $parameterName,
+                        [$parameterName => $value]
                     );
                 }
             }

--- a/tests/Unit/Note/Service/FilterServiceTest.php
+++ b/tests/Unit/Note/Service/FilterServiceTest.php
@@ -75,11 +75,11 @@ final class FilterServiceTest extends Unit
         $noteParameters = new NoteParameters(fieldFilters: $filters);
         $this->filterService->applyFieldFilters($noteListing, $noteParameters);
 
-        $this->assertSame('(`date` BETWEEN :minTime AND :maxTime) ', $noteListing->getCondition());
+        $this->assertSame('(`date` BETWEEN :minTime_0 AND :maxTime_0) ', $noteListing->getCondition());
         $this->assertSame(
             [
-                'minTime' => 1714780800,
-                'maxTime' => 1714867199,
+                'minTime_0' => 1714780800,
+                'maxTime_0' => 1714867199,
             ],
             $noteListing->getConditionVariables()
         );
@@ -102,10 +102,10 @@ final class FilterServiceTest extends Unit
         $noteParameters = new NoteParameters(fieldFilters: $filters);
         $this->filterService->applyFieldFilters($noteListing, $noteParameters);
 
-        $this->assertSame('(`numeric` = :numeric) ', $noteListing->getCondition());
+        $this->assertSame('(`numeric` = :filter_0) ', $noteListing->getCondition());
         $this->assertSame(
             [
-                'numeric' => 10,
+                'filter_0' => 10,
             ],
             $noteListing->getConditionVariables()
         );
@@ -128,10 +128,10 @@ final class FilterServiceTest extends Unit
         $noteParameters = new NoteParameters(fieldFilters: $filters);
         $this->filterService->applyFieldFilters($noteListing, $noteParameters);
 
-        $this->assertSame('(`boolean` = :boolean) ', $noteListing->getCondition());
+        $this->assertSame('(`boolean` = :filter_0) ', $noteListing->getCondition());
         $this->assertSame(
             [
-                'boolean' => 1,
+                'filter_0' => 1,
             ],
             $noteListing->getConditionVariables()
         );
@@ -154,16 +154,20 @@ final class FilterServiceTest extends Unit
         $noteParameters = new NoteParameters(fieldFilters: $filters);
         $this->filterService->applyFieldFilters($noteListing, $noteParameters);
 
-        $this->assertSame('(`list` = :list) ', $noteListing->getCondition());
+        $this->assertSame('(`list` = :filter_0) ', $noteListing->getCondition());
         $this->assertSame(
             [
-                'list' => 'list',
+                'filter_0' => 'list',
             ],
             $noteListing->getConditionVariables()
         );
     }
 
     /**
+     * The Studio UI sends the user column as `userName` (matching the Note schema) with a
+     * string `like` operator. It must be translated into a subquery against `users`.`name`
+     * and must NOT emit a bogus `` `userName` `` column condition (there is no such column).
+     *
      * @throws JsonException
      */
     public function testApplyFieldFiltersUser(): void
@@ -171,9 +175,9 @@ final class FilterServiceTest extends Unit
         $noteListing = $this->getNoteListing();
         $filters = json_encode([
             [
-                'field' => 'user',
-                'type' => 'user',
-                'operator' => 'user',
+                'field' => 'userName',
+                'type' => 'string',
+                'operator' => 'like',
                 'value' => 'admin',
             ],
         ], JSON_THROW_ON_ERROR);
@@ -181,12 +185,53 @@ final class FilterServiceTest extends Unit
         $this->filterService->applyFieldFilters($noteListing, $noteParameters);
 
         $this->assertSame(
-            '(`user` IN (SELECT `id` FROM `users` WHERE `name` = :user))  AND (`user` = :user) ',
+            '(`user` IN (SELECT `id` FROM `users` WHERE `name` LIKE :filter_0)) ',
             $noteListing->getCondition()
         );
         $this->assertSame(
             [
-                'user' => 'admin',
+                'filter_0' => '%admin%',
+            ],
+            $noteListing->getConditionVariables()
+        );
+    }
+
+    /**
+     * Regression test for the "Between" date operator (#1923). The UI decomposes a
+     * between-range into two conditions on the same `date` field (gt from + lt to).
+     * The bind parameters must be unique per condition, otherwise the second value
+     * overwrites the first and the query collapses to `date > to AND date < to`.
+     *
+     * @throws JsonException
+     */
+    public function testApplyFieldFiltersDateBetween(): void
+    {
+        $noteListing = $this->getNoteListing();
+        $filters = json_encode([
+            [
+                'field' => 'date',
+                'type' => 'date',
+                'operator' => 'gt',
+                'value' => '05/04/2024',
+            ],
+            [
+                'field' => 'date',
+                'type' => 'date',
+                'operator' => 'lt',
+                'value' => '05/06/2024',
+            ],
+        ], JSON_THROW_ON_ERROR);
+        $noteParameters = new NoteParameters(fieldFilters: $filters);
+        $this->filterService->applyFieldFilters($noteListing, $noteParameters);
+
+        $this->assertSame(
+            '(`date` > :filter_0)  AND (`date` < :filter_1) ',
+            $noteListing->getCondition()
+        );
+        $this->assertSame(
+            [
+                'filter_0' => 1714780800,
+                'filter_1' => 1714953600,
             ],
             $noteListing->getConditionVariables()
         );


### PR DESCRIPTION
## Changes in this pull request
Resolves #1923
Resolves #1925

Both bugs live in `Note/Service/FilterService::applyFieldFilters`, which translates note field filters into SQL:

- **#1923 — "Between" date filter returns empty.** The bind parameter name was derived from the field name, so two conditions on the same field collided. The UI decomposes a date "Between" range into two conditions (`gt` from + `lt` to) on `date`; the second `:date` binding overwrote the first, collapsing the query to `date > to AND date < to` → always empty. Bind parameters are now indexed per filter (`:filter_0`, `:filter_1`, `:minTime_0`/`:maxTime_0`), so the range resolves to `date > from AND date < to`.

- **#1925 — user search fails.** The user column is exposed as `userName` in the `Note` schema and the UI filters on it, but the backend only special-cased `user`, so `userName` generated a condition against a non-existent column → **500**. The `user` branch also lacked a `continue`, emitting a spurious generic column condition on top of the subquery. The `userName` field is now resolved via a subquery against `users`.`name` and short-circuits the generic condition.

## Additional info
- Aligned the backend to the field name the Studio UI actually sends (`userName`, matching the schema property) — **no UI change required**. The previously-handled `user` field name is dropped (it was broken and unused by the UI).
- Regression tests added/updated in `FilterServiceTest` for the "Between" range and the `userName` search; verified they fail without the fix. Full unit suite passes (444 tests), PHPStan clean.