### PR TITLE
[Listing] Fix date filter "Between" and Unix-timestamp columns

### DIFF
--- a/src/Listing/Filter/DateFilter.php
+++ b/src/Listing/Filter/DateFilter.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\StaticResolverBundle\Db\DbResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Filter\FilterType;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFilter;
+use Pimcore\Model\Element\Recyclebin\Item\Listing as RecycleBinListing;
 use Pimcore\Model\Listing\AbstractListing;
 use function is_array;
 
@@ -26,6 +27,16 @@ use function is_array;
  */
 final readonly class DateFilter implements FilterInterface
 {
+    /**
+     * Listings whose date columns are stored as Unix timestamps (integer) rather than a
+     * native DATE/DATETIME/TIMESTAMP. Such columns must be compared against an integer
+     * timestamp instead of a datetime string, otherwise MySQL coerces the string to a
+     * number and the comparison never matches. Keyed by listing class => column keys.
+     */
+    private const UNIX_TIMESTAMP_COLUMNS = [
+        RecycleBinListing::class => ['date'],
+    ];
+
     public function __construct(
         private DbResolverInterface $dbResolver,
     ) {
@@ -35,46 +46,71 @@ final readonly class DateFilter implements FilterInterface
         mixed $parameters,
         mixed $listing
     ): mixed {
+        $index = 0;
         foreach ($parameters->getColumnFilterByType(FilterType::DATE->value) as $column) {
-            $listing = $this->applyDateFilter($column, $listing);
+            $listing = $this->applyDateFilter($column, $listing, $index);
+            $index++;
         }
 
         return $listing;
     }
 
-    private function applyDateFilter(ColumnFilter $column, mixed $listing): mixed
+    private function applyDateFilter(ColumnFilter $column, mixed $listing, int $index): mixed
     {
         if (!is_array($column->getFilterValue())) {
             throw new InvalidArgumentException('Filter value for date must be an array');
         }
 
         $filter = $column->getFilterValue();
-        $key = $column->getKey();
-        $quotedKey = $this->dbResolver->get()->quoteIdentifier($key);
+        $quotedKey = $this->dbResolver->get()->quoteIdentifier($column->getKey());
         $carbonDate = new Carbon($filter['value']);
-        $value = $carbonDate->toDateTimeString();
+        $isUnixTimestamp = $this->isUnixTimestampColumn($listing, $column->getKeyWithOutLocale());
+
+        // The bind parameter name must be unique per applied filter. Deriving it from the
+        // column key collides when the same column is filtered twice (a "between" range is
+        // sent as `from` + `to` on the same key), silently dropping the first value.
         if ($filter['operator'] === 'on') {
-            $dateCondition = $quotedKey . ' BETWEEN :minTime AND :maxTime';
+            $dateCondition = $quotedKey . ' BETWEEN :minTime_' . $index . ' AND :maxTime_' . $index;
             $listing->addConditionParam(
                 $dateCondition,
                 [
-                    'minTime' => $value,
-                    'maxTime' => $carbonDate->addDay()->subSecond()->toDateTimeString(),
+                    'minTime_' . $index => $this->formatValue($carbonDate, $isUnixTimestamp),
+                    'maxTime_' . $index => $this->formatValue(
+                        $carbonDate->copy()->addDay()->subSecond(),
+                        $isUnixTimestamp
+                    ),
                 ]
             );
 
             return $listing;
         }
 
+        $parameterName = 'filter_' . $index;
         $dateCondition = $quotedKey . ' ' .
             $this->matchNumericOperator($filter['operator']) .
-            ' :' . $key;
+            ' :' . $parameterName;
         $listing->addConditionParam(
             $dateCondition,
-            [$key => $value]
+            [$parameterName => $this->formatValue($carbonDate, $isUnixTimestamp)]
         );
 
         return $listing;
+    }
+
+    private function formatValue(Carbon $date, bool $asUnixTimestamp): int|string
+    {
+        return $asUnixTimestamp ? $date->getTimestamp() : $date->toDateTimeString();
+    }
+
+    private function isUnixTimestampColumn(mixed $listing, string $key): bool
+    {
+        foreach (self::UNIX_TIMESTAMP_COLUMNS as $listingClass => $columns) {
+            if ($listing instanceof $listingClass && in_array($key, $columns, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function supports(mixed $listing): bool

--- a/tests/Unit/Listing/Filter/DateFilterTest.php
+++ b/tests/Unit/Listing/Filter/DateFilterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Listing\Filter;
 
+use Carbon\Carbon;
 use Codeception\Test\Unit;
 use Doctrine\DBAL\Connection;
 use Pimcore\Bundle\StaticResolverBundle\Db\DbResolverInterface;
@@ -20,6 +21,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\Listing\Filter\DateFilter;
 use Pimcore\Model\Element\Note\Listing as NoteListing;
+use Pimcore\Model\Element\Recyclebin\Item\Listing as RecycleBinListing;
 
 /**
  * @internal
@@ -37,7 +39,7 @@ final class DateFilterTest extends Unit
 
         $filter->apply($params, $listing);
 
-        $this->assertStringContainsString('`creationDate` BETWEEN :minTime AND :maxTime', $listing->getCondition());
+        $this->assertStringContainsString('`creationDate` BETWEEN :minTime_0 AND :maxTime_0', $listing->getCondition());
     }
 
     public function testDateFilterFromOperator(): void
@@ -51,7 +53,7 @@ final class DateFilterTest extends Unit
 
         $filter->apply($params, $listing);
 
-        $this->assertStringContainsString('`creationDate` >= :creationDate', $listing->getCondition());
+        $this->assertStringContainsString('`creationDate` >= :filter_0', $listing->getCondition());
     }
 
     public function testDateFilterToOperator(): void
@@ -65,7 +67,85 @@ final class DateFilterTest extends Unit
 
         $filter->apply($params, $listing);
 
-        $this->assertStringContainsString('`creationDate` <= :creationDate', $listing->getCondition());
+        $this->assertStringContainsString('`creationDate` <= :filter_0', $listing->getCondition());
+    }
+
+    /**
+     * Regression test for the "Between" date operator (#1924). The UI decomposes a
+     * between-range into two conditions on the same key (`from` + `to`). Deriving the
+     * bind parameter from the key made both bind to `:creationDate`, so the second value
+     * overwrote the first and the query collapsed to `>= to AND <= to` -> empty result.
+     * The bind parameters must be unique per applied filter.
+     */
+    public function testDateFilterBetweenUsesUniqueParameters(): void
+    {
+        $filter = $this->createFilter();
+        $listing = new NoteListing();
+
+        $params = new FilterParameter(columnFilters: [
+            ['key' => 'creationDate', 'type' => 'date', 'filterValue' => ['operator' => 'from', 'value' => '2024-06-10']],
+            ['key' => 'creationDate', 'type' => 'date', 'filterValue' => ['operator' => 'to', 'value' => '2024-06-20']],
+        ]);
+
+        $filter->apply($params, $listing);
+
+        $condition = $listing->getCondition();
+        $this->assertStringContainsString('`creationDate` >= :filter_0', $condition);
+        $this->assertStringContainsString('`creationDate` <= :filter_1', $condition);
+        $this->assertSame(
+            [
+                'filter_0' => '2024-06-10 00:00:00',
+                'filter_1' => '2024-06-20 00:00:00',
+            ],
+            $listing->getConditionVariables()
+        );
+    }
+
+    /**
+     * Regression test for #1937. The recycle bin `date` column stores a Unix timestamp
+     * (int), not a datetime, so comparing it against Carbon datetime strings failed for
+     * every operator. For such columns the bound value must be an integer Unix timestamp.
+     */
+    public function testDateFilterUnixTimestampColumnOnOperator(): void
+    {
+        $filter = $this->createFilter();
+        $listing = new RecycleBinListing();
+
+        $params = new FilterParameter(columnFilters: [
+            ['key' => 'date', 'type' => 'date', 'filterValue' => ['operator' => 'on', 'value' => '2024-06-10']],
+        ]);
+
+        $filter->apply($params, $listing);
+
+        $this->assertStringContainsString('`date` BETWEEN :minTime_0 AND :maxTime_0', $listing->getCondition());
+        $this->assertSame(
+            [
+                'minTime_0' => (new Carbon('2024-06-10'))->getTimestamp(),
+                'maxTime_0' => (new Carbon('2024-06-10'))->addDay()->subSecond()->getTimestamp(),
+            ],
+            $listing->getConditionVariables()
+        );
+    }
+
+    /**
+     * The Unix-timestamp handling must apply to range operators too (#1937).
+     */
+    public function testDateFilterUnixTimestampColumnFromOperator(): void
+    {
+        $filter = $this->createFilter();
+        $listing = new RecycleBinListing();
+
+        $params = new FilterParameter(columnFilters: [
+            ['key' => 'date', 'type' => 'date', 'filterValue' => ['operator' => 'from', 'value' => '2024-06-10']],
+        ]);
+
+        $filter->apply($params, $listing);
+
+        $this->assertStringContainsString('`date` >= :filter_0', $listing->getCondition());
+        $this->assertSame(
+            ['filter_0' => (new Carbon('2024-06-10'))->getTimestamp()],
+            $listing->getConditionVariables()
+        );
     }
 
     public function testDateFilterEscape(): void


### PR DESCRIPTION
## Changes in this pull request
Resolves #1924
Resolves #1937

Both bugs live in the shared `Listing/Filter/DateFilter`, used by the notifications, recycle-bin (and other) listings.

- **#1924 — Notifications "Between" returns empty.** The bind parameter name was derived from the column key, so two conditions on the same column collided. The UI sends a "Between" range as two `columnFilters` (`from` + `to`) on the same key (`creationDate`); both bound to `:creationDate`, the second overwrote the first, and the query collapsed to `creationDate >= to AND creationDate <= to` → always empty. This is the same class as #1923. Bind parameters are now indexed per applied filter (`:filter_0`/`:filter_1`, `:minTime_0`/`:maxTime_0`).

- **#1937 — Recycle bin date filters don't work (all operators).** In addition to the collision above, the filter always compared against a Carbon **datetime string** (`'2024-06-10 00:00:00'`), but `recyclebin.date` is an `int(11) unsigned` **Unix timestamp**. MySQL coerced the string to a number, so even "On" returned an empty list. Columns that store a Unix timestamp are now compared against an integer timestamp.

### Why a class-keyed map for the timestamp columns
The generic `DateFilter` has no reliable way to learn a column's storage type: the frontend sends a generic `date` type, listings expose no table-name accessor (the recycle-bin Dao hardcodes `FROM recyclebin` in raw SQL), and per-request schema introspection would be heavy and fragile. The storage format is a fixed, domain-specific fact, so it's encoded explicitly as `UNIX_TIMESTAMP_COLUMNS` (listing class → column keys). Notifications (`creationDate` is a `TIMESTAMP`) keeps the datetime-string path and is unaffected.

## Additional info
- Regression tests added to `DateFilterTest` for the "Between" collision and the Unix-timestamp column; verified they fail without the fix. Full unit suite passes (446 tests), PHPStan clean.
- **Follow-up (studio-ui-bundle):** the recycle-bin date filter column is currently commented out with a `TODO` referencing #1937 (`recycle-bin/filters/filters.tsx`). It should be re-enabled once this lands.
- Separate from #1945 (Notes `FilterService`), which is a different filter implementation.