### PR TITLE
[Asset Preview] Persist folder preview image size per user (#3745)

### DIFF
--- a/config/assets.yaml
+++ b/config/assets.yaml
@@ -19,6 +19,10 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Asset\Encoder\TextEncoderInterface:
       class: Pimcore\Bundle\StudioBackendBundle\Asset\Encoder\TextEncoder
 
+  # Repositories
+  Pimcore\Bundle\StudioBackendBundle\Asset\Repository\FolderPreviewSettingRepositoryInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Asset\Repository\FolderPreviewSettingRepository
+
   # Services
   Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetService

--- a/config/assets.yaml
+++ b/config/assets.yaml
@@ -15,6 +15,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Asset\Hydrator\CustomSettingsHydratorInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Asset\Hydrator\CustomSettingsHydrator
 
+  Pimcore\Bundle\StudioBackendBundle\Asset\Hydrator\FolderPreviewSettingHydratorInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Asset\Hydrator\FolderPreviewSettingHydrator
+
   # Encoder
   Pimcore\Bundle\StudioBackendBundle\Asset\Encoder\TextEncoderInterface:
       class: Pimcore\Bundle\StudioBackendBundle\Asset\Encoder\TextEncoder

--- a/config/assets.yaml
+++ b/config/assets.yaml
@@ -27,6 +27,9 @@ services:
     class: Pimcore\Bundle\StudioBackendBundle\Asset\Repository\FolderPreviewSettingRepository
 
   # Services
+  Pimcore\Bundle\StudioBackendBundle\Asset\Service\FolderPreviewSettingServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Asset\Service\FolderPreviewSettingService
+
   Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetService
 

--- a/src/Asset/Controller/FolderPreviewSetting/GetController.php
+++ b/src/Asset/Controller/FolderPreviewSetting/GetController.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Controller\FolderPreviewSetting;
+
+use OpenApi\Attributes\Get;
+use OpenApi\Attributes\JsonContent;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\FolderPreviewSetting;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\FolderPreviewSettingServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IntParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class GetController extends AbstractApiController
+{
+    private const string ROUTE = '/assets/{folderId}/preview-setting';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly FolderPreviewSettingServiceInterface $folderPreviewSettingService,
+    ) {
+        parent::__construct($serializer);
+    }
+
+    #[Route(
+        path: self::ROUTE,
+        name: 'pimcore_studio_api_get_asset_folder_preview_setting',
+        requirements: ['folderId' => '\d+'],
+        methods: ['GET']
+    )]
+    #[IsGranted(UserPermissions::ASSETS->value)]
+    #[Get(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'asset_get_folder_preview_setting',
+        description: 'asset_get_folder_preview_setting_description',
+        summary: 'asset_get_folder_preview_setting_summary',
+        tags: [Tags::Assets->name]
+    )]
+    #[IntParameter(name: 'folderId', example: 1, description: 'Id of the asset folder')]
+    #[SuccessResponse(
+        description: 'asset_get_folder_preview_setting_success_response',
+        content: new JsonContent(ref: FolderPreviewSetting::class)
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+    ])]
+    public function getFolderPreviewSetting(int $folderId): JsonResponse
+    {
+        return $this->jsonResponse($this->folderPreviewSettingService->getImageSize($folderId));
+    }
+}

--- a/src/Asset/Controller/FolderPreviewSetting/UpdateController.php
+++ b/src/Asset/Controller/FolderPreviewSetting/UpdateController.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Controller\FolderPreviewSetting;
+
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Put;
+use OpenApi\Attributes\RequestBody;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\FolderPreviewSetting;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\FolderPreviewSettingServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IntParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class UpdateController extends AbstractApiController
+{
+    private const string ROUTE = '/assets/{folderId}/preview-setting';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly FolderPreviewSettingServiceInterface $folderPreviewSettingService,
+    ) {
+        parent::__construct($serializer);
+    }
+
+    #[Route(
+        path: self::ROUTE,
+        name: 'pimcore_studio_api_update_asset_folder_preview_setting',
+        requirements: ['folderId' => '\d+'],
+        methods: ['PUT']
+    )]
+    #[IsGranted(UserPermissions::ASSETS->value)]
+    #[Put(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'asset_update_folder_preview_setting',
+        description: 'asset_update_folder_preview_setting_description',
+        summary: 'asset_update_folder_preview_setting_summary',
+        tags: [Tags::Assets->name],
+        requestBody: new RequestBody(
+            required: true,
+            content: new JsonContent(ref: FolderPreviewSetting::class)
+        )
+    )]
+    #[IntParameter(name: 'folderId', example: 1, description: 'Id of the asset folder')]
+    #[SuccessResponse(
+        description: 'asset_update_folder_preview_setting_success_response',
+        content: new JsonContent(ref: FolderPreviewSetting::class)
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+    ])]
+    public function updateFolderPreviewSetting(
+        int $folderId,
+        #[MapRequestPayload] FolderPreviewSetting $body
+    ): JsonResponse {
+        $this->folderPreviewSettingService->saveImageSize($folderId, $body->getImageSize());
+
+        return $this->jsonResponse($this->folderPreviewSettingService->getImageSize($folderId));
+    }
+}

