### PR TITLE
[Custom Reports] Enforce report sharing checks on drill-down, export, clone, delete, and column-config

### DIFF
--- a/src/Bundle/CustomReport/Controller/Chart/DrillDownOptionsController.php
+++ b/src/Bundle/CustomReport/Controller/Chart/DrillDownOptionsController.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportDr
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service\CustomReportServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\ItemsJson;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
@@ -48,7 +49,7 @@ final class DrillDownOptionsController extends AbstractApiController
     }
 
     /**
-     * @throws DatabaseException|NotFoundException
+     * @throws DatabaseException|ForbiddenException|NotFoundException
      */
     #[Route(self::ROUTE, name: 'pimcore_studio_api_custom_reports_drill_down_options_list', methods: ['POST'])]
     #[IsGranted(CustomReportPermissions::REPORTS->value)]

--- a/src/Bundle/CustomReport/Controller/Config/CloneController.php
+++ b/src/Bundle/CustomReport/Controller/Config/CloneController.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportCl
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportDetails;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service\CustomReportConfigServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotWriteableException;
@@ -50,7 +51,7 @@ final class CloneController extends AbstractApiController
     }
 
     /**
-     * @throws InvalidArgumentException|NotFoundException|NotWriteableException
+     * @throws ForbiddenException|InvalidArgumentException|NotFoundException|NotWriteableException
      */
     #[Route(self::ROUTE, name: 'pimcore_studio_api_custom_reports_config_clone', methods: ['POST'])]
     #[IsGranted(CustomReportPermissions::REPORTS_CONFIG->value)]

--- a/src/Bundle/CustomReport/Controller/Config/ColumnConfigController.php
+++ b/src/Bundle/CustomReport/Controller/Config/ColumnConfigController.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service\ColumnService
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Request\ReferenceRequestBody;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\ItemsJson;
@@ -50,7 +51,7 @@ final class ColumnConfigController extends AbstractApiController
     }
 
     /**
-     * @throws DatabaseException|EnvironmentException|NotFoundException
+     * @throws DatabaseException|EnvironmentException|ForbiddenException|NotFoundException
      */
     #[Route(self::ROUTE, name: 'pimcore_studio_api_custom_reports_column_config', methods: ['POST'])]
     #[IsGranted(CustomReportPermissions::REPORTS_CONFIG->value)]

--- a/src/Bundle/CustomReport/Controller/Config/DeleteController.php
+++ b/src/Bundle/CustomReport/Controller/Config/DeleteController.php
@@ -17,6 +17,7 @@ use OpenApi\Attributes\Delete;
 use Pimcore\Bundle\StudioBackendBundle\Asset\OpenApi\Attribute\Parameter\Path\NameParameter;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service\CustomReportConfigServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotWriteableException;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
@@ -44,7 +45,7 @@ final class DeleteController extends AbstractApiController
     }
 
     /**
-     * @throws NotFoundException|NotWriteableException
+     * @throws ForbiddenException|NotFoundException|NotWriteableException
      */
     #[Route(self::ROUTE, name: 'pimcore_studio_api_custom_reports_config_delete', methods: ['DELETE'])]
     #[IsGranted(CustomReportPermissions::REPORTS_CONFIG->value)]

--- a/src/Bundle/CustomReport/Controller/Config/UpdateController.php
+++ b/src/Bundle/CustomReport/Controller/Config/UpdateController.php
@@ -19,6 +19,7 @@ use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportDe
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportUpdate;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service\CustomReportConfigServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotWriteableException;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\StringParameter;
@@ -49,7 +50,7 @@ final class UpdateController extends AbstractApiController
     }
 
     /**
-     * @throws NotFoundException|NotWriteableException
+     * @throws ForbiddenException|NotFoundException|NotWriteableException
      */
     #[Route(self::ROUTE, name: 'pimcore_studio_api_custom_reports_config_update', methods: ['PUT'])]
     #[IsGranted(CustomReportPermissions::REPORTS_CONFIG->value)]

--- a/src/Bundle/CustomReport/Controller/Export/Csv/ExportController.php
+++ b/src/Bundle/CustomReport/Controller/Export/Csv/ExportController.php
@@ -19,6 +19,8 @@ use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Attribute\Request\Cha
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\MappedParameter\ExportParameter;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service\CsvServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\IdJson;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\CreatedResponse;
@@ -46,6 +48,9 @@ final class ExportController extends AbstractApiController
         parent::__construct($serializer);
     }
 
