### PR TITLE
Fix: stale Perspective no longer restricts Superadmin

### DIFF
--- a/src/User/Service/UserPerspectiveService.php
+++ b/src/User/Service/UserPerspectiveService.php
@@ -79,6 +79,10 @@ final readonly class UserPerspectiveService implements UserPerspectiveServiceInt
 
     public function getActivePerspective(UserInterface $user): string
     {
+        if ($user->isAdmin()) {
+            return Perspectives::DEFAULT_ID->value;
+        }
+
         $activePerspective = $this->repository->getUserActivePerspective($user->getId());
         $userPerspectives = $this->getAllUserPerspectives($user);
         if (empty($userPerspectives)) {

--- a/src/User/Service/UserPerspectiveService.php
+++ b/src/User/Service/UserPerspectiveService.php
@@ -139,6 +139,10 @@ final readonly class UserPerspectiveService implements UserPerspectiveServiceInt
 
     private function getAllUserPerspectives(UserInterface|UserRoleInterface $user): array
     {
+        if ($user instanceof UserInterface && $user->isAdmin()) {
+            return [];
+        }
+
         $userPerspectives = $this->repository->listUserPerspectives($user->getId());
         if (!$user instanceof UserInterface) {
             return $userPerspectives;

--- a/tests/Unit/User/Service/UserPerspectiveServiceTest.php
+++ b/tests/Unit/User/Service/UserPerspectiveServiceTest.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\User\Service;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Repository\PerspectiveConfigRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Service\PerspectiveServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
+use Pimcore\Bundle\StudioBackendBundle\User\Repository\PerspectiveRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveService;
+use Pimcore\Model\UserInterface;
+
+/**
+ * Regression coverage for PEES-1390 / GitHub pimcore/platform-version#253:
+ * a Superadmin who still has a stale, non-empty perspective assignment stored on their
+ * user record must not be restricted by it, since Superadmins bypass all permission checks.
+ *
+ * @internal
+ */
+final class UserPerspectiveServiceTest extends Unit
+{
+    public function testSuperadminGetsFullAllowedPerspectivesDespiteStaleAssignment(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+        ]);
+
+        // Stale data: the repository still reports one restrictive perspective for this user,
+        // as if it had been assigned before the promotion to Superadmin.
+        $service = $this->createService(listUserPerspectives: ['stale-perspective']);
+
+        $result = $service->getAllowedPerspectives($user);
+
+        $this->assertCount(2, $result);
+    }
+
+    public function testNonAdminGetsOnlyAssignedAllowedPerspectives(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => false,
+            'getRoles' => [],
+        ]);
+
+        $service = $this->createService(listUserPerspectives: ['my-perspective']);
+
+        $result = $service->getAllowedPerspectives($user);
+
+        $this->assertCount(1, $result);
+    }
+
+    public function testSuperadminGetsDefaultActivePerspectiveDespiteStaleAssignment(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+        ]);
+
+        $service = $this->createService(
+            listUserPerspectives: ['stale-perspective'],
+            getUserActivePerspective: 'stale-perspective',
+        );
+
+        $result = $service->getActivePerspective($user);
+
+        $this->assertSame(Perspectives::DEFAULT_ID->value, $result);
+    }
+
+    public function testValidatePerspectiveAccessAllowsSuperadminForAnyPerspective(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+        ]);
+
+        $service = $this->createService(listUserPerspectives: ['stale-perspective']);
+
+        $service->validatePerspectiveAccess($user, 'some-other-perspective');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidatePerspectiveAccessStillThrowsForNonAdminOutsideAssignedList(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => false,
+            'getRoles' => [],
+        ]);
+
+        $service = $this->createService(listUserPerspectives: ['my-perspective']);
+
+        $this->expectException(ForbiddenException::class);
+        $service->validatePerspectiveAccess($user, 'some-other-perspective');
+    }
+
+    private function createService(
+        array $listUserPerspectives = [],
+        ?string $getUserActivePerspective = null,
+    ): UserPerspectiveService {
+        $repository = $this->makeEmpty(PerspectiveRepositoryInterface::class, [
+            'listUserPerspectives' => $listUserPerspectives,
+            'getUserActivePerspective' => $getUserActivePerspective,
+        ]);
+
+        $configRepository = $this->makeEmpty(PerspectiveConfigRepositoryInterface::class, [
+            'getConfiguration' => [],
+        ]);
+
+        $defaultPerspective = $this->makeEmpty(PerspectiveConfig::class, [
+            'getId' => Perspectives::DEFAULT_ID->value,
+        ]);
+        $otherPerspective = $this->makeEmpty(PerspectiveConfig::class, [
+            'getId' => 'other-perspective',
+        ]);
+
+        $perspectiveService = $this->makeEmpty(PerspectiveServiceInterface::class, [
+            'hydrateListEntry' => $defaultPerspective,
+            'listConfigurations' => [$otherPerspective],
+        ]);
+
+        return new UserPerspectiveService($repository, $configRepository, $perspectiveService);
+    }
+}

