### PR TITLE
[Grid] Add User Modification and User Owner as selectable object system columns

### DIFF
--- a/config/grid.yaml
+++ b/config/grid.yaml
@@ -96,6 +96,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Grid\Column\Definition\System\IntegerDefinition:
     tags: [ 'pimcore.studio_backend.grid_column_definition' ]
 
+  Pimcore\Bundle\StudioBackendBundle\Grid\Column\Definition\System\UserDefinition:
+    tags: [ 'pimcore.studio_backend.grid_column_definition' ]
+
   Pimcore\Bundle\StudioBackendBundle\Grid\Column\Definition\System\IdDefinition:
     tags: [ 'pimcore.studio_backend.grid_column_definition' ]
 
@@ -306,6 +309,9 @@ services:
     tags: [ 'pimcore.studio_backend.grid_column_resolver' ]
 
   Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\System\IntegerResolver:
+    tags: [ 'pimcore.studio_backend.grid_column_resolver' ]
+
+  Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\System\UserResolver:
     tags: [ 'pimcore.studio_backend.grid_column_resolver' ]
 
   Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\System\FileSizeResolver:

--- a/src/Grid/Column/Collector/DataObject/SystemFieldCollector.php
+++ b/src/Grid/Column/Collector/DataObject/SystemFieldCollector.php
@@ -88,7 +88,7 @@ final readonly class SystemFieldCollector implements ColumnCollectorInterface
     {
         return match ($column) {
             'filename', 'index', 'classname',  => false,
-            default => $definition->isSortable(),
+            default => $definition->isFilterable(),
         };
     }
 

--- a/src/Grid/Column/ColumnType.php
+++ b/src/Grid/Column/ColumnType.php
@@ -18,6 +18,7 @@ enum ColumnType: string
     case SYSTEM_STRING = 'system.string';
     case SYSTEM_FILE_SIZE = 'system.fileSize';
     case SYSTEM_INTEGER = 'system.integer';
+    case SYSTEM_USER = 'system.user';
     case SYSTEM_ID = 'system.id';
     case SYSTEM_DATETIME = 'system.datetime';
     case SYSTEM_TIME = 'system.time';

--- a/src/Grid/Column/Definition/System/UserDefinition.php
+++ b/src/Grid/Column/Definition/System/UserDefinition.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Definition\System;
+
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnDefinitionInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\FrontendType;
+
+/**
+ * @internal
+ */
+final readonly class UserDefinition implements ColumnDefinitionInterface
+{
+    public function getType(): string
+    {
+        return ColumnType::SYSTEM_USER->value;
+    }
+
+    public function getConfig(mixed $config): array
+    {
+        return [];
+    }
+
+    public function isSortable(): bool
+    {
+        return true;
+    }
+
+    public function getFrontendType(): string
+    {
+        return FrontendType::INPUT->value;
+    }
+
+    public function isExportable(): bool
+    {
+        return true;
+    }
+
+    public function isFilterable(): bool
+    {
+        return false;
+    }
+}

--- a/src/Grid/Column/Resolver/System/UserResolver.php
+++ b/src/Grid/Column/Resolver/System/UserResolver.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Resolver\System;
+
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\CoreElementColumnResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\ColumnDataTrait;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\SimpleGetterTrait;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Model\Element\ElementInterface;
+
+/**
+ * @internal
+ */
+final class UserResolver implements ColumnResolverInterface, CoreElementColumnResolverInterface
+{
+    use SimpleGetterTrait;
+    use ColumnDataTrait;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function resolveForCoreElement(Column $column, ElementInterface $element): ColumnData
+    {
+        return $this->getColumnData(
+            $column,
+            $this->getValue($column, $element),
+            $this->getType()
+        );
+    }
+
+    public function getType(): string
+    {
+        return 'system.user';
+    }
+
+    public function supportedElementTypes(): array
+    {
+        return [
+            ElementTypes::TYPE_OBJECT,
+        ];
+    }
+}

--- a/src/Grid/Column/Resolver/System/UserResolver.php
+++ b/src/Grid/Column/Resolver/System/UserResolver.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\ColumnDataTrait;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\SimpleGetterTrait;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\Element\ElementInterface;
+
 /**
  * @internal
  */
