### PR TITLE
[Element] Add batch delete-info endpoint

### DIFF
--- a/config/elements.yaml
+++ b/config/elements.yaml
@@ -54,6 +54,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Element\Service\EditLockServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Element\Service\EditLockService
 
+  Pimcore\Bundle\StudioBackendBundle\Element\Service\BatchDeleteInfoServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Element\Service\BatchDeleteInfoService
+
   #
   # Handler
   #

--- a/src/Element/Controller/BatchDeleteInfoController.php
+++ b/src/Element/Controller/BatchDeleteInfoController.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Element\Controller;
+
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Post;
+use OpenApi\Attributes\RequestBody;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Element\Schema\DeleteInfo;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\BatchDeleteInfoServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\IdsParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Content\ScalarItemsJson;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\ElementTypeParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class BatchDeleteInfoController extends AbstractApiController
+{
+    private const string ROUTE = '/elements/{elementType}/batch-delete-info';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly BatchDeleteInfoServiceInterface $batchDeleteInfoService,
+        private readonly SecurityServiceInterface $securityService,
+    ) {
+        parent::__construct($serializer);
+    }
+
+    /**
+     * @throws ForbiddenException|InvalidElementTypeException|NotFoundException|SearchException|UserNotFoundException
+     */
+    #[Route(
+        self::ROUTE,
+        name: 'pimcore_studio_api_elements_batch_delete_info',
+        methods: ['POST']
+    )]
+    #[IsGranted(UserPermissions::ELEMENT_TYPE_PERMISSION->value)]
+    #[Post(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'element_batch_delete_info',
+        description: 'element_batch_delete_info_description',
+        summary: 'element_batch_delete_info_summary',
+        tags: [Tags::Elements->name]
+    )]
+    #[ElementTypeParameter]
+    #[RequestBody(
+        content: new ScalarItemsJson('integer', 'ids')
+    )]
+    #[SuccessResponse(
+        description: 'element_batch_delete_info_success_response',
+        content: new JsonContent(ref: DeleteInfo::class)
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::FORBIDDEN,
+        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::INTERNAL_SERVER_ERROR,
+    ])]
+    public function getBatchDeleteInfo(
+        string $elementType,
+        #[MapRequestPayload] IdsParameter $parameter,
+    ): JsonResponse {
+        return $this->jsonResponse(
+            $this->batchDeleteInfoService->getBatchDeleteInfo(
+                $parameter,
+                $elementType,
+                $this->securityService->getCurrentUser()
+            )
+        );
+    }
+}

