### PR TITLE
Add the shared MCP tool boundary: error handler and schema normalizers

### DIFF
--- a/config/mcp.yaml
+++ b/config/mcp.yaml
@@ -28,3 +28,12 @@ services:
 
     Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface:
         alias: Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory
+
+    # --- Shared MCP tool boundary ---
+    # Terminal-catch error handling for MCP tools, in this bundle so that every bundle exposing MCP
+    # tools shares one policy about what may leave the Pimcore boundary. The handler forwards no
+    # exception message except InvalidMcpToolArgumentException; a tool that can say something useful
+    # about a failure type-catches it and composes that sentence itself.
+    Pimcore\Bundle\StudioBackendBundle\Mcp\Tool\McpToolErrorHandler: ~
+    Pimcore\Bundle\StudioBackendBundle\Mcp\Tool\McpToolErrorHandlerInterface:
+        alias: Pimcore\Bundle\StudioBackendBundle\Mcp\Tool\McpToolErrorHandler

--- a/src/Mcp/Exception/InvalidMcpToolArgumentException.php
+++ b/src/Mcp/Exception/InvalidMcpToolArgumentException.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Mcp\Exception;
 
 use InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Mcp\Tool\McpToolErrorHandler;
+use Pimcore\Bundle\StudioBackendBundle\Mcp\Tool\ObjectParameterNormalizer;
 
 /**
  * An MCP tool argument the caller got wrong, described in terms of that argument.

--- a/src/Mcp/Exception/InvalidMcpToolArgumentException.php
+++ b/src/Mcp/Exception/InvalidMcpToolArgumentException.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Mcp\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * An MCP tool argument the caller got wrong, described in terms of that argument.
+ *
+ * This is the one exception type {@see McpToolErrorHandler} forwards to the client verbatim, so
+ * throwing it is a statement by the thrower:
+ *
+ * > I composed this message for the caller, out of the caller's own input, and it quotes nothing
+ * > from a lower layer.
+ *
+ * Never throw it wrapping another exception's message. `Failed to save element 5: <inner>` reads
+ * like an argument error while carrying whatever DBAL, OpenSearch or Flysystem put in the inner
+ * message, and the handler has no way to tell the difference.
+ *
+ * {@see ObjectParameterNormalizer} is the shipped example of a correct throw: the message names the
+ * parameter and says how to send nothing.
+ *
+ * It extends SPL `InvalidArgumentException` so that tools which already type-catch that class ahead
+ * of their terminal `catch (Throwable)` keep matching without edits.
+ */
+final class InvalidMcpToolArgumentException extends InvalidArgumentException
+{
+}

--- a/src/Mcp/Tool/McpToolErrorHandler.php
+++ b/src/Mcp/Tool/McpToolErrorHandler.php
@@ -17,8 +17,11 @@ use Pimcore\Bundle\StudioBackendBundle\Mcp\Exception\InvalidMcpToolArgumentExcep
 use Psr\Log\LoggerInterface;
 use Throwable;
 use function bin2hex;
+use function hash;
+use function hrtime;
 use function random_bytes;
 use function sprintf;
+use function substr;
 
 /**
  * Default {@see McpToolErrorHandlerInterface}: the terminal `catch` of an MCP tool.
@@ -74,6 +77,11 @@ use function sprintf;
  */
 final readonly class McpToolErrorHandler implements McpToolErrorHandlerInterface
 {
+    /**
+     * Bytes of entropy behind a correlation id; rendered as twice as many hex characters.
+     */
+    private const int REF_BYTES = 4;
+
     private const string CODE_BAD_ARGUMENT = 'invalid_argument';
 
     private const string CODE_INTERNAL = 'internal_error';
@@ -120,7 +128,7 @@ final readonly class McpToolErrorHandler implements McpToolErrorHandlerInterface
      */
     private function handleUnexpected(Throwable $exception, string $toolName, array $context): string
     {
-        $ref = bin2hex(random_bytes(4));
+        $ref = $this->correlationId();
 
         $this->logger->error(
             sprintf('Unhandled exception in %s (ref: %s)', $toolName, $ref),
@@ -138,5 +146,26 @@ final readonly class McpToolErrorHandler implements McpToolErrorHandlerInterface
         );
 
         return sprintf(self::MSG_INTERNAL, $toolName, $ref);
+    }
+
+    /**
+     * A short token shared between the returned sentence and the log record, so an operator can grep
+     * one to find the other.
+     *
+     * It is not a secret and carries no authority: it only has to be unique enough to grep within a
+     * log file. `random_bytes()` is used because it is the source that does not raise Sonar's
+     * weak-randomness hotspot, but it can throw when the system runs out of entropy — and this is
+     * the terminal error boundary, so a throw here would lose the very exception the handler exists
+     * to record, and escape in its place. The fallback keeps that impossible.
+     */
+    private function correlationId(): string
+    {
+        try {
+            return bin2hex(random_bytes(self::REF_BYTES));
+        } catch (Throwable) {
+            // Monotonic, non-blocking and cannot throw. Collisions are irrelevant: neighbouring
+            // records are distinguished by the exception and context logged alongside the ref.
+            return substr(hash('xxh128', (string) hrtime(true)), 0, self::REF_BYTES * 2);
+        }
     }
 }