--- a/src/Asset/Event/PreResponse/FolderPreviewSettingEvent.php
+++ b/src/Asset/Event/PreResponse/FolderPreviewSettingEvent.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Event\PreResponse;
+
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\FolderPreviewSetting;
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+
+final class FolderPreviewSettingEvent extends AbstractPreResponseEvent
+{
+    public const EVENT_NAME = 'pre_response.asset.folder_preview_setting';
+
+    public function __construct(
+        private readonly FolderPreviewSetting $folderPreviewSetting
+    ) {
+        parent::__construct($folderPreviewSetting);
+    }
+
+    public function getFolderPreviewSetting(): FolderPreviewSetting
+    {
+        return $this->folderPreviewSetting;
+    }
+}

--- a/src/Asset/Hydrator/FolderPreviewSettingHydrator.php
+++ b/src/Asset/Hydrator/FolderPreviewSettingHydrator.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\FolderPreviewSetting;
+
+/**
+ * @internal
+ */
+final readonly class FolderPreviewSettingHydrator implements FolderPreviewSettingHydratorInterface
+{
+    public function hydrate(string $imageSize): FolderPreviewSetting
+    {
+        return new FolderPreviewSetting($imageSize);
+    }
+}

--- a/src/Asset/Hydrator/FolderPreviewSettingHydratorInterface.php
+++ b/src/Asset/Hydrator/FolderPreviewSettingHydratorInterface.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\FolderPreviewSetting;
+
+/**
+ * @internal
+ */
+interface FolderPreviewSettingHydratorInterface
+{
+    public function hydrate(string $imageSize): FolderPreviewSetting;
+}

--- a/src/Asset/Repository/FolderPreviewSettingRepository.php
+++ b/src/Asset/Repository/FolderPreviewSettingRepository.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Asset\FolderPreviewSetting;
+
+/**
+ * @internal
+ */
+final readonly class FolderPreviewSettingRepository implements FolderPreviewSettingRepositoryInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function getByUserAndFolder(int $user, int $folderId): ?FolderPreviewSetting
+    {
+        return $this->entityManager->getRepository(FolderPreviewSetting::class)->findOneBy([
+            'user' => $user,
+            'assetFolderId' => $folderId,
+        ]);
+    }
+
+    public function save(FolderPreviewSetting $setting): FolderPreviewSetting
+    {
+        $this->entityManager->persist($setting);
+        $this->entityManager->flush();
+
+        return $setting;
+    }
+}

--- a/src/Asset/Repository/FolderPreviewSettingRepositoryInterface.php
+++ b/src/Asset/Repository/FolderPreviewSettingRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Repository;
+
+use Pimcore\Bundle\StudioBackendBundle\Entity\Asset\FolderPreviewSetting;
+
+/**
+ * @internal
+ */
+interface FolderPreviewSettingRepositoryInterface
+{
+    public function getByUserAndFolder(int $user, int $folderId): ?FolderPreviewSetting;
+
+    public function save(FolderPreviewSetting $setting): FolderPreviewSetting;
+}

--- a/src/Asset/Schema/FolderPreviewSetting.php
+++ b/src/Asset/Schema/FolderPreviewSetting.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+#[Schema(
+    title: 'FolderPreviewSetting',
+    required: ['imageSize'],
+    type: 'object'
+)]
+final class FolderPreviewSetting implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(
+            description: 'Image display size for the folder preview',
+            type: 'string',
+            enum: ['small', 'large'],
+            example: 'small'
+        )]
+        private readonly string $imageSize,
+    ) {
+    }
+
+    public function getImageSize(): string
+    {
+        return $this->imageSize;
+    }
+}

