### PR TITLE
[Asset List] Add file size field filter (#705)

### DIFF
--- a/config/data_index_filters.yaml
+++ b/config/data_index_filters.yaml
@@ -71,6 +71,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\NumberFilter:
     tags: [ 'pimcore.studio_backend.search_index.filter' ]
 
+  Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\FileSizeFilter:
+    tags: [ 'pimcore.studio_backend.search_index.filter' ]
+
   Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\SelectFilter:
     tags: [ 'pimcore.studio_backend.search_index.filter' ]
 

--- a/src/DataIndex/Filter/FileSizeFilter.php
+++ b/src/DataIndex/Filter/FileSizeFilter.php
@@ -79,8 +79,12 @@ final class FileSizeFilter implements FilterInterface
             return $query->filterNumberRange($field, $toBytes($filterValue['from']), null);
         }
 
-        if ($setting === 'between' && isset($filterValue['from'], $filterValue['to'])) {
-            return $query->filterNumberRange($field, $toBytes($filterValue['from']), $toBytes($filterValue['to']));
+        if ($setting === 'between' && (isset($filterValue['from']) || isset($filterValue['to']))) {
+            return $query->filterNumberRange(
+                $field,
+                isset($filterValue['from']) ? $toBytes($filterValue['from']) : null,
+                isset($filterValue['to']) ? $toBytes($filterValue['to']) : null
+            );
         }
 
         throw new InvalidArgumentException('Unable to apply file size filter, no correct setting given');

--- a/src/DataIndex/Filter/FileSizeFilter.php
+++ b/src/DataIndex/Filter/FileSizeFilter.php
@@ -67,8 +67,10 @@ final class FileSizeFilter implements FilterInterface
             $lower = $toBytes($filterValue['is']);
 
             // One-unit-wide band, so "is 1 MB" matches everything that reads as 1-point-something MB
-            // (the byte-precise value would practically never match on its own).
-            return $query->filterNumberRange($field, $lower, $lower + $multiplier - 1);
+            // (the byte-precise value would practically never match on its own). filterNumberRange
+            // bounds are exclusive (gt/lt), so widen by one byte on each side to make the band
+            // [lower, lower + unit - 1] inclusive.
+            return $query->filterNumberRange($field, $lower - 1, $lower + $multiplier);
         }
 
         if ($setting === 'less' && isset($filterValue['to'])) {

--- a/src/DataIndex/Filter/FileSizeFilter.php
+++ b/src/DataIndex/Filter/FileSizeFilter.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter;
+
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFilter;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFiltersParameterInterface;
+use function is_array;
+
+/**
+ * Filters the asset file size (stored in bytes). The client sends a value plus a size unit
+ * (KB/MB/GB); this handler converts the value to bytes and applies it as a numeric range, mirroring
+ * how the datetime filter rounds a coarse "on" day to a full-day range. Because the user works at a
+ * coarser precision than the stored bytes, the "is" setting matches a one-unit-wide band rather than
+ * an exact byte value.
+ *
+ * @internal
+ */
+final class FileSizeFilter implements FilterInterface
+{
+    private const BYTE_MULTIPLIER = [
+        'KB' => 1024,
+        'MB' => 1024 * 1024,
+        'GB' => 1024 * 1024 * 1024,
+    ];
+
+    public function apply(mixed $parameters, QueryInterface $query): QueryInterface
+    {
+        if (!$parameters instanceof ColumnFiltersParameterInterface) {
+            return $query;
+        }
+
+        foreach ($parameters->getColumnFilterByType(ColumnType::SYSTEM_FILE_SIZE->value) as $column) {
+            $query = $this->applyFileSizeFilter($column, $query);
+        }
+
+        return $query;
+    }
+
+    private function applyFileSizeFilter(ColumnFilter $column, QueryInterface $query): QueryInterface
+    {
+        $filterValue = $column->getFilterValue();
+
+        if (!is_array($filterValue) || !isset($filterValue['setting'])) {
+            throw new InvalidArgumentException('This filter requires a setting value');
+        }
+
+        $multiplier = $this->getMultiplier($filterValue['unit'] ?? null);
+        $field = $column->getKey();
+        $setting = $filterValue['setting'];
+        $toBytes = static fn (int|float $value): int => (int) round($value * $multiplier);
+
+        if ($setting === 'is' && isset($filterValue['is'])) {
+            $lower = $toBytes($filterValue['is']);
+
+            // One-unit-wide band, so "is 1 MB" matches everything that reads as 1-point-something MB
+            // (the byte-precise value would practically never match on its own).
+            return $query->filterNumberRange($field, $lower, $lower + $multiplier - 1);
+        }
+
+        if ($setting === 'less' && isset($filterValue['to'])) {
+            return $query->filterNumberRange($field, null, $toBytes($filterValue['to']));
+        }
+
+        if ($setting === 'more' && isset($filterValue['from'])) {
+            return $query->filterNumberRange($field, $toBytes($filterValue['from']), null);
+        }
+
+        if ($setting === 'between' && isset($filterValue['from'], $filterValue['to'])) {
+            return $query->filterNumberRange($field, $toBytes($filterValue['from']), $toBytes($filterValue['to']));
+        }
+
+        throw new InvalidArgumentException('Unable to apply file size filter, no correct setting given');
+    }
+
+    private function getMultiplier(mixed $unit): int
+    {
+        if (!is_string($unit) || !isset(self::BYTE_MULTIPLIER[$unit])) {
+            throw new InvalidArgumentException('File size filter requires a valid unit (KB, MB or GB)');
+        }
+
+        return self::BYTE_MULTIPLIER[$unit];
+    }
+}

--- a/src/Grid/Column/Definition/System/FileSizeDefinition.php
+++ b/src/Grid/Column/Definition/System/FileSizeDefinition.php
@@ -48,6 +48,6 @@ final readonly class FileSizeDefinition implements ColumnDefinitionInterface
 
     public function isFilterable(): bool
     {
-        return false;
+        return true;
     }
 }

