### PR TITLE
[Object List] Make user columns filterable + add user field filter

### DIFF
--- a/config/data_index_filters.yaml
+++ b/config/data_index_filters.yaml
@@ -74,6 +74,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\SelectFilter:
     tags: [ 'pimcore.studio_backend.search_index.filter' ]
 
+  Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\SystemUserFilter:
+    tags: [ 'pimcore.studio_backend.search_index.filter' ]
+
   Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\BooleanFilter:
     tags: [ 'pimcore.studio_backend.search_index.filter' ]
 

--- a/src/DataIndex/Filter/SystemUserFilter.php
+++ b/src/DataIndex/Filter/SystemUserFilter.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter;
+
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFilter;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFiltersParameterInterface;
+use function is_array;
+
+/**
+ * Filters the "user" system columns (userModification / userOwner) by user id. The client sends the
+ * selected user ids as an array; the column key equals the index field, so the ids are matched
+ * directly against it. Named SystemUserFilter to avoid a clash with the unrelated UserFilter, which
+ * sets the permission/context user on the query.
+ *
+ * @internal
+ */
+final class SystemUserFilter implements FilterInterface
+{
+    public function apply(mixed $parameters, QueryInterface $query): QueryInterface
+    {
+        if (!$parameters instanceof ColumnFiltersParameterInterface) {
+            return $query;
+        }
+
+        foreach ($parameters->getColumnFilterByType(ColumnType::SYSTEM_USER->value) as $column) {
+            $query = $this->applyUserFilter($column, $query);
+        }
+
+        return $query;
+    }
+
+    private function applyUserFilter(ColumnFilter $column, QueryInterface $query): QueryInterface
+    {
+        $filterValue = $column->getFilterValue();
+
+        if (!is_array($filterValue)) {
+            throw new InvalidArgumentException('Value for user filter must be an array');
+        }
+
+        return $query->filterMultiSelect($column->getKey(), $filterValue);
+    }
+}

--- a/src/Grid/Column/Definition/System/UserDefinition.php
+++ b/src/Grid/Column/Definition/System/UserDefinition.php
@@ -49,6 +49,6 @@ final readonly class UserDefinition implements ColumnDefinitionInterface
 
     public function isFilterable(): bool
     {
-        return false;
+        return true;
     }
 }

--- a/tests/Unit/DataIndex/Filter/SystemUserFilterTest.php
+++ b/tests/Unit/DataIndex/Filter/SystemUserFilterTest.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataIndex\Filter;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\SystemUserFilter;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnType;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFilter;
+use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFiltersParameterInterface;
+
+/**
+ * @internal
+ */
+final class SystemUserFilterTest extends Unit
+{
+    use ColumnFilterMockTrait;
+
+    public function testQueryIsReturnedUntouchedWhenParametersAreNotColumnFilters(): void
+    {
+        $query = $this->makeEmpty(QueryInterface::class, [
+            'filterMultiSelect' => Expected::never(),
+        ]);
+
+        $filter = new SystemUserFilter();
+
+        $this->assertSame($query, $filter->apply('invalid', $query));
+    }
+
+    public function testUserIdsAreDelegatedToFilterMultiSelect(): void
+    {
+        $parameter = $this->getColumnFilterMock(
+            'userModification',
+            ColumnType::SYSTEM_USER->value,
+            [2, 5]
+        );
+
+        $filteredQuery = $this->makeEmpty(QueryInterface::class);
+        $query = $this->makeEmpty(QueryInterface::class, [
+            'filterMultiSelect' => Expected::once(
+                function ($fieldKey, $userIds) use ($filteredQuery) {
+                    $this->assertSame('userModification', $fieldKey);
+                    $this->assertSame([2, 5], $userIds);
+
+                    return $filteredQuery;
+                }
+            ),
+        ]);
+
+        $filter = new SystemUserFilter();
+
+        $this->assertSame($filteredQuery, $filter->apply($parameter, $query));
+    }
+
+    public function testEveryUserColumnFilterIsApplied(): void
+    {
+        $parameter = $this->makeEmpty(ColumnFiltersParameterInterface::class, [
+            'getColumnFilterByType' => function () {
+                return [
+                    new ColumnFilter('userOwner', ColumnType::SYSTEM_USER->value, [2]),
+                    new ColumnFilter('userModification', ColumnType::SYSTEM_USER->value, [5, 7]),
+                ];
+            },
+        ]);
+
+        $appliedFilters = [];
+        $query = $this->makeEmpty(QueryInterface::class, [
+            'filterMultiSelect' => Expected::exactly(
+                2,
+                function ($fieldKey, $userIds) use (&$appliedFilters, &$query) {
+                    $appliedFilters[$fieldKey] = $userIds;
+
+                    return $query;
+                }
+            ),
+        ]);
+
+        $filter = new SystemUserFilter();
+        $filter->apply($parameter, $query);
+
+        $this->assertSame(
+            ['userOwner' => [2], 'userModification' => [5, 7]],
+            $appliedFilters
+        );
+    }
+
+    public function testExceptionIsThrownWhenFilterValueIsNotAnArray(): void
+    {
+        $parameter = $this->getColumnFilterMock(
+            'userModification',
+            ColumnType::SYSTEM_USER->value,
+            2
+        );
+
+        $query = $this->makeEmpty(QueryInterface::class, [
+            'filterMultiSelect' => Expected::never(),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value for user filter must be an array');
+
+        $filter = new SystemUserFilter();
+        $filter->apply($parameter, $query);
+    }
+}

--- a/tests/Unit/Grid/Column/Definition/System/UserDefinitionTest.php
+++ b/tests/Unit/Grid/Column/Definition/System/UserDefinitionTest.php
@@ -43,9 +43,9 @@ final class UserDefinitionTest extends Unit
         $this->assertTrue($this->definition->isSortable());
     }
 
-    public function testIsNotFilterable(): void
+    public function testIsFilterable(): void
     {
-        $this->assertFalse($this->definition->isFilterable());
+        $this->assertTrue($this->definition->isFilterable());
     }
 
     public function testIsExportable(): void


### PR DESCRIPTION
Backend support for the data-object **User** field filter (`userModification` / `userOwner`).

### Changes
- `UserDefinition::isFilterable()` → `true` (enables both user columns — they share the definition).
- New `SystemUserFilter` search-index handler: matches selected user ids against the user column via `filterMultiSelect` (mirrors `SelectFilter`). Named to avoid a clash with the unrelated permission-context `UserFilter`.
- Registered as a tagged `pimcore.studio_backend.search_index.filter`.

⚠️ Pairs with the studio-ui-bundle frontend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)