@@ -31,7 +32,7 @@ final class UserResolver implements ColumnResolverInterface, CoreElementColumnRe
     use ColumnDataTrait;
 
     /**
-     * @throws InvalidArgumentException 
+     * @throws InvalidArgumentException
      */
     public function resolveForCoreElement(Column $column, ElementInterface $element): ColumnData
     {

--- a/src/Grid/Column/Resolver/System/UserResolver.php
+++ b/src/Grid/Column/Resolver/System/UserResolver.php
@@ -22,7 +22,6 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\ColumnDataTrait;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Trait\SimpleGetterTrait;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\Element\ElementInterface;
-
 /**
  * @internal
  */
@@ -32,7 +31,7 @@ final class UserResolver implements ColumnResolverInterface, CoreElementColumnRe
     use ColumnDataTrait;
 
     /**
-     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException 
      */
     public function resolveForCoreElement(Column $column, ElementInterface $element): ColumnData
     {

--- a/src/Grid/Mapper/ColumnMapper.php
+++ b/src/Grid/Mapper/ColumnMapper.php
@@ -36,6 +36,8 @@ final readonly class ColumnMapper implements ColumnMapperInterface
         'classname' => 'string',
         'index' => 'integer',
         'mimetype' => 'string',
+        'userModification' => 'user',
+        'userOwner' => 'user',
     ];
 
     public function getType(string $column): string

--- a/src/Grid/Service/SystemColumnService.php
+++ b/src/Grid/Service/SystemColumnService.php
@@ -50,6 +50,8 @@ final readonly class SystemColumnService implements SystemColumnServiceInterface
 
         // Add missing columns
         $columns['type'] = 'string';
+        $columns['userModification'] = 'user';
+        $columns['userOwner'] = 'user';
 
         return $columns;
     }

--- a/tests/Unit/Grid/Column/Definition/System/UserDefinitionTest.php
+++ b/tests/Unit/Grid/Column/Definition/System/UserDefinitionTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Column\Definition\System;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\Definition\System\UserDefinition;
+
+/**
+ * @internal
+ */
+final class UserDefinitionTest extends Unit
+{
+    private UserDefinition $definition;
+
+    protected function setUp(): void
+    {
+        $this->definition = new UserDefinition();
+    }
+
+    public function testGetType(): void
+    {
+        $this->assertSame('system.user', $this->definition->getType());
+    }
+
+    public function testGetFrontendType(): void
+    {
+        $this->assertSame('input', $this->definition->getFrontendType());
+    }
+
+    public function testIsSortable(): void
+    {
+        $this->assertTrue($this->definition->isSortable());
+    }
+
+    public function testIsNotFilterable(): void
+    {
+        $this->assertFalse($this->definition->isFilterable());
+    }
+
+    public function testIsExportable(): void
+    {
+        $this->assertTrue($this->definition->isExportable());
+    }
+
+    public function testGetConfigReturnsEmptyArray(): void
+    {
+        $this->assertSame([], $this->definition->getConfig('anything'));
+    }
+}

--- a/tests/Unit/Grid/Mapper/ColumnMapperTest.php
+++ b/tests/Unit/Grid/Mapper/ColumnMapperTest.php
@@ -102,4 +102,16 @@ final class ColumnMapperTest extends Unit
         $mapper = new ColumnMapper();
         $this->assertSame('integer', $mapper->getType('index'));
     }
+
+    public function testMapperForUserModification(): void
+    {
+        $mapper = new ColumnMapper();
+        $this->assertSame('user', $mapper->getType('userModification'));
+    }
+
+    public function testMapperForUserOwner(): void
+    {
+        $mapper = new ColumnMapper();
+        $this->assertSame('user', $mapper->getType('userOwner'));
+    }
 }

--- a/tests/Unit/Grid/Service/SystemColumnServiceTest.php
+++ b/tests/Unit/Grid/Service/SystemColumnServiceTest.php
@@ -56,6 +56,8 @@ final class SystemColumnServiceTest extends Unit
             'classname' => 'string',
             'index' => 'integer',
             'type' => 'string',
+            'userModification' => 'user',
+            'userOwner' => 'user',
         ], $systemColumnService->getSystemColumnsForDataObjects());
     }
 }


### PR DESCRIPTION
## What
Exposes **User Modification** and **User Owner** as selectable system columns for data objects in the Studio grid.

Companion to the frontend PR: pimcore/studio-ui-bundle#1956 (studio-ui-bundle change).

## How
- New `system.user` column type (`ColumnType::SYSTEM_USER`) with a `UserDefinition` + `UserResolver` under `Grid/Column/*/System/`, registered in `config/grid.yaml`.
- The resolver reuses `SimpleGetterTrait`, so it resolves `getUserModification()` / `getUserOwner()` automatically and returns the raw user id.
- `SystemColumnService::getSystemColumnsForDataObjects()` now offers `userModification` and `userOwner`; `ColumnMapper` maps both to `user`.
- The Studio UI resolves the id → username for display.

## Notes
- Column is `sortable` (by user id, since the index stores the id) and `filterable: false`.
- Requires the matching studio-ui-bundle PR to render the username cell.

## Tests
- Updated `ColumnMapperTest` and `SystemColumnServiceTest`; both pass. PHPStan clean.

#1956

Refs pimcore/studio-ui-bundle#1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)