--- a/tests/Unit/User/Service/UserPerspectiveServiceTest.php
+++ b/tests/Unit/User/Service/UserPerspectiveServiceTest.php
@@ -89,7 +89,9 @@ final class UserPerspectiveServiceTest extends Unit
 
         $service = $this->createService(listUserPerspectives: ['stale-perspective']);
 
-        $service->validatePerspectiveAccess($user, 'some-other-perspective');
+        // 'other-perspective' is one of the two IDs createService() wires up as the full,
+        // unrestricted set - i.e. a perspective outside the stale assignment.
+        $service->validatePerspectiveAccess($user, 'other-perspective');
         $this->addToAssertionCount(1);
     }
 

--- a/tests/Unit/User/Service/UserPerspectiveServiceTest.php
+++ b/tests/Unit/User/Service/UserPerspectiveServiceTest.php
@@ -70,9 +70,13 @@ final class UserPerspectiveServiceTest extends Unit
             'isAdmin' => true,
         ]);
 
+        // Uses a real, still-configured perspective ID (one of the two in the mocked full set),
+        // not a fake one - otherwise this test would pass even without the isAdmin() bypass in
+        // getActivePerspective(), since a nonexistent stale ID can never match the full set either
+        // way and the bug would go unnoticed.
         $service = $this->createService(
-            listUserPerspectives: ['stale-perspective'],
-            getUserActivePerspective: 'stale-perspective',
+            listUserPerspectives: ['other-perspective'],
+            getUserActivePerspective: 'other-perspective',
         );
 
         $result = $service->getActivePerspective($user);


### PR DESCRIPTION
## Summary
- A Superadmin who still has a non-empty stored Perspective assignment (e.g. from before being
  promoted) was still being restricted by it: `getActivePerspective()`, `getAllowedPerspectives()`,
  and `validatePerspectiveAccess()` in `UserPerspectiveService` all fall back to "unrestricted"
  only when the user's stored perspective list is empty, and never checked `isAdmin()`.
- `validatePerspectiveAccess()` is also called from `UserPerspectiveVoter`, so this could throw a
  403 `ForbiddenException` if a Superadmin with a stale restrictive assignment tried to switch to
  a perspective outside it via `PUT /user/active-perspective/{perspectiveId}`.
- Fix: the shared private helper `getAllUserPerspectives()` now returns an empty list immediately
  for admins, which the existing "empty means unrestricted" fallback in all three call sites
  already handles.
- Companion fix in `studio-ui-bundle` (same branch name) unhides the Perspectives field for admins
  in the Studio user-edit UI, so a stale assignment can also be viewed/cleared through the UI.

Refs PEES-1390, pimcore/platform-version#253

## Test plan
- [ ] Added `tests/Unit/User/Service/UserPerspectiveServiceTest.php` covering: Superadmin gets the
      full allowed-perspectives set and the default active perspective despite a stale stored
      assignment, `validatePerspectiveAccess` no longer throws for a Superadmin, and non-admin
      behavior is unchanged (regression guard). **Not yet run in CI/locally by me** — please run
      the suite before merge.
- [x] Manual repro: assign a restrictive Perspective to a user, promote them to Superadmin,
      confirm they now get the full Studio UI (trees/menus) instead of the stale restricted view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)