### PR TITLE
[Permissions] User can save object and asset data even if not allowed to (PEES-1371)

### DIFF
--- a/src/Patcher/Service/PatchService.php
+++ b/src/Patcher/Service/PatchService.php
@@ -35,11 +35,14 @@ use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Config;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\Jobs;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Util\StepConfig;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\PatchFolderParameter;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Updater\Service\UpdateServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\DataObject\FieldKeys;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\PatchDataKeys;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\PatcherActions;
+use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Element\DuplicateFullPathException;
 use Pimcore\Model\Element\ElementDescriptor;
@@ -62,7 +65,8 @@ final readonly class PatchService implements PatchServiceInterface
         private ElementServiceInterface $elementService,
         private JobExecutionAgentInterface $jobExecutionAgent,
         private ElementIndexServiceInterface $indexService,
-        private ElementSaveServiceInterface $elementSaveService
+        private ElementSaveServiceInterface $elementSaveService,
+        private SecurityServiceInterface $securityService
     ) {
     }
 
@@ -134,7 +138,7 @@ final readonly class PatchService implements PatchServiceInterface
     }
 
     /**
-     * @throws ElementSavingFailedException
+     * @throws ElementSavingFailedException|ForbiddenException
      */
     public function patchElement(
         ElementInterface $element,
@@ -142,6 +146,12 @@ final readonly class PatchService implements PatchServiceInterface
         array $elementPatchData,
         UserInterface $user,
     ): void {
+        if ($element instanceof Concrete) {
+            $this->securityService->hasElementPermission($element, $user, ElementPermissions::SAVE_PERMISSION);
+        } elseif ($element instanceof Asset) {
+            $this->securityService->hasElementPermission($element, $user, ElementPermissions::PUBLISH_PERMISSION);
+        }
+
         try {
             if (isset($elementPatchData[UpdateServiceInterface::EDITABLE_DATA_KEY]) && $element instanceof Concrete) {
                 $this->patchEditableData(

--- a/src/Patcher/Service/PatchService.php
+++ b/src/Patcher/Service/PatchService.php
@@ -146,9 +146,13 @@ final readonly class PatchService implements PatchServiceInterface
         array $elementPatchData,
         UserInterface $user,
     ): void {
-        if ($element instanceof Concrete) {
+        // Writing object field data requires the workspace `save` permission. Publish/unpublish
+        // (PublishAdapter) and the other adapters enforce their own permissions inside the try
+        // below; their ForbiddenException is re-thrown so it is not masked as a 500.
+        if ($element instanceof Concrete && isset($elementPatchData[UpdateServiceInterface::EDITABLE_DATA_KEY])) {
             $this->securityService->hasElementPermission($element, $user, ElementPermissions::SAVE_PERMISSION);
         } elseif ($element instanceof Asset) {
+            // Assets have no workspace `save` permission; `publish` is their edit/write permission.
             $this->securityService->hasElementPermission($element, $user, ElementPermissions::PUBLISH_PERMISSION);
         }
 
@@ -181,6 +185,8 @@ final readonly class PatchService implements PatchServiceInterface
             throw new ElementExistsException(
                 message: sprintf('Element with full path [%s] already exists', $element->getRealFullPath())
             );
+        } catch (ForbiddenException $exception) {
+            throw $exception;
         } catch (Exception $exception) {
             throw new ElementSavingFailedException($element->getId(), $exception->getMessage());
         }

--- a/src/Updater/Service/UpdateService.php
+++ b/src/Updater/Service/UpdateService.php
@@ -23,10 +23,14 @@ use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementSaveServiceInterfa
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementExistsException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementSavingFailedException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\FieldValidationFailedException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Document\DocumentFieldKeys;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementSaveTasks;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
+use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Document;
 use Pimcore\Model\Document\Folder;
@@ -34,6 +38,7 @@ use Pimcore\Model\Document\PageSnippet;
 use Pimcore\Model\Element\DuplicateFullPathException;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\ValidationException;
+use function in_array;
 use function sprintf;
 
 /**
@@ -56,13 +61,21 @@ final readonly class UpdateService implements UpdateServiceInterface
     }
 
     /**
-     * @throws ElementSavingFailedException|FieldValidationFailedException|NotFoundException
+     * @throws ElementSavingFailedException|FieldValidationFailedException|ForbiddenException|NotFoundException
      */
     public function update(string $elementType, int $id, array $data): void
     {
         $user = $this->securityService->getCurrentUser();
         $task = $data[ElementSaveServiceInterface::INDEX_TASK] ?? null;
         $element = $this->getLatestElement($this->getElement($this->serviceResolver, $elementType, $id), $data, $task);
+
+        if ($element instanceof Concrete && $this->requiresSavePermission($task)) {
+            $this->securityService->hasElementPermission($element, $user, ElementPermissions::SAVE_PERMISSION);
+        }
+
+        if ($element instanceof Asset) {
+            $this->securityService->hasElementPermission($element, $user, ElementPermissions::PUBLISH_PERMISSION);
+        }
 
         if (isset($data[self::EDITABLE_DATA_KEY]) && $element instanceof Concrete) {
             $this->objectDataService->updateEditableData($element, $data[self::EDITABLE_DATA_KEY], $user);
@@ -93,6 +106,19 @@ final readonly class UpdateService implements UpdateServiceInterface
         } catch (Exception $e) {
             throw new ElementSavingFailedException($id, $e->getMessage());
         }
+    }
+
+    /**
+     * Persisting object data (save, autoSave, version or an untasked write) requires the workspace
+     * `save` permission. Publishing/unpublishing is gated separately by ElementSaveService.
+     */
+    private function requiresSavePermission(?string $task): bool
+    {
+        return !in_array(
+            $task,
+            [ElementSaveTasks::PUBLISH->value, ElementSaveTasks::UNPUBLISH->value],
+            true
+        );
     }
 
     private function getLatestElement(

--- a/src/Updater/Service/UpdateService.php
+++ b/src/Updater/Service/UpdateService.php
@@ -103,6 +103,10 @@ final readonly class UpdateService implements UpdateServiceInterface
             );
         } catch (ValidationException $e) {
             throw new FieldValidationFailedException($e->getMessage(), previous: $e);
+        } catch (ForbiddenException $e) {
+            // Publish/unpublish permission is checked inside elementSaveService->save();
+            // re-throw so it stays a 403 instead of being masked as a 500 below.
+            throw $e;
         } catch (Exception $e) {
             throw new ElementSavingFailedException($id, $e->getMessage());
         }

--- a/src/Util/Constant/ElementPermissions.php
+++ b/src/Util/Constant/ElementPermissions.php
@@ -22,6 +22,8 @@ final class ElementPermissions
 
     public const string VIEW_PERMISSION = 'view';
 
+    public const string SAVE_PERMISSION = 'save';
+
     public const string  PUBLISH_PERMISSION = 'publish';
 
     public const string UNPUBLISH_PERMISSION = 'unpublish';


### PR DESCRIPTION
## Issue

Tracking: **[PEES-1371](https://github.com/pimcore/service-operations/issues/1010)** — *[Permissions][Studio UI] User can save any object data even if they are not allowed to.*

## Problem

The element update and patch endpoints only enforced the **global menu permission**
(`#[IsGranted(objects/assets)]`). None of them checked the **per-object workspace
permission** on the write path, so a user who could reach the Objects/Assets area but
lacked edit rights on a specific element could still persist changes:

- `PUT /data-objects/{id}` and `PUT /assets/{id}` (normal edit + auto-save)
- `PATCH /data-objects` and `PATCH /assets` (**Batch Edit**, single and multi-element)

Only `publish`/`unpublish` were guarded (in `ElementSaveService`); the `save`, `autoSave`,
`version` and untasked writes reached `$element->save()` with no workspace check. The
multi-element Batch Edit path did not even check `view`. The workspace flags were correctly
computed and sent to the UI, but never enforced server-side.

## Fix

Enforce the workspace permission at the two write choke points, before any data is persisted:

- **`UpdateService::update()`** and **`PatchService::patchElement()`**
- **Data objects (`Concrete`)** → require the **`save`** permission for `save` / `autoSave` /
  `version` / untasked writes. `publish` / `unpublish` remain gated by their existing checks
  in `ElementSaveService`, so a publish-only user can still Save & Publish.
- **Assets** → require the **`publish`** permission (assets have no `save` workspace
  permission; `publish` is their edit/write permission, matching the Studio UI save button).

A denied write now throws `ForbiddenException` (HTTP 403) regardless of the entry point —
editor save, auto-save, or Batch Edit (including the async multi-element job, which is checked
against the initiating user). Object/asset **creation** paths are untouched (they do not go
through these services).

A new `ElementPermissions::SAVE_PERMISSION` constant is added (there was none).

## Scope note

This PR covers **data objects and assets**. Documents share the same `UpdateService` /
`PatchService` code path and have the same gap; they are intentionally left out of this change
and can be addressed as a follow-up.

## Verification

- `php -l` passes on all changed files.
- The full Codeception suite, php-cs-fixer and PHPStan were **not** run locally (dev
  dependencies are not installed in this checkout) — please rely on CI. No regression test is
  included in this PR yet; a unit test asserting `ForbiddenException` on the object/asset
  write paths for a user lacking the permission should follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
