### PR TITLE
[Relation] Tolerate missing column type/config in GridService instead of failing the whole grid

### DIFF
--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -25,6 +25,7 @@ use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Config;
 use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnCollectorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnDefinitionInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\CoreElementColumnResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ExportResolverInterface;
@@ -341,13 +342,30 @@ final class GridService implements GridServiceInterface
 
         $columns = [];
         foreach ($config as $column) {
+            if (!isset($column['key'])) {
+                throw new InvalidArgumentException('Invalid column configuration');
+            }
+
+            $type = $column['type'] ?? $this->resolveSystemColumnType($column['key']);
+            if ($type === null) {
+                // The frontend may send default fallback columns without a type (e.g. relation
+                // preview grids with no configured visible fields). Skip a single column that
+                // cannot be resolved instead of failing the whole grid request.
+                $this->pimcoreLogger->warning(
+                    'Skipping grid column with unresolvable type',
+                    ['columnKey' => $column['key']]
+                );
+
+                continue;
+            }
+
             try {
                 $columns[] = new Column(
                     key: $column['key'],
                     locale: $column['locale'] ?? null,
-                    type: $column['type'],
+                    type: $type,
                     group: $column['group'] ?? null,
-                    config: $column['config'],
+                    config: $column['config'] ?? [],
                     width: $column['width'] ?? null
                 );
             } catch (Exception) {
@@ -356,6 +374,19 @@ final class GridService implements GridServiceInterface
         }
 
         return new ColumnCollection($columns);
+    }
+
+    /**
+     * Resolve the column type for well-known system columns that the frontend may send without
+     * an explicit type (default relation-grid fallback columns).
+     */
+    private function resolveSystemColumnType(string $key): ?string
+    {
+        return match ($key) {
+            'id' => ColumnType::SYSTEM_ID->value,
+            'fullpath', 'classname' => ColumnType::SYSTEM_STRING->value,
+            default => null,
+        };
     }
 
     private function supports(Column $column, string $elementType): bool

--- a/tests/Unit/Grid/Service/GridServiceTest.php
+++ b/tests/Unit/Grid/Service/GridServiceTest.php
@@ -20,7 +20,11 @@ use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\LocalizedFieldResolver
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\DataObjectSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Grid\GridSearchInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\System\IdResolver;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\System\StringResolver;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnCollectorLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnDefinitionLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnResolverLoaderInterface;
@@ -106,6 +110,15 @@ final class GridServiceTest extends Unit
             serviceResolver: $this->makeEmpty(ServiceResolverInterface::class, [
                 'getElementById' => $this->makeEmpty(AbstractObject::class),
             ]),
+            // No column should be skipped: all three must resolve to a system type.
+            logger: $this->makeEmpty(LoggerInterface::class, ['warning' => Expected::never()]),
+            // Real resolvers keyed by the types resolveSystemColumnType() must produce.
+            columnResolverLoader: $this->makeEmpty(ColumnResolverLoaderInterface::class, [
+                'loadColumnResolvers' => [
+                    ColumnType::SYSTEM_ID->value => new IdResolver(),
+                    ColumnType::SYSTEM_STRING->value => new StringResolver(),
+                ],
+            ]),
         );
 
         // Default relation-grid fallback columns: only a key, no type/config.
@@ -124,6 +137,24 @@ final class GridServiceTest extends Unit
 
         $this->assertCount(1, $result->getItems());
         $this->assertSame(1, $result->getTotalItems());