+    /**
+     * @throws ForbiddenException|NotFoundException
+     */
     #[Route(self::ROUTE, name: 'pimcore_studio_api_custom_report_export_csv', methods: ['Post'])]
     #[IsGranted(CustomReportPermissions::REPORTS->value)]
     #[Post(

--- a/src/Bundle/CustomReport/ExecutionEngine/AutomationAction/Messenger/Handler/CsvCollectionHandler.php
+++ b/src/Bundle/CustomReport/ExecutionEngine/AutomationAction/Messenger/Handler/CsvCollectionHandler.php
@@ -67,6 +67,8 @@ final class CsvCollectionHandler extends AbstractHandler
         $stepData = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CUSTOM_REPORT_CONFIG->value);
         $name = $stepData['name'];
 
+        $reportConfig = null;
+
         try {
             $reportConfig = $this->customReportConfigService->getAllowedReportForUser($name, $user);
         } catch (NotFoundException $e) {

--- a/src/Bundle/CustomReport/ExecutionEngine/AutomationAction/Messenger/Handler/CsvCollectionHandler.php
+++ b/src/Bundle/CustomReport/ExecutionEngine/AutomationAction/Messenger/Handler/CsvCollectionHandler.php
@@ -19,6 +19,7 @@ use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\ExecutionEngine\Autom
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\MappedParameter\ExportParameter;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service\AdapterServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service\CustomReportConfigServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\AutomationAction\AbstractHandler;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Config;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
@@ -65,7 +66,18 @@ final class CsvCollectionHandler extends AbstractHandler
 
         $stepData = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CUSTOM_REPORT_CONFIG->value);
         $name = $stepData['name'];