--- a/tests/Unit/DataIndex/Filter/FileSizeFilterTest.php
+++ b/tests/Unit/DataIndex/Filter/FileSizeFilterTest.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataIndex\Filter;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\FileSizeFilter;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\AssetQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+
+/**
+ * @internal
+ */
+final class FileSizeFilterTest extends Unit
+{
+    use ColumnFilterMockTrait;
+
+    private const KB = 1024;
+
+    private const MB = 1024 * 1024;
+
+    private const GB = 1024 * 1024 * 1024;
+
+    public function testThrowsWhenFilterValueIsNotAnArray(): void
+    {
+        $filter = new FileSizeFilter();
+        $parameters = $this->getColumnFilterMock('fileSize', 'system.fileSize', 123);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This filter requires a setting value');
+        $filter->apply($parameters, $this->makeEmpty(AssetQueryInterface::class));
+    }
+
+    public function testThrowsWhenUnitIsMissing(): void
+    {
+        $filter = new FileSizeFilter();
+        $parameters = $this->getColumnFilterMock('fileSize', 'system.fileSize', ['setting' => 'is', 'is' => 1]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('File size filter requires a valid unit (KB, MB or GB)');
+        $filter->apply($parameters, $this->makeEmpty(AssetQueryInterface::class));
+    }
+
+    public function testThrowsWhenUnitIsInvalid(): void
+    {
+        $filter = new FileSizeFilter();
+        $parameters = $this->getColumnFilterMock(
+            'fileSize',
+            'system.fileSize',
+            ['setting' => 'is', 'is' => 1, 'unit' => 'TB']
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('File size filter requires a valid unit (KB, MB or GB)');
+        $filter->apply($parameters, $this->makeEmpty(AssetQueryInterface::class));
+    }
+
+    public function testIsProducesAnInclusiveOneUnitBand(): void
+    {
+        $filter = new FileSizeFilter();
+        $queryMock = $this->makeEmpty(AssetQueryInterface::class, [
+            'filterNumberRange' => Expected::once(function ($field, $min, $max) {
+                $this->assertSame('fileSize', $field);
+                // Exclusive gt/lt widened by one byte -> inclusive [1 MB, 2 MB - 1].
+                $this->assertSame(self::MB - 1, $min);
+                $this->assertSame(self::MB + self::MB, $max);
+
+                return $this->makeEmpty(AssetQueryInterface::class);
+            }),
+        ]);
+
+        $parameters = $this->getColumnFilterMock(
+            'fileSize',
+            'system.fileSize',
+            ['setting' => 'is', 'is' => 1, 'unit' => 'MB']
+        );
+
+        $filter->apply($parameters, $queryMock);
+    }
+
+    public function testLessConvertsKilobytesToBytes(): void
+    {
+        $filter = new FileSizeFilter();
+        $queryMock = $this->makeEmpty(AssetQueryInterface::class, [
+            'filterNumberRange' => Expected::once(function ($field, $min, $max) {
+                $this->assertSame('fileSize', $field);
+                $this->assertNull($min);
+                $this->assertSame(500 * self::KB, $max);
+
+                return $this->makeEmpty(AssetQueryInterface::class);
+            }),
+        ]);
+
+        $parameters = $this->getColumnFilterMock(
+            'fileSize',
+            'system.fileSize',
+            ['setting' => 'less', 'to' => 500, 'unit' => 'KB']
+        );
+
+        $filter->apply($parameters, $queryMock);
+    }
+
+    public function testMoreConvertsGigabytesToBytes(): void
+    {
+        $filter = new FileSizeFilter();
+        $queryMock = $this->makeEmpty(AssetQueryInterface::class, [
+            'filterNumberRange' => Expected::once(function ($field, $min, $max) {
+                $this->assertSame('fileSize', $field);
+                $this->assertSame(2 * self::GB, $min);
+                $this->assertNull($max);
+
+                return $this->makeEmpty(AssetQueryInterface::class);
+            }),
+        ]);
+
+        $parameters = $this->getColumnFilterMock(
+            'fileSize',
+            'system.fileSize',
+            ['setting' => 'more', 'from' => 2, 'unit' => 'GB']
+        );
+
+        $filter->apply($parameters, $queryMock);
+    }
+
+    public function testBetweenConvertsBothBounds(): void
+    {
+        $filter = new FileSizeFilter();
+        $queryMock = $this->makeEmpty(AssetQueryInterface::class, [
+            'filterNumberRange' => Expected::once(function ($field, $min, $max) {
+                $this->assertSame('fileSize', $field);
+                $this->assertSame(self::MB, $min);
+                $this->assertSame(2 * self::MB, $max);
+
+                return $this->makeEmpty(AssetQueryInterface::class);
+            }),
+        ]);
+
+        $parameters = $this->getColumnFilterMock(
+            'fileSize',
+            'system.fileSize',
+            ['setting' => 'between', 'from' => 1, 'to' => 2, 'unit' => 'MB']
+        );
+
+        $filter->apply($parameters, $queryMock);
+    }
+
+    public function testBetweenToleratesASingleBound(): void
+    {
+        $filter = new FileSizeFilter();
+        $queryMock = $this->makeEmpty(AssetQueryInterface::class, [
+            'filterNumberRange' => Expected::once(function ($field, $min, $max) {
+                $this->assertSame('fileSize', $field);
+                $this->assertSame(self::MB, $min);
+                $this->assertNull($max);
+
+                return $this->makeEmpty(AssetQueryInterface::class);
+            }),
+        ]);
+
+        $parameters = $this->getColumnFilterMock(
+            'fileSize',
+            'system.fileSize',
+            ['setting' => 'between', 'from' => 1, 'unit' => 'MB']
+        );
+
+        $filter->apply($parameters, $queryMock);
+    }
+
+    public function testThrowsWhenSettingHasNoUsableValue(): void
+    {
+        $filter = new FileSizeFilter();
+        $parameters = $this->getColumnFilterMock(
+            'fileSize',
+            'system.fileSize',
+            ['setting' => 'is', 'unit' => 'MB']
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to apply file size filter, no correct setting given');
+        $filter->apply($parameters, $this->makeEmpty(AssetQueryInterface::class));
+    }
+}


### PR DESCRIPTION
Part of pimcore/studio-ui-bundle#705

Backend support for the Asset List **Size** filter.

### Changes
- `FileSizeDefinition::isFilterable()` → `true`.
- New `FileSizeFilter` search-index handler (registered/tagged in `data_index_filters.yaml`): reads the client value + unit (KB/MB/GB), converts to bytes, and applies a numeric range on the `fileSize` field.
- `is` matches a one-unit-wide band (mirroring the datetime `roundToDay` behaviour) since file size is stored byte-precise.

Follows the quantity-value filter convention (dedicated tagged handler reusing the numeric range primitives).

⚠️ Pairs with the studio-ui-bundle frontend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)