--- a/src/Asset/Service/FolderPreviewSettingService.php
+++ b/src/Asset/Service/FolderPreviewSettingService.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Asset\Event\PreResponse\FolderPreviewSettingEvent;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Hydrator\FolderPreviewSettingHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Repository\FolderPreviewSettingRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\FolderPreviewSetting;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Asset\FolderPreviewSetting as FolderPreviewSettingEntity;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+final readonly class FolderPreviewSettingService implements FolderPreviewSettingServiceInterface
+{
+    private const string DEFAULT_IMAGE_SIZE = 'small';
+
+    public function __construct(
+        private FolderPreviewSettingRepositoryInterface $repository,
+        private FolderPreviewSettingHydratorInterface $hydrator,
+        private SecurityServiceInterface $securityService,
+        private EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function getImageSize(int $folderId): FolderPreviewSetting
+    {
+        $userId = $this->securityService->getCurrentUser()->getId();
+        $entity = $this->repository->getByUserAndFolder($userId, $folderId);
+        $imageSize = $entity?->getImageSize() ?? self::DEFAULT_IMAGE_SIZE;
+
+        $folderPreviewSetting = $this->hydrator->hydrate($imageSize);
+
+        $this->eventDispatcher->dispatch(
+            new FolderPreviewSettingEvent($folderPreviewSetting),
+            FolderPreviewSettingEvent::EVENT_NAME
+        );
+
+        return $folderPreviewSetting;
+    }
+
+    public function saveImageSize(int $folderId, string $imageSize): void
+    {
+        $userId = $this->securityService->getCurrentUser()->getId();
+        $entity = $this->repository->getByUserAndFolder($userId, $folderId) ?? new FolderPreviewSettingEntity();
+        $entity->setUser($userId);
+        $entity->setAssetFolderId($folderId);
+        $entity->setImageSize($imageSize);
+
+        $this->repository->save($entity);
+    }
+}

--- a/src/Asset/Service/FolderPreviewSettingServiceInterface.php
+++ b/src/Asset/Service/FolderPreviewSettingServiceInterface.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\FolderPreviewSetting;
+
+/**
+ * @internal
+ */
+interface FolderPreviewSettingServiceInterface
+{
+    public function getImageSize(int $folderId): FolderPreviewSetting;
+
+    public function saveImageSize(int $folderId, string $imageSize): void;
+}

--- a/src/Entity/Asset/FolderPreviewSetting.php
+++ b/src/Entity/Asset/FolderPreviewSetting.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Entity\Asset;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @internal
+ */
+#[ORM\Entity]
+#[ORM\Table(name: FolderPreviewSetting::TABLE_NAME)]
+class FolderPreviewSetting
+{
+    public const string TABLE_NAME = 'bundle_studio_asset_folder_preview_settings';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private int $user;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private int $assetFolderId;
+
+    #[ORM\Column(type: 'string', length: 10, nullable: false)]
+    private string $imageSize;
+
+    public function getUser(): int
+    {
+        return $this->user;
+    }
+
+    public function setUser(int $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function getAssetFolderId(): int
+    {
+        return $this->assetFolderId;
+    }
+
+    public function setAssetFolderId(int $assetFolderId): void
+    {
+        $this->assetFolderId = $assetFolderId;
+    }
+
+    public function getImageSize(): string
+    {
+        return $this->imageSize;
+    }
+
+    public function setImageSize(string $imageSize): void
+    {
+        $this->imageSize = $imageSize;
+    }
+}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
 use Pimcore\Bundle\GenericExecutionEngineBundle\Utils\Constants\TableConstants;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Asset\FolderPreviewSetting;
 use Pimcore\Bundle\StudioBackendBundle\Entity\ExecutionEngine\JobRunHidden;
 use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\Entity\Grid\GridConfigurationFavorite;
@@ -65,6 +66,7 @@ final class Installer extends SettingsStoreAwareInstaller
         $this->createUserPerspectivesTable($schema);
         $this->createJobRunHiddenTable($schema);
         $this->createMcpAccessTokenTable($schema);
+        $this->createFolderPreviewSettingTable($schema);
         $this->addUserPermission($schema);
         $this->executeDiffSql($schema);
 
@@ -109,6 +111,10 @@ final class Installer extends SettingsStoreAwareInstaller
 
         if ($schema->hasTable(McpAccessToken::TABLE_NAME)) {
             $schema->dropTable(McpAccessToken::TABLE_NAME);
+        }
+
+        if ($schema->hasTable(FolderPreviewSetting::TABLE_NAME)) {
+            $schema->dropTable(FolderPreviewSetting::TABLE_NAME);
         }
 
         $this->removeUserPermission($schema);
@@ -499,6 +505,24 @@ final class Installer extends SettingsStoreAwareInstaller
             ['onDelete' => 'CASCADE'],
             'fk_' . McpAccessToken::TABLE_NAME . '_users'
         );
+    }
+
+    /**
+     * @throws SchemaException
+     */
+    public function createFolderPreviewSettingTable(Schema $schema): void
+    {
+        if ($schema->hasTable(FolderPreviewSetting::TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schema->createTable(FolderPreviewSetting::TABLE_NAME);
+
+        $table->addColumn('user', 'integer', ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('assetFolderId', 'integer', ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('imageSize', 'string', ['notnull' => true, 'length' => 10]);
+
+        $table->setPrimaryKey(['user', 'assetFolderId'], 'pk_' . FolderPreviewSetting::TABLE_NAME);
     }
 
     /**

--- a/src/Migrations/Version20260715120000.php
+++ b/src/Migrations/Version20260715120000.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Asset\FolderPreviewSetting;
+
+/**
+ * Persist the asset folder preview image display size per user and folder so the choice survives
+ * logout/login instead of only living in the browser session.
+ *
+ * @internal
+ */
+final class Version20260715120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add table to persist asset folder preview image size per user and folder';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable(FolderPreviewSetting::TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schema->createTable(FolderPreviewSetting::TABLE_NAME);
+        $table->addColumn('user', 'integer', ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('assetFolderId', 'integer', ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('imageSize', 'string', ['notnull' => true, 'length' => 10]);
+        $table->setPrimaryKey(['user', 'assetFolderId'], 'pk_' . FolderPreviewSetting::TABLE_NAME);
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable(FolderPreviewSetting::TABLE_NAME)) {
+            $schema->dropTable(FolderPreviewSetting::TABLE_NAME);
+        }
+    }
+}

--- a/src/Migrations/Version20260715120000.php
+++ b/src/Migrations/Version20260715120000.php
@@ -31,23 +31,25 @@ final class Version20260715120000 extends AbstractMigration
         return 'Add table to persist asset folder preview image size per user and folder';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
-        if ($schema->hasTable(FolderPreviewSetting::TABLE_NAME)) {
-            return;
-        }
-
-        $table = $schema->createTable(FolderPreviewSetting::TABLE_NAME);
-        $table->addColumn('user', 'integer', ['notnull' => true, 'unsigned' => true]);
-        $table->addColumn('assetFolderId', 'integer', ['notnull' => true, 'unsigned' => true]);
-        $table->addColumn('imageSize', 'string', ['notnull' => true, 'length' => 10]);
-        $table->setPrimaryKey(['user', 'assetFolderId'], 'pk_' . FolderPreviewSetting::TABLE_NAME);
+        $this->addSql('
+            CREATE TABLE IF NOT EXISTS ' . FolderPreviewSetting::TABLE_NAME . ' (
+                user INT UNSIGNED NOT NULL,
+                assetFolderId INT UNSIGNED NOT NULL,
+                imageSize VARCHAR(10) NOT NULL,
+                PRIMARY KEY (user, assetFolderId)
+            )
+        ');
     }
 
     public function down(Schema $schema): void
     {
-        if ($schema->hasTable(FolderPreviewSetting::TABLE_NAME)) {
-            $schema->dropTable(FolderPreviewSetting::TABLE_NAME);
-        }
+        $this->addSql('DROP TABLE IF EXISTS ' . FolderPreviewSetting::TABLE_NAME);
     }
 }

--- a/tests/Unit/Asset/Hydrator/FolderPreviewSettingHydratorTest.php
+++ b/tests/Unit/Asset/Hydrator/FolderPreviewSettingHydratorTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Asset\Hydrator;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Hydrator\FolderPreviewSettingHydrator;
+
+final class FolderPreviewSettingHydratorTest extends Unit
+{
+    public function testHydrateBuildsDtoWithImageSize(): void
+    {
+        $hydrator = new FolderPreviewSettingHydrator();
+
+        $dto = $hydrator->hydrate('large');
+
+        $this->assertSame('large', $dto->getImageSize());
+    }
+}

--- a/tests/Unit/Asset/Repository/FolderPreviewSettingRepositoryTest.php
+++ b/tests/Unit/Asset/Repository/FolderPreviewSettingRepositoryTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Asset\Repository;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Repository\FolderPreviewSettingRepository;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Asset\FolderPreviewSetting;
+
+final class FolderPreviewSettingRepositoryTest extends Unit
+{
+    public function testGetByUserAndFolderReturnsNullWhenMissing(): void
+    {
+        $doctrineRepo = $this->makeEmpty(EntityRepository::class, [
+            'findOneBy' => null,
+        ]);
+        $em = $this->makeEmpty(EntityManagerInterface::class, [
+            'getRepository' => $doctrineRepo,
+        ]);
+
+        $repo = new FolderPreviewSettingRepository($em);
+
+        $this->assertNull($repo->getByUserAndFolder(7, 42));
+    }
+
+    public function testGetByUserAndFolderReturnsStoredEntity(): void
+    {
+        $setting = new FolderPreviewSetting();
+        $setting->setUser(7);
+        $setting->setAssetFolderId(42);
+        $setting->setImageSize('large');
+
+        $doctrineRepo = $this->makeEmpty(EntityRepository::class, [
+            'findOneBy' => $setting,
+        ]);
+        $em = $this->makeEmpty(EntityManagerInterface::class, [
+            'getRepository' => $doctrineRepo,
+        ]);
+
+        $repo = new FolderPreviewSettingRepository($em);
+
+        $this->assertSame($setting, $repo->getByUserAndFolder(7, 42));
+    }
+
+    public function testSavePersistsAndFlushes(): void
+    {
+        $setting = new FolderPreviewSetting();
+        $setting->setUser(7);
+        $setting->setAssetFolderId(42);
+        $setting->setImageSize('large');
+
+        $em = $this->makeEmpty(EntityManagerInterface::class, [
+            'persist' => Expected::once(),
+            'flush' => Expected::once(),
+        ]);
+
+        $repo = new FolderPreviewSettingRepository($em);
+
+        $this->assertSame($setting, $repo->save($setting));
+    }
+}

--- a/tests/Unit/Asset/Service/FolderPreviewSettingServiceTest.php
+++ b/tests/Unit/Asset/Service/FolderPreviewSettingServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Asset\Service;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Hydrator\FolderPreviewSettingHydrator;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Repository\FolderPreviewSettingRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\FolderPreviewSettingService;
+use Pimcore\Bundle\StudioBackendBundle\Entity\Asset\FolderPreviewSetting as FolderPreviewSettingEntity;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Model\UserInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class FolderPreviewSettingServiceTest extends Unit
+{
+    private function securityFor(int $userId): SecurityServiceInterface
+    {
+        $user = $this->makeEmpty(UserInterface::class, ['getId' => $userId]);
+
+        return $this->makeEmpty(SecurityServiceInterface::class, ['getCurrentUser' => $user]);
+    }
+
+    private function dispatcher(): EventDispatcherInterface
+    {
+        return $this->makeEmpty(EventDispatcherInterface::class, [
+            'dispatch' => static fn ($event) => $event,
+        ]);
+    }
+
+    public function testGetImageSizeReturnsDefaultWhenMissing(): void
+    {
+        $repository = $this->makeEmpty(FolderPreviewSettingRepositoryInterface::class, [
+            'getByUserAndFolder' => null,
+        ]);
+
+        $service = new FolderPreviewSettingService(
+            $repository,
+            new FolderPreviewSettingHydrator(),
+            $this->securityFor(7),
+            $this->dispatcher(),
+        );
+
+        $this->assertSame('small', $service->getImageSize(42)->getImageSize());
+    }
+
+    public function testGetImageSizeReturnsStoredValue(): void
+    {
+        $entity = new FolderPreviewSettingEntity();
+        $entity->setUser(7);
+        $entity->setAssetFolderId(42);
+        $entity->setImageSize('large');
+
+        $repository = $this->makeEmpty(FolderPreviewSettingRepositoryInterface::class, [
+            'getByUserAndFolder' => $entity,
+        ]);
+
+        $service = new FolderPreviewSettingService(
+            $repository,
+            new FolderPreviewSettingHydrator(),
+            $this->securityFor(7),
+            $this->dispatcher(),
+        );
+
+        $this->assertSame('large', $service->getImageSize(42)->getImageSize());
+    }
+
+    public function testSaveImageSizeUpsert(): void
+    {
+        $repository = $this->makeEmpty(FolderPreviewSettingRepositoryInterface::class, [
+            'getByUserAndFolder' => null,
+            'save' => Expected::once(),
+        ]);
+
+        $service = new FolderPreviewSettingService(
+            $repository,
+            new FolderPreviewSettingHydrator(),
+            $this->securityFor(7),
+            $this->dispatcher(),
+        );
+
+        $service->saveImageSize(42, 'large');
+    }
+}

--- a/tests/Unit/Asset/Service/FolderPreviewSettingServiceTest.php
+++ b/tests/Unit/Asset/Service/FolderPreviewSettingServiceTest.php
@@ -80,7 +80,7 @@ final class FolderPreviewSettingServiceTest extends Unit
     {
         $repository = $this->makeEmpty(FolderPreviewSettingRepositoryInterface::class, [
             'getByUserAndFolder' => null,
-            'save' => Expected::once(),
+            'save' => Expected::once(static fn (FolderPreviewSettingEntity $setting): FolderPreviewSettingEntity => $setting),
         ]);
 
         $service = new FolderPreviewSettingService(

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -18,6 +18,16 @@ asset_clone_description: |
   Clones a specific asset with the given <strong>{id}</strong>. <br> The <strong>{parentId}</strong> must be a folder
 asset_clone_success_response: Successfully copied asset
 asset_clone_summary: Clone a specific asset
+asset_get_folder_preview_setting_description: |
+  Returns the stored image display size for the folder preview of the given <strong>{folderId}</strong>
+  for the current user. Falls back to <strong>small</strong> when nothing has been stored yet.
+asset_get_folder_preview_setting_success_response: Successfully returned the folder preview image size
+asset_get_folder_preview_setting_summary: Get the folder preview image size
+asset_update_folder_preview_setting_description: |
+  Stores the image display size for the folder preview of the given <strong>{folderId}</strong>
+  for the current user so it persists across sessions
+asset_update_folder_preview_setting_success_response: Successfully stored the folder preview image size
+asset_update_folder_preview_setting_summary: Update the folder preview image size
 asset_export_zip_created_response: Successfully created <strong>jobRun</strong> for zip export
 asset_export_zip_asset_description: |
   Creating a ZIP file for assets based on the provided asset IDs in <strong>{assets}</strong> parameter. <br>


### PR DESCRIPTION
## What
Backend for pimcore/studio-ui-bundle#3745 — persist the asset folder **Preview** tab image-display size (small/large) **per user + folder**, so it survives logout/login instead of only living in the browser session.

## Changes
- New Doctrine entity `Entity/Asset/FolderPreviewSetting` (composite PK `user` + `assetFolderId`, `imageSize`), created in `Installer` + migration `Version20260715120000` (raw `CREATE TABLE` to avoid the MariaDB `bit`-type schema-diff error).
- `Asset/Repository/FolderPreviewSettingRepository` (get by user+folder, upsert).
- `Asset/Service/FolderPreviewSettingService` — returns default `small` when unset, upserts on save; dispatches a pre-response event.
- `Asset/Schema/FolderPreviewSetting` DTO + `Asset/Hydrator/...` + `Asset/Event/PreResponse/FolderPreviewSettingEvent`.
- Two one-action controllers under `Asset/Controller/FolderPreviewSetting/`: `GET`/`PUT /assets/{folderId}/preview-setting`, guarded with `#[IsGranted(ASSETS)]`, fully OpenAPI-documented (+6 translation keys).

## Tests
- Codeception unit tests for repository, hydrator and service.

## Companion PR
- Frontend: pimcore/studio-ui-bundle (branch `feature/3745-persist-asset-preview-image-size-2026x`).

## Notes
- Follows the layered Controller→Service→Repository→Hydrator/DTO/Event architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)