-        $reportConfig = $this->customReportConfigService->getAllowedReportForUser($name, $user);
+
+        try {
+            $reportConfig = $this->customReportConfigService->getAllowedReportForUser($name, $user);
+        } catch (NotFoundException $e) {
+            $this->abort($this->getAbortData(
+                Config::CSV_DATA_COLLECTION_FAILED_MESSAGE->value,
+                [
+                    'id' => $name,
+                    'message' => $e->getMessage(),
+                ]
+            ));
+        }
 
         if ($reportConfig === null) {
             $this->abort($this->getAbortData(

--- a/src/Bundle/CustomReport/ExecutionEngine/AutomationAction/Messenger/Handler/CsvCollectionHandler.php
+++ b/src/Bundle/CustomReport/ExecutionEngine/AutomationAction/Messenger/Handler/CsvCollectionHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\ExecutionEngine\AutomationAction\Messenger\Handler;
 
 use Exception;
+use Pimcore\Bundle\StaticResolverBundle\Models\User\UserResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\ExecutionEngine\AutomationAction\Messenger\Messages\CsvCollectionMessage;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\MappedParameter\ExportParameter;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service\AdapterServiceInterface;
@@ -38,7 +39,8 @@ final class CsvCollectionHandler extends AbstractHandler
         private readonly PublishServiceInterface $publishService,
         private readonly UserTopicServiceInterface $userTopicService,
         private readonly CustomReportConfigServiceInterface $customReportConfigService,
-        private readonly AdapterServiceInterface $customReportAdapterService
+        private readonly AdapterServiceInterface $customReportAdapterService,
+        private readonly UserResolverInterface $userResolver
     ) {
         parent::__construct();
     }
@@ -52,12 +54,30 @@ final class CsvCollectionHandler extends AbstractHandler
         if (!$this->shouldBeExecuted($jobRun)) {
             return;
         }
-        $name = '';
+
+        $user = $this->userResolver->getById($jobRun->getOwnerId());
+        if ($user === null) {
+            $this->abort($this->getAbortData(
+                Config::USER_NOT_FOUND_MESSAGE->value,
+                ['userId' => $jobRun->getOwnerId()]
+            ));
+        }
+
+        $stepData = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CUSTOM_REPORT_CONFIG->value);
+        $name = $stepData['name'];
+        $reportConfig = $this->customReportConfigService->getAllowedReportForUser($name, $user);
+
+        if ($reportConfig === null) {
+            $this->abort($this->getAbortData(
+                Config::REPORT_PERMISSION_MISSING_MESSAGE->value,
+                [
+                    'userId' => $user->getId(),
+                    'name' => $name,
+                ]
+            ));
+        }
 
         try {
-
-            $stepData = $this->extractConfigFieldFromJobStepConfig($message, StepConfig::CUSTOM_REPORT_CONFIG->value);
-            $reportConfig = $this->customReportConfigService->getCustomReportByName($stepData['name']);
             $exportFields = $this->customReportConfigService->getFieldsForExport($reportConfig);
             $stepData['fields'] = $exportFields;
             $exportParameter = ExportParameter::fromArray($stepData);

--- a/src/Bundle/CustomReport/Repository/CustomReportRepository.php
+++ b/src/Bundle/CustomReport/Repository/CustomReportRepository.php
@@ -101,6 +101,23 @@ final class CustomReportRepository implements CustomReportRepositoryInterface
     /**
      * {@inheritdoc}
      */
+    public function loadByNameForUser(string $name, User $user): ?Config
+    {
+        $report = $this->loadByName($name);
+        $allowedReports = $this->loadForUser($user);
+
+        foreach ($allowedReports as $allowedReport) {
+            if ($allowedReport->getName() === $report->getName()) {
+                return $report;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function create(string $name): Config
     {
         $config = new Config();

--- a/src/Bundle/CustomReport/Repository/CustomReportRepositoryInterface.php
+++ b/src/Bundle/CustomReport/Repository/CustomReportRepositoryInterface.php
@@ -40,6 +40,11 @@ interface CustomReportRepositoryInterface
     public function loadByNameForCurrentUser(string $name): ?Config;
 
     /**
+     * @throws NotFoundException
+     */
+    public function loadByNameForUser(string $name, User $user): ?Config;
+
+    /**
      * @throws NotWriteableException
      */
     public function create(string $name): Config;

--- a/src/Bundle/CustomReport/Service/ColumnService.php
+++ b/src/Bundle/CustomReport/Service/ColumnService.php
@@ -39,7 +39,7 @@ final readonly class ColumnService implements ColumnServiceInterface
      */
     public function getColumnConfig(string $name, CustomReportDataSourceConfig $dataSourceConfig): array
     {
-        $report = $this->customReportConfigService->getCustomReportByName($name);
+        $report = $this->customReportConfigService->getAllowedReport($name);
         $columns = $this->adapterService->getAdapterColumns($dataSourceConfig->getConfiguration());
         $hydrated = [];
 

--- a/src/Bundle/CustomReport/Service/ColumnServiceInterface.php
+++ b/src/Bundle/CustomReport/Service/ColumnServiceInterface.php
@@ -17,6 +17,7 @@ use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportCo
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportDataSourceConfig;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 
 /**
@@ -25,7 +26,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 interface ColumnServiceInterface
 {
     /**
-     * @throws DatabaseException|EnvironmentException|NotFoundException
+     * @throws DatabaseException|EnvironmentException|ForbiddenException|NotFoundException
      *
      * @return CustomReportColumnInformation[]
      */

--- a/src/Bundle/CustomReport/Service/CsvService.php
+++ b/src/Bundle/CustomReport/Service/CsvService.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\MappedParameter\Expor
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Config;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Jobs;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Export\ExecutionEngine\AutomationAction\Messenger\Messages\CsvCreationMessage;
 use Pimcore\Bundle\StudioBackendBundle\Export\ExecutionEngine\Util\JobSteps;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
@@ -33,12 +34,18 @@ final readonly class CsvService implements CsvServiceInterface
 {
     public function __construct(
         private JobExecutionAgentInterface $jobExecutionAgent,
-        private SecurityServiceInterface $securityService
+        private SecurityServiceInterface $securityService,
+        private CustomReportConfigServiceInterface $customReportConfigService
     ) {
     }
 
+    /**
+     * @throws ForbiddenException
+     */
     public function generateCsvFile(ExportParameter $exportParameter): int
     {
+        $this->customReportConfigService->getAllowedReport($exportParameter->getName());
+
         $collectionSettings = [
             StepConfig::CUSTOM_REPORT_CONFIG->value => $exportParameter,
         ];

--- a/src/Bundle/CustomReport/Service/CsvService.php
+++ b/src/Bundle/CustomReport/Service/CsvService.php
@@ -19,10 +19,11 @@ use Pimcore\Bundle\GenericExecutionEngineBundle\Model\JobStep;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\ExecutionEngine\AutomationAction\Messenger\Messages\CsvCollectionMessage;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\ExecutionEngine\Util\JobSteps as CustomReportJobSteps;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\MappedParameter\ExportParameter;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Config;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Jobs;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Export\ExecutionEngine\AutomationAction\Messenger\Messages\CsvCreationMessage;
 use Pimcore\Bundle\StudioBackendBundle\Export\ExecutionEngine\Util\JobSteps;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
@@ -40,7 +41,7 @@ final readonly class CsvService implements CsvServiceInterface
     }
 
     /**
-     * @throws ForbiddenException
+     * @throws ForbiddenException|NotFoundException
      */
     public function generateCsvFile(ExportParameter $exportParameter): int
     {

--- a/src/Bundle/CustomReport/Service/CsvServiceInterface.php
+++ b/src/Bundle/CustomReport/Service/CsvServiceInterface.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service;
 
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\MappedParameter\ExportParameter;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 
 /**
  * @internal
@@ -22,7 +23,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 interface CsvServiceInterface
 {
     /**
-     * @throws ForbiddenException
+     * @throws ForbiddenException|NotFoundException
      */
     public function generateCsvFile(ExportParameter $exportParameter): int;
 }

--- a/src/Bundle/CustomReport/Service/CsvServiceInterface.php
+++ b/src/Bundle/CustomReport/Service/CsvServiceInterface.php
@@ -14,11 +14,15 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service;
 
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\MappedParameter\ExportParameter;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 
 /**
  * @internal
  */
 interface CsvServiceInterface
 {
+    /**
+     * @throws ForbiddenException
+     */
     public function generateCsvFile(ExportParameter $exportParameter): int;
 }

--- a/src/Bundle/CustomReport/Service/CustomReportConfigService.php
+++ b/src/Bundle/CustomReport/Service/CustomReportConfigService.php
@@ -28,6 +28,7 @@ use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportUp
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ValidateConfigurationTrait;
+use Pimcore\Model\User;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use function sprintf;
 
@@ -120,7 +121,7 @@ final readonly class CustomReportConfigService implements CustomReportConfigServ
             );
         }
 
-        $reportToClone = $this->getCustomReportByName($reportName);
+        $reportToClone = $this->getAllowedReport($reportName);
         $config = $this->customReportRepository->cloneConfig($reportToClone, $newName);
 
         return $this->customReportHydrator->extractReportDetails($config);
@@ -131,7 +132,7 @@ final readonly class CustomReportConfigService implements CustomReportConfigServ
      */
     public function deleteCustomReport(string $name): void
     {
-        $customReport = $this->getCustomReportByName($name);
+        $customReport = $this->getAllowedReport($name);
         $this->customReportRepository->delete($customReport);
     }
 
@@ -315,9 +316,9 @@ final readonly class CustomReportConfigService implements CustomReportConfigServ
     }
 
     /**
-     * @throws ForbiddenException
+     * {@inheritdoc}
      */
-    private function getAllowedReport(string $reportName): Config
+    public function getAllowedReport(string $reportName): Config
     {
         $report = $this->customReportRepository->loadByNameForCurrentUser($reportName);
 
@@ -326,5 +327,13 @@ final readonly class CustomReportConfigService implements CustomReportConfigServ
         }
 
         return $report;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllowedReportForUser(string $reportName, User $user): ?Config
+    {
+        return $this->customReportRepository->loadByNameForUser($reportName, $user);
     }
 }

--- a/src/Bundle/CustomReport/Service/CustomReportConfigServiceInterface.php
+++ b/src/Bundle/CustomReport/Service/CustomReportConfigServiceInterface.php
@@ -20,9 +20,11 @@ use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportDe
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportTreeConfigNode;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportTreeNodeFolder;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Schema\CustomReportUpdate;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotWriteableException;
+use Pimcore\Model\User;
 
 /**
  * @internal
@@ -42,17 +44,17 @@ interface CustomReportConfigServiceInterface
     public function createCustomReport(CustomReportAdd $parameters): CustomReportDetails;
 
     /**
-     * @throws NotFoundException|NotWriteableException
+     * @throws ForbiddenException|NotFoundException|NotWriteableException
      */
     public function updateCustomReport(string $name, CustomReportUpdate $parameters): CustomReportDetails;
 
     /**
-     * @throws NotFoundException|NotWriteableException
+     * @throws ForbiddenException|NotFoundException|NotWriteableException
      */
     public function cloneCustomReport(string $reportName, CustomReportClone $parameters): CustomReportDetails;
 
     /**
-     * @throws NotFoundException|NotWriteableException
+     * @throws ForbiddenException|NotFoundException|NotWriteableException
      */
     public function deleteCustomReport(string $name): void;
 
@@ -60,6 +62,16 @@ interface CustomReportConfigServiceInterface
      * @throws NotFoundException
      */
     public function getCustomReportByName(string $reportName): Config;
+
+    /**
+     * @throws ForbiddenException|NotFoundException
+     */
+    public function getAllowedReport(string $reportName): Config;
+
+    /**
+     * @throws NotFoundException
+     */
+    public function getAllowedReportForUser(string $reportName, User $user): ?Config;
 
     /**
      * @throws NotFoundException

--- a/src/Bundle/CustomReport/Service/CustomReportService.php
+++ b/src/Bundle/CustomReport/Service/CustomReportService.php
@@ -69,7 +69,7 @@ final readonly class CustomReportService implements CustomReportServiceInterface
     public function getDrillDownOptions(DrillDownParameter $parameters): array
     {
         $options = [];
-        $config = $this->customReportRepository->loadByName($parameters->getName());
+        $config = $this->getAllowedReport($parameters->getName());
         $adapter = $this->adapterService->getAdapter($config);
 
         try {

--- a/src/Bundle/CustomReport/Service/CustomReportServiceInterface.php
+++ b/src/Bundle/CustomReport/Service/CustomReportServiceInterface.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\Service;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\MappedParameter\ChartDataParameter;
 use Pimcore\Bundle\StudioBackendBundle\Bundle\CustomReport\MappedParameter\DrillDownParameter;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
 
@@ -25,12 +26,12 @@ use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
 interface CustomReportServiceInterface
 {
     /**
-     * @throws NotFoundException
+     * @throws ForbiddenException|NotFoundException
      */
     public function getChartData(ChartDataParameter $parameters): Collection;
 
     /**
-     * @throws DatabaseException|NotFoundException
+     * @throws DatabaseException|ForbiddenException|NotFoundException
      */
     public function getDrillDownOptions(DrillDownParameter $parameters): array;
 }

--- a/src/ExecutionEngine/Util/Config.php
+++ b/src/ExecutionEngine/Util/Config.php
@@ -23,6 +23,7 @@ enum Config: string
     case ENVIRONMENT_VARIABLE_NOT_FOUND = 'studio_ee_environment_variable_not_found';
     case ELEMENT_LOCKED_MESSAGE = 'studio_ee_element_locked';
     case ELEMENT_PERMISSION_MISSING_MESSAGE = 'studio_ee_element_permission_missing';
+    case REPORT_PERMISSION_MISSING_MESSAGE = 'studio_ee_report_permission_missing';
     case ELEMENT_HAS_CHILDREN_MESSAGE = 'studio_ee_element_has_existing_children';
     case ELEMENT_DELETE_FAILED_MESSAGE = 'studio_ee_element_delete_failed';
     case ELEMENT_BATCH_DELETE_FAILED_MESSAGE = 'studio_ee_element_batch_delete_failed';

--- a/translations/studio.de.yaml
+++ b/translations/studio.de.yaml
@@ -4,6 +4,7 @@ studio_ee_user_not_found: Benutzer mit ID %userId% nicht gefunden
 studio_ee_environment_variable_not_found: Umgebungsvariable %variable% nicht gefunden
 studio_ee_element_locked: Element vom Typ %type% mit ID %id% ist gesperrt
 studio_ee_element_permission_missing: Benutzer mit ID %userId% hat fehlende Berechtigung %permission% für Element vom Typ %type% mit ID %id%
+studio_ee_report_permission_missing: Benutzer mit ID %userId% hat keinen Zugriff auf den Bericht %name%
 studio_ee_element_delete_failed: 'Element vom Typ %type% mit ID %id% konnte nicht gelöscht werden: %message%'
 studio_ee_element_batch_delete_failed: 'Stapellöschung von Element vom Typ %type% mit ID %id% und dessen untergeordneten Elementen fehlgeschlagen: %message%'
 studio_ee_zip_file_copy_failed: 'ZIP-Datei konnte nicht kopiert werden: %message%'

--- a/translations/studio.en.yaml
+++ b/translations/studio.en.yaml
@@ -6,6 +6,7 @@ studio_ee_user_not_found: User with ID %userId% not found
 studio_ee_environment_variable_not_found: Environment variable %variable% not found
 studio_ee_element_locked: Element with type %type% with ID %id% is locked
 studio_ee_element_permission_missing: User with ID %userId% has missing permission %permission% on element with type %type% and ID %id%
+studio_ee_report_permission_missing: User with ID %userId% does not have access to report %name%
 studio_ee_element_delete_failed: 'Element with type %type% with ID %id% could not be deleted: %message%'
 studio_ee_element_batch_delete_failed: 'Processing batch deletion of element with type %type% with ID %id% and its children failed: %message%'
 studio_ee_zip_file_copy_failed: 'Zip file could not be copied: %message%'

--- a/translations/studio.es.yaml
+++ b/translations/studio.es.yaml
@@ -4,6 +4,7 @@ studio_ee_user_not_found: Usuario con ID %userId% no encontrado
 studio_ee_environment_variable_not_found: Variable de entorno %variable% no encontrada
 studio_ee_element_locked: El elemento de tipo %type% con ID %id% está bloqueado
 studio_ee_element_permission_missing: El usuario con ID %userId% no tiene el permiso %permission% sobre el elemento de tipo %type% con ID %id%
+studio_ee_report_permission_missing: El usuario con ID %userId% no tiene acceso al informe %name%
 studio_ee_element_delete_failed: 'El elemento de tipo %type% con ID %id% no se pudo eliminar: %message%'
 studio_ee_element_batch_delete_failed: 'La eliminación por lotes del elemento de tipo %type% con ID %id% y sus elementos secundarios falló: %message%'
 studio_ee_zip_file_copy_failed: 'El archivo ZIP no se pudo copiar: %message%'

--- a/translations/studio.fr.yaml
+++ b/translations/studio.fr.yaml
@@ -4,6 +4,7 @@ studio_ee_user_not_found: Utilisateur avec l'ID %userId% introuvable
 studio_ee_environment_variable_not_found: Variable d'environnement %variable% introuvable
 studio_ee_element_locked: L'élément de type %type% avec l'ID %id% est verrouillé
 studio_ee_element_permission_missing: L'utilisateur avec l'ID %userId% n'a pas la permission %permission% sur l'élément de type %type% avec l'ID %id%
+studio_ee_report_permission_missing: L'utilisateur avec l'ID %userId% n'a pas accès au rapport %name%
 studio_ee_element_delete_failed: "L'élément de type %type% avec l'ID %id% n'a pas pu être supprimé : %message%"
 studio_ee_element_batch_delete_failed: "La suppression par lot de l'élément de type %type% avec l'ID %id% et de ses éléments enfants a échoué : %message%"
 studio_ee_zip_file_copy_failed: "Le fichier ZIP n'a pas pu être copié : %message%"

--- a/translations/studio.it.yaml
+++ b/translations/studio.it.yaml
@@ -4,6 +4,7 @@ studio_ee_user_not_found: Utente con ID %userId% non trovato
 studio_ee_environment_variable_not_found: Variabile di ambiente %variable% non trovata
 studio_ee_element_locked: L'elemento di tipo %type% con ID %id% è bloccato
 studio_ee_element_permission_missing: L'utente con ID %userId% non dispone del permesso %permission% sull'elemento di tipo %type% con ID %id%
+studio_ee_report_permission_missing: L'utente con ID %userId% non ha accesso al report %name%
 studio_ee_element_delete_failed: "L'elemento di tipo %type% con ID %id% non è stato eliminato: %message%"
 studio_ee_element_batch_delete_failed: "L'eliminazione in blocco dell'elemento di tipo %type% con ID %id% e dei suoi elementi figli non è riuscita: %message%"
 studio_ee_zip_file_copy_failed: 'Il file ZIP non è stato copiato: %message%'

--- a/translations/studio.no.yaml
+++ b/translations/studio.no.yaml
@@ -4,6 +4,7 @@ studio_ee_user_not_found: Bruker med ID %userId% ble ikke funnet
 studio_ee_environment_variable_not_found: Miljøvariabel %variable% ble ikke funnet
 studio_ee_element_locked: Element av type %type% med ID %id% er låst
 studio_ee_element_permission_missing: Bruker med ID %userId% mangler tillatelse %permission% på element av type %type% med ID %id%
+studio_ee_report_permission_missing: Bruker med ID %userId% har ikke tilgang til rapporten %name%
 studio_ee_element_delete_failed: 'Element av type %type% med ID %id% kunne ikke slettes: %message%'
 studio_ee_element_batch_delete_failed: 'Massesletting av element av type %type% med ID %id% og dets underordnede elementer mislyktes: %message%'
 studio_ee_zip_file_copy_failed: 'ZIP-filen kunne ikke kopieres: %message%'

--- a/translations/studio.sv.yaml
+++ b/translations/studio.sv.yaml
@@ -4,6 +4,7 @@ studio_ee_user_not_found: Användare med ID %userId% hittades inte
 studio_ee_environment_variable_not_found: Miljövariabel %variable% hittades inte
 studio_ee_element_locked: Element av typ %type% med ID %id% är låst
 studio_ee_element_permission_missing: Användare med ID %userId% saknar behörighet %permission% för element av typ %type% med ID %id%
+studio_ee_report_permission_missing: Användare med ID %userId% har inte åtkomst till rapporten %name%
 studio_ee_element_delete_failed: 'Element av typ %type% med ID %id% kunde inte tas bort: %message%'
 studio_ee_element_batch_delete_failed: 'Massborttagning av element av typ %type% med ID %id% och dess underordnade element misslyckades: %message%'
 studio_ee_zip_file_copy_failed: 'ZIP-filen kunde inte kopieras: %message%'


### PR DESCRIPTION
## Summary

`CustomReportRepository::loadByName()` resolves a report by name with no ownership
check, while `loadByNameForCurrentUser()` wraps it and enforces the report's sharing
model (admin flag, `shareGlobally`, `sharedUserIds`, `sharedRoleIds`). Several code
paths called the unprotected method directly, letting any user with only the
generic `reports`/`reports-config` permission read or manage private reports they
were never shared:

- `CustomReportService::getDrillDownOptions()` — `POST /bundle/custom-reports/drill-down-options`
- `CsvService::generateCsvFile()` — `POST /bundle/custom-reports/export/csv` (queues the async export job)
- `CsvCollectionHandler` — the async Messenger worker that actually collects the export data; it runs with no HTTP security token, so it resolves the job-owning user via `UserResolverInterface`/`JobRun::getOwnerId()` (the same pattern `AbstractHandler::validateJobParameters` already uses elsewhere)
- `CustomReportConfigService::cloneCustomReport()` / `deleteCustomReport()` — clone/delete config endpoints
- `ColumnService::getColumnConfig()` — column-config endpoint

All of these now route through `getAllowedReport()` (throws `ForbiddenException`,
synchronous HTTP context) or the new `getAllowedReportForUser()` (returns `null`,
used from the async worker), matching the pattern already used correctly by
`getChartData()` and `updateCustomReport()`.

## Changes

- `CustomReportRepository`: new `loadByNameForUser(string $name, User $user): ?Config`
- `CustomReportConfigService`: `getAllowedReport()` made public (was private, reused
  by existing callers unchanged); new `getAllowedReportForUser()`
- Swapped the unprotected calls in the five spots above
- Added `REPORT_PERMISSION_MISSING_MESSAGE` to the execution-engine `Config` enum
  plus translations in all 8 locale files, for the async abort path
- Updated `@throws` docblocks on the affected interfaces/controllers

## Test plan

- [ ] As a user with only the generic `reports`/`reports-config` permission and no
      sharing on a given report, confirm `drill-down-options`, `export/csv`,
      clone, delete, and `column-config` all now return 403 (matching the existing
      `chart` endpoint behavior) instead of returning report data
- [ ] Confirm CSV export still succeeds end-to-end for a report the user *is*
      allowed to access (request-time check passes, async worker check passes,
      file downloads normally)
- [ ] Run the bundle's CI test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)