+
+        // The typeless columns were actually resolved (mapped to their system types) and used,
+        // not silently skipped: assert the resulting column keys and field types.
+        /** @var ColumnData[] $columns */
+        $columns = $result->getItems()[0]['columns'];
+        $this->assertCount(3, $columns);
+        $this->assertSame(
+            ['id', 'fullpath', 'classname'],
+            array_map(static fn (ColumnData $column): string => $column->getKey(), $columns)
+        );
+        $this->assertSame(
+            [
+                ColumnType::SYSTEM_ID->value,
+                ColumnType::SYSTEM_STRING->value,
+                ColumnType::SYSTEM_STRING->value,
+            ],
+            array_map(static fn (ColumnData $column): mixed => $column->getFieldType(), $columns)
+        );
     }
 
     /**
@@ -165,10 +196,11 @@ final class GridServiceTest extends Unit
         ?GridSearchInterface $gridSearch = null,
         ?ServiceResolverInterface $serviceResolver = null,
         ?LoggerInterface $logger = null,
+        ?ColumnResolverLoaderInterface $columnResolverLoader = null,
     ): GridService {
         return new GridService(
             $this->makeEmpty(ColumnDefinitionLoaderInterface::class),
-            $this->makeEmpty(ColumnResolverLoaderInterface::class),
+            $columnResolverLoader ?? $this->makeEmpty(ColumnResolverLoaderInterface::class),
             $this->makeEmpty(ColumnCollectorLoaderInterface::class),
             $gridSearch ?? $this->makeEmpty(GridSearchInterface::class),
             $this->makeEmpty(EventDispatcherInterface::class),

--- a/tests/Unit/Grid/Service/GridServiceTest.php
+++ b/tests/Unit/Grid/Service/GridServiceTest.php
@@ -84,6 +84,83 @@ final class GridServiceTest extends Unit
         $this->assertSame(2, $result->getTotalItems());
     }
 
+    /**
+     * Relation preview grids with no configured visible fields fall back to default columns
+     * (id / fullpath / classname) that the frontend sends without a `type` or `config`. These
+     * must resolve to their system column types instead of failing the whole grid request with
+     * a 422 "Invalid column configuration".
+     */
+    public function testGetDataObjectGridResolvesTypelessSystemColumns(): void
+    {
+        $searchResult = new DataObjectSearchResult(
+            items: [$this->makeEmpty(StudioElementInterface::class, ['getId' => 100])],
+            currentPage: 1,
+            pageSize: 10,
+            totalItems: 1,
+        );
+
+        $service = $this->createService(
+            gridSearch: $this->makeEmpty(GridSearchInterface::class, [
+                'searchDataObjects' => $searchResult,
+            ]),
+            serviceResolver: $this->makeEmpty(ServiceResolverInterface::class, [
+                'getElementById' => $this->makeEmpty(AbstractObject::class),
+            ]),
+        );
+
+        // Default relation-grid fallback columns: only a key, no type/config.
+        $gridParameter = new GridParameter(
+            folderId: 1,
+            columns: [
+                ['key' => 'id'],
+                ['key' => 'fullpath'],
+                ['key' => 'classname'],
+            ],
+            filters: null,
+        );
+
+        // Previously threw InvalidArgumentException (422); now completes normally.
+        $result = $service->getDataObjectGrid($gridParameter, null);
+
+        $this->assertCount(1, $result->getItems());
+        $this->assertSame(1, $result->getTotalItems());
+    }
+
+    /**
+     * A single column whose type is missing and cannot be resolved as a system column must be
+     * skipped (and logged), not abort the whole grid request.
+     */
+    public function testGetDataObjectGridSkipsColumnWithUnresolvableType(): void
+    {
+        $searchResult = new DataObjectSearchResult(
+            items: [$this->makeEmpty(StudioElementInterface::class, ['getId' => 100])],
+            currentPage: 1,
+            pageSize: 10,
+            totalItems: 1,
+        );
+
+        $service = $this->createService(
+            gridSearch: $this->makeEmpty(GridSearchInterface::class, [
+                'searchDataObjects' => $searchResult,
+            ]),
+            serviceResolver: $this->makeEmpty(ServiceResolverInterface::class, [
+                'getElementById' => $this->makeEmpty(AbstractObject::class),
+            ]),
+            // The unresolvable column must produce exactly one warning.
+            logger: $this->makeEmpty(LoggerInterface::class, ['warning' => Expected::once()]),
+        );
+
+        $gridParameter = new GridParameter(
+            folderId: 1,
+            columns: [['key' => 'someUnknownColumn']],
+            filters: null,
+        );
+
+        $result = $service->getDataObjectGrid($gridParameter, null);
+
+        $this->assertCount(1, $result->getItems());
+    }
+
     private function createService(
         ?GridSearchInterface $gridSearch = null,
         ?ServiceResolverInterface $serviceResolver = null,


### PR DESCRIPTION
GridService::getConfigurationFromArray() built each Column with type: $column['type'] / config: $column['config'] and no null-coalescing, so a single column missing type/config aborted the entire grid request with 422 "Invalid column configuration" (and an "Undefined array key type" warning). This broke relation preview grids whose default fallback columns arrive without a type.

Harden the column construction:

- default config to [] when missing
- resolve a missing type for known system columns (id -> system.id, fullpath/classname -> system.string) via a new resolveSystemColumnType()
- skip a single column whose type is still unresolvable, logging a warning, instead of failing the whole request (mirrors the existing index-out-of-sync skip pattern)
- keep throwing InvalidArgumentException only for genuinely malformed input
    (missing key)

Add GridServiceTest coverage: typeless system columns resolve without a 422, and an unresolvable column is skipped rather than fatal.