### PR TITLE
Run static analysis on pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 3 * * 1,3,5'
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [ opened, synchronize, reopened ]
     paths-ignore:
       - 'assets/**'


### PR DESCRIPTION
Part of pimcore/product-management#1311 §2.

**Change:** static analysis trigger `pull_request_target` → `pull_request`.

**Why it's safe (verified):** static analysis needs no secrets —
- shared reusable has no `cache:clear`/kernel-boot step,
- `phpstan.neon` sets no `containerXmlPath` (no compiled container needed),
- `composer.json` has no auto-scripts (composer install boots nothing),
- public repo → deps from public Packagist, no token needed.

**Why it's better:** on `pull_request_target` this checks out fork PR head **with secrets in scope**, which `actions/checkout` now refuses (pwn-request guardrail) — so fork PRs currently fail at "Checkout code". On `pull_request`, fork PRs run safely without secrets and the failure is gone, with **no security gate needed**.

Draft pending review. Replicate to other active maintenance branches per the repo's convention.