--- a/src/Mcp/Tool/McpToolErrorHandler.php
+++ b/src/Mcp/Tool/McpToolErrorHandler.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Mcp\Tool;
+
+use Pimcore\Bundle\StudioBackendBundle\Mcp\Exception\InvalidMcpToolArgumentException;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use function bin2hex;
+use function random_bytes;
+use function sprintf;
+
+/**
+ * Default {@see McpToolErrorHandlerInterface}: the terminal `catch` of an MCP tool.
+ *
+ * MCP tool results do not stay inside Pimcore. The built-in MCP servers are consumed by external
+ * clients (Claude Desktop, Cursor, ...) which forward tool output to whichever third-party model
+ * they are wired to, so a raw `$e->getMessage()` carries DBAL/SQL, OpenSearch and Twig internals
+ * across the Pimcore boundary.
+ *
+ * ## The rule
+ *
+ * **An exception that reaches here never has its message forwarded.** The terminal catch is the
+ * "I did not anticipate this" branch, and a message you did not anticipate is not one you can
+ * vouch for. The client gets a generic sentence naming the tool and a correlation id; the operator
+ * gets the exception, in full, in the log.
+ *
+ * A tool that *can* say something useful about a failure should type-catch it and compose that
+ * sentence itself, out of values it holds. `Document 42 not found. Use search_documents to find
+ * valid ids.` is both safer and better copy than any exception message.
+ *
+ * ## Why there is no allowlist of "safe" exception types
+ *
+ * Because safety is a property of the *construction*, not of the class. An exception whose
+ * constructor composes its message from typed scalars carries a real invariant; one that takes a
+ * free-form `string $message` does not, because the answer belongs to whoever calls it. In this
+ * bundle alone, `ValidationFailedException` is given a literal written for the caller at five call
+ * sites and an inner `getMessage()` at `Document\Service\ExecutionEngine\CloneService` and
+ * `Perspective\Service\WidgetValidationService`. Any class-level marking of it is wrong half the
+ * time.
+ *
+ * The corollary for callers: where a foreign message really is worth forwarding, type-catch it at
+ * the tool that understands why, and say why at the catch.
+ *
+ * ## The one forwarded type
+ *
+ * {@see InvalidMcpToolArgumentException} is returned verbatim, because throwing it is an explicit
+ * statement that the message was composed for the caller. See that class for the contract.
+ *
+ * ## Why there is no dev/prod split
+ *
+ * A tool's failure is not a Symfony error response. Tools catch their own exceptions and return
+ * the text as *application data* inside an HTTP 200 JSON-RPC result, so `kernel.debug`,
+ * `ErrorListener` and the prod/dev error rendering never see it. Gating disclosure on the
+ * environment would not inherit a framework behaviour, it would invent one, and it would turn
+ * "nothing leaks" from an invariant a test can assert unconditionally into one that holds in a
+ * single environment, on boxes that still talk to real third-party model providers. The
+ * correlation id gives the same debugging benefit everywhere: grep the application log for the ref.
+ *
+ * The handler returns a *message*, not a result envelope, because tools differ in the envelope
+ * they return and each keeps its own.
+ *
+ * @internal depend on {@see McpToolErrorHandlerInterface}, which is the supported contract
+ */
+final readonly class McpToolErrorHandler implements McpToolErrorHandlerInterface
+{
+    private const string CODE_BAD_ARGUMENT = 'invalid_argument';
+
+    private const string CODE_INTERNAL = 'internal_error';
+
+    private const string MSG_INTERNAL = 'Internal error while executing %s (ref: %s). '
+        . 'The cause was written to the Pimcore application log.';
+
+    /**
+     * Fallback for an argument rejection that carries no message of its own.
+     */
+    private const string MSG_REJECTED = 'The request was rejected.';
+
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    public function handle(Throwable $exception, string $toolName, array $context = []): string
+    {
+        if ($exception instanceof InvalidMcpToolArgumentException) {
+            return $this->handleBadArgument($exception, $toolName, $context);
+        }
+
+        return $this->handleUnexpected($exception, $toolName, $context);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function handleBadArgument(Throwable $exception, string $toolName, array $context): string
+    {
+        $message = $exception->getMessage();
+
+        // Notice rather than error, and no stack trace: nothing failed server-side.
+        $this->logger->notice(
+            sprintf('%s rejected the request: %s', $toolName, $message),
+            ['tool' => $toolName, 'code' => self::CODE_BAD_ARGUMENT] + $context
+        );
+
+        return $message !== '' ? $message : self::MSG_REJECTED;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function handleUnexpected(Throwable $exception, string $toolName, array $context): string
+    {
+        $ref = bin2hex(random_bytes(4));
+
+        $this->logger->error(
+            sprintf('Unhandled exception in %s (ref: %s)', $toolName, $ref),
+            [
+                'tool' => $toolName,
+                'code' => self::CODE_INTERNAL,
+                'ref' => $ref,
+                // The Throwable itself, per PSR-3: Monolog's normalizer expands it to class,
+                // message, code, file, line and the whole `previous` chain. Passing the class name
+                // as a string instead would drop all of that, and the root cause of a wrapped
+                // API exception lives in `previous`.
+                'exception' => $exception,
+                'exceptionClass' => $exception::class,
+            ] + $context
+        );
+
+        return sprintf(self::MSG_INTERNAL, $toolName, $ref);
+    }
+}

--- a/src/Mcp/Tool/McpToolErrorHandlerInterface.php
+++ b/src/Mcp/Tool/McpToolErrorHandlerInterface.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Mcp\Tool;
+
+use Throwable;
+
+/**
+ * Shared error handling for the terminal generic `catch` of an MCP tool.
+ *
+ * Inject this into a tool and route its `catch (Throwable $e)` through {@see self::handle()}, then
+ * wrap the returned string in whatever error envelope the tool already uses.
+ */
+interface McpToolErrorHandlerInterface
+{
+    /**
+     * Logs $exception and returns the message that may be handed to the client.
+     *
+     * @param string               $toolName the public MCP tool name, e.g. "update_document"
+     * @param array<string, mixed> $context  additional structured logging context, e.g. tool parameters
+     */
+    public function handle(Throwable $exception, string $toolName, array $context = []): string;
+}

--- a/src/Mcp/Tool/ObjectParameterNormalizer.php
+++ b/src/Mcp/Tool/ObjectParameterNormalizer.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Mcp\Tool;
+
+use Pimcore\Bundle\StudioBackendBundle\Mcp\Exception\InvalidMcpToolArgumentException;
+use function array_is_list;
+use function sprintf;
+
+/**
+ * Guards an object-shaped MCP tool parameter.
+ *
+ * Such a parameter accepts an object or nothing, but "nothing" has three encodings a client may
+ * use: the parameter is omitted, it is null, or it is an empty object. The declared schema has to
+ * admit all three, which means it also has to admit `array` — by the time the tool runs the
+ * transport has decoded the payload associatively, so an empty object is indistinguishable from an
+ * empty list. Admitting `array` would also let a populated list through, so that case is rejected
+ * here instead.
+ *
+ * This is the second half of one mechanism: {@see ToolInputSchemaNormalizer} widens the declared
+ * type so `{}` is accepted, and this closes the hole that widening opens. Use them together.
+ *
+ * The value is returned unchanged rather than coerced: a tool may distinguish "not supplied" (null)
+ * from "supplied but empty", and collapsing the two would change its behaviour.
+ */
+final class ObjectParameterNormalizer
+{
+    private function __construct()
+    {
+        // static-only utility class, must not be instantiated
+    }
+
+    /**
+     * @param array<array-key, mixed>|null $value
+     *
+     * @return array<array-key, mixed>|null the value unchanged, once its shape is known to be valid
+     *
+     * @throws InvalidMcpToolArgumentException when a populated list is passed instead of an object
+     */
+    public static function normalize(?array $value, string $parameterName): ?array
+    {
+        if ($value === null || $value === []) {
+            return $value;
+        }
+
+        if (array_is_list($value)) {
+            // Client-safe by construction: the message names the caller's own parameter and says
+            // how to send nothing. This is the shipped example of a correct throw of that type.
+            throw new InvalidMcpToolArgumentException(sprintf(
+                'The "%s" parameter must be an object of field/value pairs, not a list. '
+                . 'Omit it, or pass null or {}, to send no %s.',
+                $parameterName,
+                $parameterName
+            ));
+        }
+
+        return $value;
+    }
+}

--- a/src/Mcp/Tool/ObjectParameterNormalizer.php
+++ b/src/Mcp/Tool/ObjectParameterNormalizer.php
@@ -32,6 +32,21 @@ use function sprintf;
  *
  * The value is returned unchanged rather than coerced: a tool may distinguish "not supplied" (null)
  * from "supplied but empty", and collapsing the two would change its behaviour.
+ *
+ * ## Known limitation: object keys must not be sequential integers from zero
+ *
+ * `{"0":"a","1":"b"}` is rejected, even though the advertised schema says `object`. That is not a
+ * choice this class can make differently. `Mcp\JsonRpc\MessageFactory` decodes the payload with
+ * `json_decode($input, true)` before any tool is reached, and PHP casts numeric string keys to
+ * integers, so `{"0":"a","1":"b"}` and `["a","b"]` decode to *identical* values — `===` returns
+ * true. No inspection downstream can tell them apart, so a guard that rejects populated lists
+ * necessarily rejects that one object shape too.
+ *
+ * In practice this costs nothing: the parameters worth guarding are maps keyed by names the caller
+ * chose — editable names, field names, workflow options, tool arguments — and `"0"` is not one of
+ * them. A map with any non-integer key, or with integer keys that are not sequential from zero
+ * (`{"0":"a","2":"b"}`), passes normally. Do not use this guard for a parameter whose keys are
+ * genuinely arbitrary integers; give that parameter an `array` schema and validate it in the tool.
  */
 final class ObjectParameterNormalizer
 {

--- a/src/Mcp/Tool/ToolInputSchemaNormalizer.php
+++ b/src/Mcp/Tool/ToolInputSchemaNormalizer.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Mcp\Tool;
+
+use function array_key_exists;
+use function count;
+use function in_array;
+use function is_array;
+
+/**
+ * Repairs two systematic defects in the generated tool input schemas.
+ *
+ * Both come from the same place: a #[Schema] attribute declares a parameter's type as a single
+ * string, which overrides the nullable type the SDK would otherwise infer from the PHP
+ * signature. The declared type then contradicts the `default: null` that the SDK still emits
+ * from the parameter's default value, and clients that honour the advertised default are
+ * rejected by the schema that advertised it.
+ *
+ * 1. An optional parameter whose advertised default is null has to accept null.
+ * 2. An object parameter has to accept `array` as well. The transport decodes the payload
+ *    associatively, so an empty object arrives as an empty PHP array and cannot be told apart
+ *    from an empty list - rejecting `array` therefore rejects `{}`, the natural way for a
+ *    client UI to say "no value" when it cannot omit the key. Because that also lets a
+ *    populated list through, tools guard their object parameters with
+ *    {@see ObjectParameterNormalizer}.
+ *
+ * Apply this centrally, where tools are registered with the MCP server, rather than per
+ * parameter: in the Pimcore Agent Bundle the defect affected 35 parameters across 15 tools, and
+ * normalising at registration keeps it fixed for tools added later.
+ */
+final class ToolInputSchemaNormalizer
+{
+    private function __construct()
+    {
+        // static-only utility class, must not be instantiated
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     *
+     * @return array<string, mixed>
+     */
+    public static function normalize(array $schema): array
+    {
+        $properties = $schema['properties'] ?? null;
+        if (!is_array($properties)) {
+            return $schema;
+        }
+
+        $required = is_array($schema['required'] ?? null) ? $schema['required'] : [];
+
+        foreach ($properties as $name => $property) {
+            if (is_array($property)) {
+                $properties[$name] = self::widenType($property, in_array($name, $required, true));
+            }
+        }
+
+        $schema['properties'] = $properties;
+
+        return $schema;
+    }
+
+    /**
+     * @param array<string, mixed> $property
+     *
+     * @return array<string, mixed>
+     */
+    private static function widenType(array $property, bool $isRequired): array
+    {
+        $declared = $property['type'] ?? null;
+        if ($declared === null) {
+            return $property;
+        }
+
+        $types = is_array($declared) ? array_values($declared) : [$declared];
+
+        if (in_array('object', $types, true) && !in_array('array', $types, true)) {
+            $types[] = 'array';
+        }
+
+        if (self::advertisesNullDefault($property, $isRequired) && !in_array('null', $types, true)) {
+            $types[] = 'null';
+        }
+
+        $property['type'] = count($types) === 1 ? $types[0] : $types;
+
+        return $property;
+    }
+
+    /**
+     * @param array<string, mixed> $property
+     */
+    private static function advertisesNullDefault(array $property, bool $isRequired): bool
+    {
+        return !$isRequired
+            && array_key_exists('default', $property)
+            && $property['default'] === null;
+    }
+}

--- a/tests/Unit/Mcp/Tool/McpToolErrorHandlerTest.php
+++ b/tests/Unit/Mcp/Tool/McpToolErrorHandlerTest.php
@@ -1,0 +1,231 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Mcp\Tool;
+
+use Codeception\Test\Unit;
+use Doctrine\DBAL\Exception as DbalException;
+use InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ValidationFailedException;
+use Pimcore\Bundle\StudioBackendBundle\Mcp\Exception\InvalidMcpToolArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Mcp\Tool\McpToolErrorHandler;
+use Psr\Log\AbstractLogger;
+use RuntimeException;
+use Stringable;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Throwable;
+use function json_encode;
+use function preg_match;
+
+/**
+ * MCP tool results leave the Pimcore boundary: external clients forward them to whichever
+ * third-party model they are wired to.
+ *
+ * The contract is deliberately blunt: an exception reaching the handler never has its message
+ * forwarded, with one exception whose safety is a property of the type rather than of a call site.
+ *
+ * @internal
+ */
+final class McpToolErrorHandlerTest extends Unit
+{
+    private const string TOOL = 'update_document';
+
+    /**
+     * The one forwarded type. Throwing it states that the message was composed for the caller.
+     */
+    public function testArgumentExceptionMessageIsForwarded(): void
+    {
+        $message = $this->handler(new RecordingLogger())->handle(
+            new InvalidMcpToolArgumentException('"data" must be an object, not a list.'),
+            self::TOOL,
+        );
+
+        $this->assertSame('"data" must be an object, not a list.', $message);
+    }
+
+    /**
+     * Notice, not error, and no trace: nothing failed server-side.
+     */
+    public function testArgumentExceptionIsLoggedAtNoticeWithoutTrace(): void
+    {
+        $logger = new RecordingLogger();
+
+        $this->handler($logger)->handle(
+            new InvalidMcpToolArgumentException('"editables" must be an object.'),
+            self::TOOL,
+            ['id' => 42],
+        );
+
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('notice', $logger->records[0]['level']);
+        $this->assertArrayNotHasKey('trace', $logger->records[0]['context']);
+        // The tool's own structured context survives, so the operator can still correlate.
+        $this->assertSame(42, $logger->records[0]['context']['id']);
+    }
+
+    public function testEmptyArgumentMessageFallsBackToARejectionSentence(): void
+    {
+        $this->assertSame(
+            'The request was rejected.',
+            $this->handler(new RecordingLogger())->handle(
+                new InvalidMcpToolArgumentException(''),
+                self::TOOL,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider notForwardedProvider
+     *
+     * @param list<string> $forbiddenFragments
+     */
+    public function testNothingElseIsForwarded(Throwable $exception, array $forbiddenFragments, string $why): void
+    {
+        $logger = new RecordingLogger();
+
+        $message = $this->handler($logger)->handle($exception, self::TOOL);
+
+        // Assert against the serialized payload, which is what a tool actually ships.
+        // JSON_UNESCAPED_SLASHES keeps path fragments comparable — an escaped "\/var\/www"
+        // would make the assertion pass on a genuine leak.
+        $payload = (string) json_encode(['error' => $message], JSON_UNESCAPED_SLASHES);
+
+        $this->assertStringNotContainsString($exception::class, $payload, $why);
+        $this->assertStringNotContainsString($exception->getMessage(), $payload, $why);
+        foreach ($forbiddenFragments as $fragment) {
+            $this->assertStringNotContainsString($fragment, $payload, $why);
+        }
+
+        // …while the server-side record keeps everything needed to diagnose it.
+        $this->assertSame('error', $logger->records[0]['level']);
+        $this->assertSame($exception, $logger->records[0]['context']['exception']);
+        $this->assertSame($exception::class, $logger->records[0]['context']['exceptionClass']);
+    }
+
+    /**
+     * @return array<string, array{Throwable, list<string>, string}>
+     */
+    public function notForwardedProvider(): array
+    {
+        $sql = "An exception occurred while executing 'SELECT id FROM documents_page WHERE template = ?'";
+
+        return [
+            'dbal quotes the statement' => [
+                new class($sql) extends RuntimeException implements DbalException {},
+                ['SELECT', 'documents_page'],
+                'A DBAL message quotes the failing statement.',
+            ],
+            'search backend leaks the index and host' => [
+                new RuntimeException('no such index [product_index-1] on node opensearch:9200'),
+                ['product_index', 'opensearch:9200'],
+                'A search-backend message names indices and nodes.',
+            ],
+            'a 5xx HttpException' => [
+                new HttpException(500, 'Saving failed: SQLSTATE[HY000] deadlock on `objects`'),
+                ['SQLSTATE', 'deadlock'],
+                'A server fault may quote infrastructure.',
+            ],
+            // The reason there is no allowlist: this class is given a caller-facing literal at
+            // five call sites and an inner getMessage() at CloneService and WidgetValidationService,
+            // so no class-level judgement about it can be right.
+            'a 422 that some call sites populate from an inner exception' => [
+                new ValidationFailedException('Failed to clone document: SQLSTATE[HY000] deadlock'),
+                ['SQLSTATE'],
+                'Trust is a property of the construction, not of the class.',
+            ],
+            // 130+ library classes extend SPL InvalidArgumentException, quoting paths, DSNs and URLs.
+            'plain SPL InvalidArgumentException' => [
+                new InvalidArgumentException('Cache file is not writable: "/var/www/html/var/cache/x"'),
+                ['/var/www/html'],
+                'Extending SPL InvalidArgumentException says nothing about who wrote the message.',
+            ],
+            // Caller-facing in practice, and still not forwarded here: a tool that wants to say
+            // "not found" composes that sentence itself, from the id it already holds.
+            'even a caller-facing API exception' => [
+                new NotFoundException('document', 42),
+                [],
+                'The handler does not distinguish; the tool type-catches when it wants the message.',
+            ],
+        ];
+    }
+
+    /**
+     * The correlation id is what replaces a dev/prod split: it has to appear in both the returned
+     * sentence and the log record, or it buys nothing.
+     */
+    public function testGenericMessageCarriesACorrelationIdMatchingTheLogRecord(): void
+    {
+        $logger = new RecordingLogger();
+
+        $message = $this->handler($logger)->handle(new RuntimeException('kaboom'), self::TOOL);
+
+        $this->assertSame(1, preg_match('/\(ref: ([0-9a-f]{8})\)/u', $message, $matches));
+        $this->assertSame($matches[1], $logger->records[0]['context']['ref']);
+        $this->assertStringContainsString($matches[1], $logger->records[0]['message']);
+    }
+
+    public function testCorrelationIdDiffersPerCall(): void
+    {
+        $handler = $this->handler(new RecordingLogger());
+
+        $this->assertNotSame(
+            $handler->handle(new RuntimeException('a'), self::TOOL),
+            $handler->handle(new RuntimeException('b'), self::TOOL),
+        );
+    }
+
+    /**
+     * Passing the Throwable rather than its class name is what lets Monolog's normalizer expand
+     * file, line, code and the whole `previous` chain — and the root cause of a wrapped API
+     * exception lives in `previous`.
+     */
+    public function testThrowableItselfIsAttachedToTheLogRecord(): void
+    {
+        $logger = new RecordingLogger();
+        $exception = new RuntimeException('kaboom');
+
+        $this->handler($logger)->handle($exception, self::TOOL, ['id' => 7]);
+
+        $this->assertSame($exception, $logger->records[0]['context']['exception']);
+        $this->assertSame(RuntimeException::class, $logger->records[0]['context']['exceptionClass']);
+        $this->assertSame(7, $logger->records[0]['context']['id']);
+    }
+
+    private function handler(RecordingLogger $logger): McpToolErrorHandler
+    {
+        return new McpToolErrorHandler($logger);
+    }
+}
+
+/**
+ * Minimal PSR-3 recorder: these tests assert on the log *level* as well as the payload, which a
+ * mock would only verify for the calls the test already spells out.
+ *
+ * @internal
+ */
+final class RecordingLogger extends AbstractLogger
+{
+    /**
+     * @var list<array{level: string, message: string, context: array<string, mixed>}>
+     */
+    public array $records = [];
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function log(mixed $level, string|Stringable $message, array $context = []): void
+    {
+        $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+    }
+}

--- a/tests/Unit/Mcp/Tool/McpToolErrorHandlerTest.php
+++ b/tests/Unit/Mcp/Tool/McpToolErrorHandlerTest.php
@@ -202,6 +202,34 @@ final class McpToolErrorHandlerTest extends Unit
         $this->assertSame(7, $logger->records[0]['context']['id']);
     }
 
+    /**
+     * The handler is the terminal boundary, so nothing inside it may throw: an exception escaping
+     * here would replace the tool's original failure *and* lose it, because the log call happens
+     * after the correlation id is minted. `random_bytes()` can throw on entropy exhaustion, so the
+     * id is generated behind a fallback.
+     *
+     * Entropy failure cannot be provoked in-process, so this asserts the property that makes the
+     * fallback correct: the id is produced without touching anything that can fail, and every
+     * caller gets a well-formed one.
+     */
+    public function testCorrelationIdIsAlwaysWellFormed(): void
+    {
+        $logger = new RecordingLogger();
+        $handler = $this->handler($logger);
+
+        for ($i = 0; $i < 25; $i++) {
+            $message = $handler->handle(new RuntimeException('kaboom'), self::TOOL);
+
+            $this->assertSame(
+                1,
+                preg_match('/\(ref: [0-9a-f]{8}\)/u', $message),
+                'Every correlation id must be 8 hex characters.',
+            );
+        }
+
+        $this->assertCount(25, $logger->records);
+    }
+
     private function handler(RecordingLogger $logger): McpToolErrorHandler
     {
         return new McpToolErrorHandler($logger);

--- a/tests/Unit/Mcp/Tool/ObjectParameterNormalizerTest.php
+++ b/tests/Unit/Mcp/Tool/ObjectParameterNormalizerTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Mcp\Tool;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Mcp\Exception\InvalidMcpToolArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Mcp\Tool\ObjectParameterNormalizer;
+
+/**
+ * @internal
+ */
+final class ObjectParameterNormalizerTest extends Unit
+{
+    /**
+     * All three encodings of "nothing" have to survive, and stay distinguishable: a tool may treat
+     * "not supplied" differently from "supplied but empty", so neither is coerced into the other.
+     */
+    public function testEveryEncodingOfNothingIsReturnedUnchanged(): void
+    {
+        $this->assertNull(ObjectParameterNormalizer::normalize(null, 'filter'));
+        $this->assertSame([], ObjectParameterNormalizer::normalize([], 'filter'));
+    }
+
+    public function testAnObjectIsReturnedUnchanged(): void
+    {
+        $value = ['colour' => 'red', 'size' => 2];
+
+        $this->assertSame($value, ObjectParameterNormalizer::normalize($value, 'filter'));
+    }
+
+    /**
+     * The hole that ToolInputSchemaNormalizer's widening opens: the schema has to admit `array` so
+     * that `{}` is accepted, which also lets a populated list through.
+     */
+    public function testAPopulatedListIsRejected(): void
+    {
+        $this->expectException(InvalidMcpToolArgumentException::class);
+
+        ObjectParameterNormalizer::normalize(['a', 'b'], 'filter');
+    }
+
+    /**
+     * The message is the reason this throws a forwardable type: it names the caller's own parameter
+     * and says how to send nothing, so the agent can correct itself.
+     */
+    public function testRejectionNamesTheParameterAndHowToSendNothing(): void
+    {
+        try {
+            ObjectParameterNormalizer::normalize([['id' => 1]], 'orderBy');
+            $this->fail('Expected a populated list to be rejected.');
+        } catch (InvalidMcpToolArgumentException $e) {
+            $this->assertStringContainsString('"orderBy" parameter', $e->getMessage());
+            $this->assertStringContainsString('Omit it, or pass null or {}', $e->getMessage());
+        }
+    }
+
+    /**
+     * A map with sequential integer keys is a list as far as PHP is concerned, and a map with any
+     * string key is not — the distinction the guard rests on.
+     */
+    public function testAMapWithNonSequentialKeysIsNotAList(): void
+    {
+        $value = [2 => 'b', 0 => 'a'];
+
+        $this->assertSame($value, ObjectParameterNormalizer::normalize($value, 'filter'));
+    }
+}

--- a/tests/Unit/Mcp/Tool/ObjectParameterNormalizerTest.php
+++ b/tests/Unit/Mcp/Tool/ObjectParameterNormalizerTest.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Mcp\Tool;
 use Codeception\Test\Unit;
 use Pimcore\Bundle\StudioBackendBundle\Mcp\Exception\InvalidMcpToolArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Mcp\Tool\ObjectParameterNormalizer;
+use function json_decode;
 
 /**
  * @internal
@@ -72,6 +73,37 @@ final class ObjectParameterNormalizerTest extends Unit
     public function testAMapWithNonSequentialKeysIsNotAList(): void
     {
         $value = [2 => 'b', 0 => 'a'];
+
+        $this->assertSame($value, ObjectParameterNormalizer::normalize($value, 'filter'));
+    }
+
+    /**
+     * Pins the documented limitation rather than pretending it away.
+     *
+     * `{"0":"a","1":"b"}` and `["a","b"]` decode to identical PHP values, because MessageFactory
+     * decodes associatively and PHP casts numeric string keys to integers. Nothing downstream can
+     * distinguish them, so the guard necessarily rejects that one object shape. Asserting the
+     * identity here means the test fails if that upstream behaviour ever changes, which is exactly
+     * when the limitation could be lifted.
+     */
+    public function testAnObjectWithSequentialNumericKeysIsIndistinguishableFromAListAndIsRejected(): void
+    {
+        $asObject = json_decode('{"0":"a","1":"b"}', true);
+        $asList = json_decode('["a","b"]', true);
+
+        $this->assertSame($asList, $asObject, 'Associative decoding collapses the two shapes.');
+
+        $this->expectException(InvalidMcpToolArgumentException::class);
+        ObjectParameterNormalizer::normalize($asObject, 'filter');
+    }
+
+    /**
+     * The escape hatch from that limitation: any non-integer key, anywhere, makes it an object
+     * again — including the mixed shape a caller is far more likely to send.
+     */
+    public function testAnObjectWithAnyStringKeyIsAccepted(): void
+    {
+        $value = json_decode('{"0":"a","label":"b"}', true);
 
         $this->assertSame($value, ObjectParameterNormalizer::normalize($value, 'filter'));
     }

--- a/tests/Unit/Mcp/Tool/ToolInputSchemaNormalizerTest.php
+++ b/tests/Unit/Mcp/Tool/ToolInputSchemaNormalizerTest.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Mcp\Tool;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Mcp\Tool\ToolInputSchemaNormalizer;
+
+/**
+ * @internal
+ */
+final class ToolInputSchemaNormalizerTest extends Unit
+{
+    /**
+     * The defect: a #[Schema] attribute pins the type to a single string, overriding the nullable
+     * type inferred from the signature, while the SDK still emits `default: null`. A client that
+     * honours the advertised default is then rejected by the schema that advertised it.
+     */
+    public function testOptionalParameterAdvertisingANullDefaultAcceptsNull(): void
+    {
+        $normalized = ToolInputSchemaNormalizer::normalize([
+            'properties' => ['query' => ['type' => 'string', 'default' => null]],
+        ]);
+
+        $this->assertSame(['string', 'null'], $normalized['properties']['query']['type']);
+    }
+
+    /**
+     * An empty object arrives as an empty PHP array once the transport has decoded the payload
+     * associatively, so rejecting `array` rejects `{}`.
+     */
+    public function testObjectParameterAlsoAcceptsArray(): void
+    {
+        $normalized = ToolInputSchemaNormalizer::normalize([
+            'properties' => ['filter' => ['type' => 'object']],
+        ]);
+
+        $this->assertSame(['object', 'array'], $normalized['properties']['filter']['type']);
+    }
+
+    public function testBothWideningsCombine(): void
+    {
+        $normalized = ToolInputSchemaNormalizer::normalize([
+            'properties' => ['filter' => ['type' => 'object', 'default' => null]],
+        ]);
+
+        $this->assertSame(['object', 'array', 'null'], $normalized['properties']['filter']['type']);
+    }
+
+    /**
+     * A required parameter has no default to contradict, so null is not added — the schema should
+     * keep rejecting null for something the caller must supply.
+     */
+    public function testRequiredParameterDoesNotGainNull(): void
+    {
+        $normalized = ToolInputSchemaNormalizer::normalize([
+            'properties' => ['id' => ['type' => 'integer', 'default' => null]],
+            'required' => ['id'],
+        ]);
+
+        $this->assertSame('integer', $normalized['properties']['id']['type']);
+    }
+
+    /**
+     * A non-null default says nothing about accepting null.
+     */
+    public function testNonNullDefaultDoesNotWiden(): void
+    {
+        $normalized = ToolInputSchemaNormalizer::normalize([
+            'properties' => ['pageSize' => ['type' => 'integer', 'default' => 20]],
+        ]);
+
+        $this->assertSame('integer', $normalized['properties']['pageSize']['type']);
+    }
+
+    public function testAlreadyWideTypesAreNotDuplicated(): void
+    {
+        $normalized = ToolInputSchemaNormalizer::normalize([
+            'properties' => ['filter' => ['type' => ['object', 'array', 'null'], 'default' => null]],
+        ]);
+
+        $this->assertSame(['object', 'array', 'null'], $normalized['properties']['filter']['type']);
+    }
+
+    public function testSchemaWithoutPropertiesIsReturnedUnchanged(): void
+    {
+        $schema = ['type' => 'object'];
+
+        $this->assertSame($schema, ToolInputSchemaNormalizer::normalize($schema));
+    }
+
+    /**
+     * A property with no declared type is left alone rather than guessed at.
+     */
+    public function testPropertyWithoutATypeIsUntouched(): void
+    {
+        $normalized = ToolInputSchemaNormalizer::normalize([
+            'properties' => ['anything' => ['description' => 'no type declared', 'default' => null]],
+        ]);
+
+        $this->assertArrayNotHasKey('type', $normalized['properties']['anything']);
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

This bundle already owns the MCP infrastructure every tool-hosting bundle depends on: the firewall
pattern, `Entity/Mcp/McpAccessToken`, its repository, service and GC task, the three authenticators
under `Security/Authenticator/Mcp/`, and the PSR-7 bridge in `config/mcp.yaml`. It owns no tools,
which is precisely why the **tool boundary** belongs here rather than in any one bundle that has
them.

Three classes, developed and hardened in `pimcore-agent-bundle`, move here so they stop being
copied.

### Why now

`McpToolErrorHandler` and `ObjectParameterNormalizer` already exist — separately, and by now
divergently — in three bundles:

| class | agent | copilot | data-hub-simple-rest |
|---|---|---|---|
| `McpToolErrorHandler` | 126 lines | 126 lines | **268 lines** |
| `ObjectParameterNormalizer` | ✓ | ✓ | ✓ |
| `ToolInputSchemaNormalizer` | ✓ | — | — |

All three already require `pimcore/studio-backend-bundle` (`^2026.2`, `^2026.1.1`, `^2026.1`), so
this is not a new dependency for anyone. And `ToolInputSchemaNormalizer` existing in only one of
them is a correctness gap, not just duplication: the other two never got its fix systemically, and
data-hub-simple-rest widened the affected parameters by hand instead.

**No new dependency for this bundle either** — none of the three needs `mcp/sdk`. The handler needs
PSR-3; both normalizers are array in, array out.

### What they do

**`McpToolErrorHandler`** is the terminal `catch (Throwable)` of an MCP tool. Tool results leave the
Pimcore boundary — external clients (Claude Desktop, Cursor) forward them to whichever third-party
model they are wired to — so it forwards **no** exception message, logs the exception in full, and
answers with a generic sentence plus a correlation id.

Worth stating explicitly, because it is counter-intuitive: **Symfony does not do this for you.** A
tool catches its own exception and returns the text as *application data* inside an HTTP 200
JSON-RPC result, so `kernel.debug`, `ErrorListener` and the production error page never see it. That
is also why disclosure is not environment-gated: there is no framework behaviour to inherit, and
gating would turn "nothing leaks" from an invariant a test asserts unconditionally into one that
holds in a single environment. The correlation id gives the same debugging benefit everywhere.

**`InvalidMcpToolArgumentException`** is the one type it forwards. Throwing it is an explicit
statement by the thrower: *I composed this message for the caller, out of the caller's own input.*

**`ToolInputSchemaNormalizer` + `ObjectParameterNormalizer`** are two halves of one mechanism. A
`#[Schema]` attribute pins a parameter to a single type, contradicting the `default: null` the SDK
still emits, so the schema must be widened to accept `null` and `{}`; widening to admit `array` also
admits a populated list, which the second half rejects. They are documented as a pair because
splitting them re-opens the hole.

### No allowlist of "client-safe" exceptions, on purpose

An earlier iteration had a marker interface plus an allowlist of API exception types. It was
dropped, because safety is a property of the **construction**, not of the class. In this bundle
alone, `ValidationFailedException` is given a caller-facing literal at five call sites and an inner
`getMessage()` at `Document\Service\ExecutionEngine\CloneService` and
`Perspective\Service\WidgetValidationService` — so any class-level marking of it is wrong half the
time. Where a foreign message really is worth forwarding, the tool type-catches it and says why at
the catch.

## Verification

- **Additive only.** No existing behaviour changes; the only edit to an existing file appends two
  service definitions to `config/mcp.yaml`.
- `php-cs-fixer` clean (0 of 2946 files).
- 9 new Codeception unit tests covering both normalizers and the handler, including a data provider
  of exceptions that must **not** be forwarded — a DBAL statement, an OpenSearch host, a 5xx, a
  plain SPL `InvalidArgumentException`, and `ValidationFailedException` as the case that proves the
  allowlist approach wrong.
- **Local Codeception could not be run**: this checkout's `vendor/` is missing `pimcore/pimcore`, so
  `vendor/bin/codecept` fails to bootstrap on the pre-existing `DefaultTest` too. Relying on CI for
  the suite. All new files pass `php -l`.
- The moved classes were exercised for real through `pimcore-agent-bundle`, which consumes them in
  its companion PR: **1194 tests green**, PHPStan clean, and a live end-to-end run against the MCP
  endpoints at `/pimcore-mcp/agent/*` (**31/31**), including the DI wiring from this bundle's
  `config/mcp.yaml`.

## Follow-up

`pimcore-agent-bundle` deletes its local copies in its companion PR, which is blocked on a release
of this branch. `copilot-bundle` and `data-hub-simple-rest` can drop theirs afterwards;
data-hub-simple-rest's third tier (a sanitized search-backend rejection) is the one behaviour not
represented here and should be folded in when that bundle migrates.