### PR TITLE
[Bug, EC] PEES-1178: (Object) Relations to "folder" result in an exception in grid view

### DIFF
--- a/src/Grid/Column/Collector/DataObject/AdvancedColumnCollector.php
+++ b/src/Grid/Column/Collector/DataObject/AdvancedColumnCollector.php
@@ -293,6 +293,10 @@ final class AdvancedColumnCollector implements
         $fieldsByClass = [];
 
         foreach ($classes as $class) {
+            if ($this->isFolderPseudoClass($class['classes'])) {
+                continue;
+            }
+
             $classDefinition = $this->classRepository->getClassDefinition($class['classes']);
             $classIds[] = $classDefinition->getId();
             $fieldsByClass[] = $this->buildFieldForClassName($class['classes']);
@@ -306,6 +310,11 @@ final class AdvancedColumnCollector implements
             classIds: $classIds,
             fields: $fields
         );
+    }
+
+    private function isFolderPseudoClass(string $className): bool
+    {
+        return $className === ElementTypes::TYPE_FOLDER;
     }
 
     /**

--- a/src/Grid/Service/ColumnConfigurationForRelationService.php
+++ b/src/Grid/Service/ColumnConfigurationForRelationService.php
@@ -100,9 +100,15 @@ final readonly class ColumnConfigurationForRelationService implements ColumnConf
                 continue;
             }
 
-            $classId = $this->classDefinitionResolver->getByName(
+            $classDefinition = $this->classDefinitionResolver->getByName(
                 $class['classes'],
-            )->getId();
+            );
+
+            if (!$classDefinition) {
+                continue;
+            }
+
+            $classId = $classDefinition->getId();
 
             $availableConfigurationsForRelation[$classId] = $this->columnConfigurationService
                 ->getAvailableDataObjectColumnConfiguration(
@@ -126,9 +132,19 @@ final readonly class ColumnConfigurationForRelationService implements ColumnConf
         AdvancedManyToManyObjectRelation $fieldDefinition,
         UserInterface $user
     ): array {
-        $classId = $this->classDefinitionResolver->getByName(
-            $fieldDefinition->getAllowedClassId()
-        )->getId();
+        $allowedClassId = $fieldDefinition->getAllowedClassId();
+
+        if ($allowedClassId === ElementTypes::TYPE_FOLDER) {
+            return [];
+        }
+
+        $classDefinition = $this->classDefinitionResolver->getByName($allowedClassId);
+
+        if (!$classDefinition) {
+            return [];
+        }
+
+        $classId = $classDefinition->getId();
 
         $availableConfigurationsForRelation[$classId] = $this->columnConfigurationService
             ->getAvailableDataObjectColumnConfiguration(

--- a/src/Grid/Service/ColumnConfigurationForRelationService.php
+++ b/src/Grid/Service/ColumnConfigurationForRelationService.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ParseException as ApiParseE
 use Pimcore\Bundle\StudioBackendBundle\Exception\ParseException;
 use Pimcore\Bundle\StudioBackendBundle\FieldDefinition\Parser\DotNotationParserInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation;
 use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyObjectRelation;
 use Pimcore\Model\UserInterface;
@@ -95,6 +96,10 @@ final readonly class ColumnConfigurationForRelationService implements ColumnConf
         $availableConfigurationsForRelation = [];
 
         foreach ($classes as $class) {
+            if ($class['classes'] === ElementTypes::TYPE_FOLDER) {
+                continue;
+            }
+
             $classId = $this->classDefinitionResolver->getByName(
                 $class['classes'],
             )->getId();

--- a/tests/Unit/Grid/Column/Collector/DataObject/AdvancedColumnCollectorTest.php
+++ b/tests/Unit/Grid/Column/Collector/DataObject/AdvancedColumnCollectorTest.php
@@ -23,6 +23,7 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Service\SystemColumnServiceInterface
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\TransformerLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\SimpleField;
 use Pimcore\Bundle\StudioBackendBundle\ObjectBrick\Service\ObjectBrickServiceInterface;
+use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
 use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyObjectRelation;
@@ -61,6 +62,67 @@ final class AdvancedColumnCollectorTest extends Unit
         $config = $this->getAdvancedConfig($collector);
 
         $this->assertSame([], $config->getConfig()['relationField']);
+    }
+
+    public function testGetColumnConfigurationsSkipsFolderPseudoClassInRelationField(): void
+    {
+        $relation = new ManyToManyObjectRelation();
+        $relation->setName('relatedItems');
+        $relation->setTitle('Related Items');
+        $relation->setClasses([['classes' => 'folder']]);
+
+        $collector = $this->createCollector([$relation]);
+
+        $config = $this->getAdvancedConfig($collector);
+        $relationFields = $config->getConfig()['relationField'];
+
+        $this->assertCount(1, $relationFields);
+        $this->assertSame([], $relationFields[0]->getClassIds());
+        $this->assertSame([], $relationFields[0]->getFields());
+    }
+
+    public function testGetColumnConfigurationsProcessesRealClassAlongsideSkippedFolder(): void
+    {
+        $relation = new ManyToManyObjectRelation();
+        $relation->setName('relatedItems');
+        $relation->setTitle('Related Items');
+        $relation->setClasses([
+            ['classes' => 'folder'],
+            ['classes' => 'Car'],
+        ]);
+
+        $realClassDefinition = new ClassDefinition();
+        $realClassDefinition->setId('123');
+
+        $layout = $this->makeEmpty(Layout::class, [
+            'getChildren' => [$relation],
+        ]);
+
+        $collector = new AdvancedColumnCollector(
+            $this->makeEmpty(ClassDefinitionServiceInterface::class, [
+                'getFilteredLayoutDefinitions' => $layout,
+            ]),
+            $this->makeEmpty(ClassDefinitionRepositoryInterface::class, [
+                'getClassDefinition' => $realClassDefinition,
+            ]),
+            $this->makeEmpty(TransformerLoaderInterface::class, [
+                'loadTransformers' => [],
+            ]),
+            $this->makeEmpty(DefinitionResolverInterface::class),
+            $this->makeEmpty(ObjectBrickServiceInterface::class),
+            $this->makeEmpty(SystemColumnServiceInterface::class, [
+                'getSystemColumnsForDataObjects' => [],
+            ]),
+        );
+        $collector->setClassId('CAR');
+        $collector->setFolderId(1);
+        $collector->setUser($this->makeEmpty(UserInterface::class));
+
+        $config = $this->getAdvancedConfig($collector);
+        $relationFields = $config->getConfig()['relationField'];
+
+        $this->assertCount(1, $relationFields);
+        $this->assertSame(['123'], $relationFields[0]->getClassIds());
     }
 
     public function testGetColumnConfigurationsExposesClassificationStoreFieldAsMarkedSimpleField(): void

--- a/tests/Unit/Grid/Service/ColumnConfigurationForRelationServiceTest.php
+++ b/tests/Unit/Grid/Service/ColumnConfigurationForRelationServiceTest.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnConfigurationForRelationService;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnConfigurationServiceInterface;
 use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation;
 use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyObjectRelation;
 use Pimcore\Model\UserInterface;
 
@@ -63,6 +64,95 @@ final class ColumnConfigurationForRelationServiceTest extends Unit
 
         $this->assertArrayHasKey('id', $result);
         $this->assertSame('id', $result['id']->getKey());
+    }
+
+    public function testGetAvailableDataObjectColumnConfigurationForRelationSkipsUnresolvableClass(): void
+    {
+        $fieldDefinition = new ManyToManyObjectRelation();
+        $fieldDefinition->setName('relatedCars');
+        $fieldDefinition->setClasses([
+            ['classes' => 'DeletedClass'],
+            ['classes' => 'Car'],
+        ]);
+        $fieldDefinition->setVisibleFields('id');
+
+        $carClassDefinition = new ClassDefinition();
+        $carClassDefinition->setId('123');
+
+        $service = $this->createService(
+            classDefinitionResolver: $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+                'getById' => new ClassDefinition(),
+                'getByName' => static fn (string $name): ?ClassDefinition => $name === 'DeletedClass' ? null : $carClassDefinition,
+            ]),
+            dotNotationParser: $this->makeEmpty(DotNotationParserInterface::class, [
+                'parseByClassId' => new FieldDefinitionWrapper($fieldDefinition, 'object', 'relatedCars'),
+            ]),
+            columnConfigurationService: $this->makeEmpty(ColumnConfigurationServiceInterface::class, [
+                'getAvailableDataObjectColumnConfiguration' => [$this->createColumnConfiguration('id')],
+            ]),
+        );
+
+        $result = $service->getAvailableDataObjectColumnConfigurationForRelation(
+            'CAR',
+            'relatedCars',
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertSame('id', $result['id']->getKey());
+    }
+
+    public function testGetAvailableDataObjectColumnConfigurationForRelationSkipsFolderPseudoClassForAdvancedRelation(): void
+    {
+        $fieldDefinition = new AdvancedManyToManyObjectRelation();
+        $fieldDefinition->setName('relatedCars');
+        $fieldDefinition->setAllowedClassId('folder');
+        $fieldDefinition->setVisibleFields('id');
+
+        $service = $this->createService(
+            classDefinitionResolver: $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+                'getById' => new ClassDefinition(),
+            ]),
+            dotNotationParser: $this->makeEmpty(DotNotationParserInterface::class, [
+                'parseByClassId' => new FieldDefinitionWrapper($fieldDefinition, 'object', 'relatedCars'),
+            ]),
+            columnConfigurationService: $this->makeEmpty(ColumnConfigurationServiceInterface::class),
+        );
+
+        $result = $service->getAvailableDataObjectColumnConfigurationForRelation(
+            'CAR',
+            'relatedCars',
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetAvailableDataObjectColumnConfigurationForRelationSkipsUnresolvableClassForAdvancedRelation(): void
+    {
+        $fieldDefinition = new AdvancedManyToManyObjectRelation();
+        $fieldDefinition->setName('relatedCars');
+        $fieldDefinition->setAllowedClassId('DeletedClass');
+        $fieldDefinition->setVisibleFields('id');
+
+        $service = $this->createService(
+            classDefinitionResolver: $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+                'getById' => new ClassDefinition(),
+                'getByName' => static fn (): ?ClassDefinition => null,
+            ]),
+            dotNotationParser: $this->makeEmpty(DotNotationParserInterface::class, [
+                'parseByClassId' => new FieldDefinitionWrapper($fieldDefinition, 'object', 'relatedCars'),
+            ]),
+            columnConfigurationService: $this->makeEmpty(ColumnConfigurationServiceInterface::class),
+        );
+
+        $result = $service->getAvailableDataObjectColumnConfigurationForRelation(
+            'CAR',
+            'relatedCars',
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertSame([], $result);
     }
 
     private function createService(

--- a/tests/Unit/Grid/Service/ColumnConfigurationForRelationServiceTest.php
+++ b/tests/Unit/Grid/Service/ColumnConfigurationForRelationServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Service;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\FieldDefinition\FieldDefinitionWrapper;
+use Pimcore\Bundle\StudioBackendBundle\FieldDefinition\Parser\DotNotationParserInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnConfigurationForRelationService;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnConfigurationServiceInterface;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyObjectRelation;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+final class ColumnConfigurationForRelationServiceTest extends Unit
+{
+    public function testGetAvailableDataObjectColumnConfigurationForRelationSkipsFolderPseudoClass(): void
+    {
+        $fieldDefinition = new ManyToManyObjectRelation();
+        $fieldDefinition->setName('relatedCars');
+        $fieldDefinition->setClasses([
+            ['classes' => 'folder'],
+            ['classes' => 'Car'],
+        ]);
+        $fieldDefinition->setVisibleFields('id');
+
+        $carClassDefinition = new ClassDefinition();
+        $carClassDefinition->setId('123');
+
+        $service = $this->createService(
+            classDefinitionResolver: $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+                'getById' => new ClassDefinition(),
+                'getByName' => static fn (string $name): ?ClassDefinition => $name === 'folder' ? null : $carClassDefinition,
+            ]),
+            dotNotationParser: $this->makeEmpty(DotNotationParserInterface::class, [
+                'parseByClassId' => new FieldDefinitionWrapper($fieldDefinition, 'object', 'relatedCars'),
+            ]),
+            columnConfigurationService: $this->makeEmpty(ColumnConfigurationServiceInterface::class, [
+                'getAvailableDataObjectColumnConfiguration' => [$this->createColumnConfiguration('id')],
+            ]),
+        );
+
+        $result = $service->getAvailableDataObjectColumnConfigurationForRelation(
+            'CAR',
+            'relatedCars',
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertSame('id', $result['id']->getKey());
+    }
+
+    private function createService(
+        ClassDefinitionResolverInterface $classDefinitionResolver,
+        ColumnConfigurationServiceInterface $columnConfigurationService,
+        DotNotationParserInterface $dotNotationParser,
+    ): ColumnConfigurationForRelationService {
+        return new ColumnConfigurationForRelationService(
+            $classDefinitionResolver,
+            $columnConfigurationService,
+            $dotNotationParser,
+        );
+    }
+
+    private function createColumnConfiguration(string $key): ColumnConfiguration
+    {
+        return new ColumnConfiguration(
+            $key,
+            ['data_object'],
+            false,
+            false,
+            false,
+            false,
+            false,
+            null,
+            'string',
+            'string',
+            [],
+        );
+    }
+}


### PR DESCRIPTION
Object relations that allow linking to folders included the "folder" pseudo-class when resolving class definitions, causing an exception in grid view since folders have no class definition to look up.

## Changes in this pull request
Resolves [#850](https://github.com/pimcore/service-operations/issues/850)