--- a/src/Element/Service/BatchDeleteInfoService.php
+++ b/src/Element/Service/BatchDeleteInfoService.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Element\Schema\DeleteInfo;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\IdsParameter;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Model\UserInterface;
+use function in_array;
+
+/**
+ * @internal
+ */
+final readonly class BatchDeleteInfoService implements BatchDeleteInfoServiceInterface
+{
+    public function __construct(
+        private ElementServiceInterface $elementService,
+        private ElementDeleteServiceInterface $elementDeleteService,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBatchDeleteInfo(
+        IdsParameter $ids,
+        string $elementType,
+        UserInterface $user
+    ): DeleteInfo {
+        if (!in_array($elementType, ElementTypes::ALLOWED_STUDIO_TYPES, true)) {
+            throw new InvalidElementTypeException($elementType);
+        }
+
+        $hasDependencies = false;
+        $canUseRecycleBin = true;
+
+        foreach ($ids->getIds() as $id) {
+            // hasDependencies can only flip to true, canUseRecycleBin only to false: once both are
+            // final there is nothing left to learn, so skip the remaining elements.
+            if ($hasDependencies && !$canUseRecycleBin) {
+                break;
+            }
+
+            $element = $this->elementService->getAllowedElementById($elementType, $id, $user);
+            $deleteInfo = $this->elementDeleteService->getElementDeleteInfo($element, $user);
+
+            $hasDependencies = $hasDependencies || $deleteInfo->getHasDependencies();
+            $canUseRecycleBin = $canUseRecycleBin && $deleteInfo->getCanUseRecycleBin();
+        }
+
+        return new DeleteInfo($hasDependencies, $canUseRecycleBin);
+    }
+}

--- a/src/Element/Service/BatchDeleteInfoServiceInterface.php
+++ b/src/Element/Service/BatchDeleteInfoServiceInterface.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Element\Schema\DeleteInfo;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\SearchException;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\IdsParameter;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+interface BatchDeleteInfoServiceInterface
+{
+    /**
+     * Aggregates the single-element delete info over the given elements: whether any of them has
+     * dependencies and whether the whole selection can still use the recycle bin. The aggregation
+     * stops as soon as both results are final.
+     *
+     * @throws ForbiddenException|InvalidElementTypeException|NotFoundException|SearchException
+     */
+    public function getBatchDeleteInfo(
+        IdsParameter $ids,
+        string $elementType,
+        UserInterface $user
+    ): DeleteInfo;
+}

--- a/tests/Unit/Element/Service/BatchDeleteInfoServiceTest.php
+++ b/tests/Unit/Element/Service/BatchDeleteInfoServiceTest.php
@@ -1,0 +1,157 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\Element\Schema\DeleteInfo;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\BatchDeleteInfoService;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementDeleteServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\IdsParameter;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+final class BatchDeleteInfoServiceTest extends Unit
+{
+    /**
+     * @throws Exception
+     */
+    public function testNoDependenciesAndAllRecyclable(): void
+    {
+        $service = $this->createService(
+            [1 => ['deps' => false, 'recycle' => true], 2 => ['deps' => false, 'recycle' => true]],
+            $calls
+        );
+
+        $result = $service->getBatchDeleteInfo(new IdsParameter([1, 2]), ElementTypes::TYPE_DATA_OBJECT, $this->makeUser());
+
+        $this->assertFalse($result->getHasDependencies());
+        $this->assertTrue($result->getCanUseRecycleBin());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testHasDependenciesWhenAnyElementHasThem(): void
+    {
+        $service = $this->createService(
+            [1 => ['deps' => false, 'recycle' => true], 2 => ['deps' => true, 'recycle' => true]],
+            $calls
+        );
+
+        $result = $service->getBatchDeleteInfo(new IdsParameter([1, 2]), ElementTypes::TYPE_DATA_OBJECT, $this->makeUser());
+
+        $this->assertTrue($result->getHasDependencies());
+        $this->assertTrue($result->getCanUseRecycleBin());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testNotRecyclableWhenAnyElementIsNotRecyclable(): void
+    {
+        $service = $this->createService(
+            [1 => ['deps' => false, 'recycle' => true], 2 => ['deps' => false, 'recycle' => false]],
+            $calls
+        );
+
+        $result = $service->getBatchDeleteInfo(new IdsParameter([1, 2]), ElementTypes::TYPE_DATA_OBJECT, $this->makeUser());
+
+        $this->assertFalse($result->getCanUseRecycleBin());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testStopsOnceBothResultsAreFinal(): void
+    {
+        // Element 1 both has dependencies and is not recyclable -> both aggregates are final, so the
+        // remaining elements must not be resolved or queried.
+        $service = $this->createService(
+            [
+                1 => ['deps' => true, 'recycle' => false],
+                2 => ['deps' => true, 'recycle' => false],
+                3 => ['deps' => true, 'recycle' => false],
+            ],
+            $calls
+        );
+
+        $result = $service->getBatchDeleteInfo(new IdsParameter([1, 2, 3]), ElementTypes::TYPE_DATA_OBJECT, $this->makeUser());
+
+        $this->assertSame([1], $calls['resolved']);
+        $this->assertSame([1], $calls['info']);
+        $this->assertTrue($result->getHasDependencies());
+        $this->assertFalse($result->getCanUseRecycleBin());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testInvalidElementTypeThrows(): void
+    {
+        $service = $this->createService([1 => ['deps' => false, 'recycle' => true]], $calls);
+
+        $this->expectException(InvalidElementTypeException::class);
+
+        $service->getBatchDeleteInfo(new IdsParameter([1]), 'bogus', $this->makeUser());
+    }
+
+    /**
+     * @param array<int, array{deps: bool, recycle: bool}> $spec
+     * @param array<string, array<int>>                    $calls
+     *
+     * @throws Exception
+     */
+    private function createService(array $spec, ?array &$calls = null): BatchDeleteInfoService
+    {
+        $calls = ['resolved' => [], 'info' => []];
+
+        $elements = [];
+        foreach (array_keys($spec) as $id) {
+            $elements[$id] = $this->makeEmpty(ElementInterface::class, ['getId' => $id]);
+        }
+
+        $elementService = $this->makeEmpty(ElementServiceInterface::class, [
+            'getAllowedElementById' => function (string $type, int $id, UserInterface $user) use (&$calls, $elements) {
+                $calls['resolved'][] = $id;
+
+                return $elements[$id];
+            },
+        ]);
+
+        $elementDeleteService = $this->makeEmpty(ElementDeleteServiceInterface::class, [
+            'getElementDeleteInfo' => function (ElementInterface $element, UserInterface $user) use (&$calls, $spec) {
+                $calls['info'][] = $element->getId();
+
+                return new DeleteInfo($spec[$element->getId()]['deps'], $spec[$element->getId()]['recycle']);
+            },
+        ]);
+
+        return new BatchDeleteInfoService($elementService, $elementDeleteService);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function makeUser(): UserInterface
+    {
+        return $this->makeEmpty(UserInterface::class, ['getId' => 42]);
+    }
+}

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -574,6 +574,10 @@ documents_list_available_sites_summary: List all available sites
 document_get_search_description: Document grid for search
 document_get_search_summary: Get document data for search
 document_get_search_success_response: Documents for search grid
+element_batch_delete_info_description: |
+  Get aggregated delete info for the given <strong>{elementType}</strong> and the provided list of <strong>ids</strong>. <br> Returns whether any of the selected elements has dependencies (child elements or references to it) and whether the whole selection can still use the recycle bin.
+element_batch_delete_info_success_response: Batch delete info for the given elements
+element_batch_delete_info_summary: Get batch delete info for multiple elements by id list and element type
 element_delete_created_response: Successfully created jobRun for deleting element
   and its children
 element_delete_description: |


### PR DESCRIPTION
Part of https://github.com/pimcore/studio-ui-bundle/issues/3666
## What

Adds a batch variant of the element delete-info endpoint:

`POST /pimcore-studio/api/elements/{elementType}/batch-delete-info` — body `{ "ids": [ … ] }`
→ `DeleteInfo { "hasDependencies": bool, "canUseRecycleBin": bool }`

It aggregates the single-element delete info over all given ids in **one** request:

- **hasDependencies** — `true` if any selected element has children or is referenced by other elements.
- **canUseRecycleBin** — `true` only if *every* selected element would go to the recycle bin (`false` ⇒ at least one would be deleted permanently).

The service iterates the ids, calls `ElementDeleteService::getElementDeleteInfo()` per element, and **stops as soon as both results are final** (a dependency found *and* one element that would be permanent), since `hasDependencies` can only flip to `true` and `canUseRecycleBin` only to `false`.

## Why

The grid batch-delete dialog currently calls the single-id delete-info endpoint **once per selected row** (N parallel requests) to choose "Delete" vs "Delete permanently". Large selections hit browser connection limits and hammer the server with N index queries. This provides a single aggregated call. Backend side of pimcore/studio-ui-bundle#3666.

## Notes / trade-offs

- Reuses `getElementDeleteInfo`, so `canUseRecycleBin` uses `countElementChildren()` (which materializes descendant ids). Fine for typical selections; a lean index total-hits count can be reintroduced behind the same contract if giant-folder previews become slow.
- The early-stop skips resolving later ids once both flags are final; authoritative permission/lock checks still run at actual delete time.

## Tests

- **Unit:** `BatchDeleteInfoServiceTest` covers the aggregation and both early-stop paths; full `tests/Unit/Element` suite green.
- **Static analysis:** PHPStan and php-cs-fixer clean.
- **Manual:** verified live on a demo instance — container wiring, route registration, and real data (folders with 51 / 543 descendants, aggregated selections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
