### PR TITLE
Allow disabling auto-create of missing translation keys

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -51,6 +51,8 @@ services:
     tags: [ 'pimcore.studio_backend.settings_provider' ]
 
   Pimcore\Bundle\StudioBackendBundle\Setting\Provider\SystemSettingsProvider:
+    arguments:
+      $autoCreateTranslations: '%pimcore_studio_backend.translations.auto_create_missing_keys%'
     tags: [
       'pimcore.studio_backend.settings_provider',
       'pimcore.studio_backend.update_settings_provider'

--- a/doc/03_Extending/07_Translations.md
+++ b/doc/03_Extending/07_Translations.md
@@ -38,6 +38,36 @@ This keeps the full catalogue private until the user has logged in.
 
 ---
 
+## Auto-Creating Missing Keys
+
+When the Studio frontend renders a translation key that does not yet exist in the `studio`
+catalogue, it reports the key to the backend, which creates an empty entry in the
+`translations_studio` database table. This mirrors the behaviour of the Classic UI and makes
+newly introduced keys immediately visible in the Translations editor.
+
+In setups where translations are provided exclusively through YAML files (for example
+`translations/studio.en.yaml`), this auto-creation is often undesirable: non-translatable
+labels such as numeric values or select-field choices end up polluting the `studio` domain
+with keys that never need a translation.
+
+Auto-creation can be disabled globally:
+
+```yaml
+# config/config.yaml
+pimcore_studio_backend:
+    translations:
+        auto_create_missing_keys: false # default: true
+```
+
+When disabled, missing keys are no longer persisted automatically. Manually adding keys
+through the Translations editor (and importing them) continues to work unchanged.
+
+> **Note:** This setting only affects auto-creation triggered by the Studio frontend. Keys
+> that the backend itself resolves through the Symfony translator may still be created by
+> Pimcore core's write-on-miss behaviour for registered translation domains.
+
+---
+
 ## OpenAPI Documentation Translations
 
 Endpoint descriptions, summaries, and success response texts in OpenAPI attributes are

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -868,6 +868,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('path')->defaultNull()->end()
+                        ->booleanNode('auto_create_missing_keys')->defaultTrue()->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/DependencyInjection/PimcoreStudioBackendExtension.php
+++ b/src/DependencyInjection/PimcoreStudioBackendExtension.php
@@ -215,6 +215,11 @@ class PimcoreStudioBackendExtension extends Extension implements PrependExtensio
         $definition = $container->getDefinition(AdminLanguageServiceInterface::class);
         $definition->setArgument('$translationsPath', $config['translations']['path']);
         $definition->setArgument('$defaultTranslationsPath', '%translator.default_path%');
+
+        $container->setParameter(
+            'pimcore_studio_backend.translations.auto_create_missing_keys',
+            $config['translations']['auto_create_missing_keys']
+        );
     }
 
     /**

--- a/src/Setting/Provider/SystemSettingsProvider.php
+++ b/src/Setting/Provider/SystemSettingsProvider.php
@@ -43,6 +43,7 @@ final readonly class SystemSettingsProvider implements SettingsProviderInterface
         private ServiceResolverInterface $serviceResolver,
         private ElementDataServiceInterface $elementDataService,
         private AdminLanguageServiceInterface $adminLanguageService,
+        private bool $autoCreateTranslations = true,
     ) {
         $this->systemSettings = $systemSettingsConfig->getSystemSettingsConfig();
     }
@@ -65,6 +66,7 @@ final readonly class SystemSettingsProvider implements SettingsProviderInterface
             'availableAdminLanguages' => $this->adminLanguageService->getAvailableAdminLanguages(),
             'validLocales' => $this->toolResolver->getSupportedJSLocales(),
             'debug_admin_translations' => (bool)$this->systemSettings['general']['debug_admin_translations'],
+            'auto_create_translations' => $this->autoCreateTranslations,
             'main_domain' => $this->systemSettings['general']['domain'],
             'upload_max_filesize' => $this->getUploadMaxFilesize(),
             'session_gc_maxlifetime' => $this->getSessionLifeTime(),


### PR DESCRIPTION
## What

Adds a global config flag to disable the automatic creation of missing translation keys for the `studio` translation domain.

```yaml
# config/config.yaml
pimcore_studio_backend:
    translations:
        auto_create_missing_keys: false # default: true
```

The flag is exposed to the Studio frontend via `SystemSettingsProvider` as `auto_create_translations`.

## Why

Resolves [#2730](https://github.com/pimcore/studio-ui-bundle/issues/2730). Projects that maintain the `studio` domain exclusively through YAML files (e.g. `translations/studio.en.yaml`) currently get the `translations_studio` table polluted with hundreds of non-translatable keys (numeric values, select-field choices) that the frontend auto-creates on render. This flag lets them opt out. Default `true` preserves current behaviour.

## Scope / follow-up

This PR is the **backend half**. The flag is currently dormant: the frontend gate that actually stops the auto-create request based on `auto_create_translations` ships **separately in `studio-ui-bundle`** (Path 1 — the i18next `saveMissing` → `translationCreate` flow). Until that lands, behaviour is unchanged.

Manual creation via the Translations editor is unaffected.

> Note: this only covers the frontend-driven auto-creation. Keys the backend itself resolves through the Symfony translator may still be created by Pimcore core's write-on-miss behaviour for registered domains (documented in the Translations doc).

## Docs

Added an "Auto-Creating Missing Keys" section to `doc/03_Extending/07_Translations.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)