### PR TITLE
[Permissions] GridView ignores Viewable Languages permission (PEES-1063)

### DIFF
--- a/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
@@ -240,7 +240,12 @@ final class AdvancedColumnResolver implements
             config: $config,
         );
 
-        if (!$this->gridService->isLocaleViewableForElement($element, $subColumn->getLocale(), $this->user)) {
+        if (!$this->gridService->isLocaleViewableForElement(
+            $element,
+            $subColumn->getLocale(),
+            $this->user,
+            isLocalizedField: $isLocalizable,
+        )) {
             return;
         }
 
@@ -300,7 +305,12 @@ final class AdvancedColumnResolver implements
 
         $relationLocale = $isRelationLocalizable ? $column->getLocale() : null;
 
-        if (!$this->gridService->isLocaleViewableForElement($element, $relationLocale, $this->user)) {
+        if (!$this->gridService->isLocaleViewableForElement(
+            $element,
+            $relationLocale,
+            $this->user,
+            isLocalizedField: $isRelationLocalizable,
+        )) {
             return [];
         }
 

--- a/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/AdvancedColumnResolver.php
@@ -240,6 +240,10 @@ final class AdvancedColumnResolver implements
             config: $config,
         );
 
+        if (!$this->gridService->isLocaleViewableForElement($element, $subColumn->getLocale(), $this->user)) {
+            return;
+        }
+
         $data = null;
         if ($resolver instanceof CoreElementColumnResolverInterface && !$export) {
             $data = $resolver->resolveForCoreElement($subColumn, $element);
@@ -294,9 +298,15 @@ final class AdvancedColumnResolver implements
             $this->user
         );
 
+        $relationLocale = $isRelationLocalizable ? $column->getLocale() : null;
+
+        if (!$this->gridService->isLocaleViewableForElement($element, $relationLocale, $this->user)) {
+            return [];
+        }
+
         $relation = $this->getLocalizedValueFromKey(
             $relationKey,
-            $isRelationLocalizable ? $column->getLocale() : null,
+            $relationLocale,
             $element
         );
 

--- a/src/Grid/Service/ClassDefinitionService.php
+++ b/src/Grid/Service/ClassDefinitionService.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service;
 
 use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Model\DataObject\ClassDefinition;
@@ -30,6 +31,7 @@ final readonly class ClassDefinitionService implements ClassDefinitionServiceInt
     public function __construct(
         private ClassDefinitionResolverInterface $classDefinitionResolver,
         private DataObjectServiceResolverInterface $dataObjectServiceResolver,
+        private DataObjectResolverInterface $dataObjectResolver,
     ) {
     }
 
@@ -57,8 +59,15 @@ final readonly class ClassDefinitionService implements ClassDefinitionServiceInt
         /** @var Layout $layoutDefinitions */
         $layoutDefinitions = $filteredDefinitions['layoutDefinition'];
 
+        // No Concrete object is available for a folder-scoped grid config, but the folder/object
+        // permission subject can still be handed through context['object'] so language-permission
+        // enrichment (PEES-1063) can run without requiring field-level Concrete enrichment.
         $this->dataObjectServiceResolver->enrichLayoutDefinition(
             $layoutDefinitions,
+            context: [
+                'object' => $folderId ? $this->dataObjectResolver->getById($folderId) : null,
+                'purpose' => 'gridconfig',
+            ],
             user: $user
         );
 

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -44,7 +44,9 @@ use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
+use Pimcore\Localization\LocaleServiceInterface;
 use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\User;
@@ -89,6 +91,7 @@ final class GridService implements GridServiceInterface
         private readonly LoggerInterface $pimcoreLogger,
         private readonly DataObjectServiceResolverInterface $dataObjectServiceResolver,
         private readonly ToolResolverInterface $toolResolver,
+        private readonly LocaleServiceInterface $localeService,
     ) {
     }
 
@@ -99,9 +102,26 @@ final class GridService implements GridServiceInterface
         ElementInterface $element,
         ?string $locale,
         ?UserInterface $user = null,
+        bool $isLocalizedField = false,
     ): bool {
-        if ($locale === null || !$element instanceof Concrete) {
+        if (!$element instanceof Concrete) {
             return true;
+        }
+
+        if ($locale === null) {
+            if (!$isLocalizedField) {
+                return true;
+            }
+
+            // A localized field read without an explicit locale resolves to the current request
+            // locale or the default language (Localizedfield::getLanguage()). That effective
+            // locale must be authorized like an explicit one - otherwise omitting the locale
+            // from the column configuration would bypass the language permission entirely.
+            $locale = $this->getImplicitReadLocale();
+
+            if ($locale === null) {
+                return true;
+            }
         }
 
         $user ??= $this->securityService->getCurrentUser();
@@ -298,8 +318,12 @@ final class GridService implements GridServiceInterface
         bool $isExport,
         ?UserInterface $user,
     ): ColumnData {
+        $isLocalizedField = $column->getLocale() === null
+            && $databaseElement !== null
+            && $this->isLocalizedClassField($databaseElement, $column->getKey());
+
         if ($databaseElement !== null
-            && !$this->isLocaleViewableForElement($databaseElement, $column->getLocale(), $user)
+            && !$this->isLocaleViewableForElement($databaseElement, $column->getLocale(), $user, $isLocalizedField)
         ) {
             return new ColumnData(
                 key: $column->getKey(),
@@ -324,6 +348,33 @@ final class GridService implements GridServiceInterface
                     CoreElementColumnResolverInterface'
                 ),
         };
+    }
+
+    /**
+     * The locale core actually reads when a localized getter is called without an explicit
+     * locale - the current request locale if it is a configured language, otherwise the
+     * default language. Mirrors Localizedfield::getLanguage().
+     */
+    private function getImplicitReadLocale(): ?string
+    {
+        $currentLocale = $this->localeService->getLocale();
+        if ($currentLocale !== null && $this->toolResolver->isValidLanguage($currentLocale)) {
+            return $currentLocale;
+        }
+
+        return $this->toolResolver->getDefaultLanguage();
+    }
+
+    private function isLocalizedClassField(ElementInterface $element, string $key): bool
+    {
+        if (!$element instanceof Concrete) {
+            return false;
+        }
+
+        $localizedFields = $element->getClass()->getFieldDefinition('localizedfields');
+
+        return $localizedFields instanceof Localizedfields
+            && $localizedFields->getFieldDefinition($key) !== null;
     }
 
     /**

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service;
 
 use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\LocalizedFieldResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Grid\GridSearchInterface;
@@ -43,6 +44,9 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
 use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\User;
 use Pimcore\Model\UserInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -82,7 +86,36 @@ final class GridService implements GridServiceInterface
         private readonly ClassDefinitionResolverInterface $classDefinitionResolver,
         private readonly LocalizedFieldResolverInterface $localizedFieldResolver,
         private readonly LoggerInterface $pimcoreLogger,
+        private readonly DataObjectServiceResolverInterface $dataObjectServiceResolver,
     ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isLocaleViewableForElement(
+        ElementInterface $element,
+        ?string $locale,
+        ?UserInterface $user = null,
+    ): bool {
+        if ($locale === null || !$element instanceof Concrete) {
+            return true;
+        }
+
+        $user ??= $this->securityService->getCurrentUser();
+
+        /** @var User $user */
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        $allowedView = $this->dataObjectServiceResolver->getLanguagePermissions($element, $user, 'lView');
+
+        if ($allowedView === null) {
+            return true;
+        }
+
+        return array_key_exists($locale, $allowedView);
     }
 
     /**
@@ -217,19 +250,30 @@ final class GridService implements GridServiceInterface
 
             $resolver = $this->getColumnResolvers()[$column->getType()];
 
-            $columnData = match (true) {
-                $databaseElement && $isExport && $user && $resolver instanceof ExportResolverInterface =>
-                    $resolver->resolveForExport($column, $databaseElement, $user),
-                $databaseElement && $resolver instanceof CoreElementColumnResolverInterface =>
-                    $resolver->resolveForCoreElement($column, $databaseElement),
-                $element !== null && $resolver instanceof StudioElementColumnResolverInterface =>
-                    $resolver->resolveForStudioElement($column, $element),
-                default =>
-                    throw new InvalidArgumentException(
-                        'Resolver must implement either StudioElementColumnResolverInterface or
-                        CoreElementColumnResolverInterface'
-                    ),
-            };
+            if ($databaseElement !== null
+                && !$this->isLocaleViewableForElement($databaseElement, $column->getLocale(), $user)
+            ) {
+                $columnData = new ColumnData(
+                    key: $column->getKey(),
+                    locale: $column->getLocale(),
+                    value: null,
+                    fieldType: $column->getType(),
+                );
+            } else {
+                $columnData = match (true) {
+                    $databaseElement && $isExport && $user && $resolver instanceof ExportResolverInterface =>
+                        $resolver->resolveForExport($column, $databaseElement, $user),
+                    $databaseElement && $resolver instanceof CoreElementColumnResolverInterface =>
+                        $resolver->resolveForCoreElement($column, $databaseElement),
+                    $element !== null && $resolver instanceof StudioElementColumnResolverInterface =>
+                        $resolver->resolveForStudioElement($column, $element),
+                    default =>
+                        throw new InvalidArgumentException(
+                            'Resolver must implement either StudioElementColumnResolverInterface or
+                            CoreElementColumnResolverInterface'
+                        ),
+                };
+            }
 
             $this->eventDispatcher->dispatch(
                 new GridColumnDataEvent($columnData),

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -248,32 +248,13 @@ final class GridService implements GridServiceInterface
                 continue;
             }
 
-            $resolver = $this->getColumnResolvers()[$column->getType()];
-
-            if ($databaseElement !== null
-                && !$this->isLocaleViewableForElement($databaseElement, $column->getLocale(), $user)
-            ) {
-                $columnData = new ColumnData(
-                    key: $column->getKey(),
-                    locale: $column->getLocale(),
-                    value: null,
-                    fieldType: $column->getType(),
-                );
-            } else {
-                $columnData = match (true) {
-                    $databaseElement && $isExport && $user && $resolver instanceof ExportResolverInterface =>
-                        $resolver->resolveForExport($column, $databaseElement, $user),
-                    $databaseElement && $resolver instanceof CoreElementColumnResolverInterface =>
-                        $resolver->resolveForCoreElement($column, $databaseElement),
-                    $element !== null && $resolver instanceof StudioElementColumnResolverInterface =>
-                        $resolver->resolveForStudioElement($column, $element),
-                    default =>
-                        throw new InvalidArgumentException(
-                            'Resolver must implement either StudioElementColumnResolverInterface or
-                            CoreElementColumnResolverInterface'
-                        ),
-                };
-            }
+            $columnData = $this->resolveColumnDataRespectingLocalePermission(
+                $column,
+                $databaseElement,
+                $element,
+                $isExport,
+                $user
+            );
 
             $this->eventDispatcher->dispatch(
                 new GridColumnDataEvent($columnData),
@@ -287,6 +268,41 @@ final class GridService implements GridServiceInterface
         }
 
         return $data;
+    }
+
+    private function resolveColumnDataRespectingLocalePermission(
+        Column $column,
+        ?ElementInterface $databaseElement,
+        ?StudioElementInterface $element,
+        bool $isExport,
+        ?UserInterface $user,
+    ): ColumnData {
+        if ($databaseElement !== null
+            && !$this->isLocaleViewableForElement($databaseElement, $column->getLocale(), $user)
+        ) {
+            return new ColumnData(
+                key: $column->getKey(),
+                locale: $column->getLocale(),
+                value: null,
+                fieldType: $column->getType(),
+            );
+        }
+
+        $resolver = $this->getColumnResolvers()[$column->getType()];
+
+        return match (true) {
+            $databaseElement && $isExport && $user && $resolver instanceof ExportResolverInterface =>
+                $resolver->resolveForExport($column, $databaseElement, $user),
+            $databaseElement && $resolver instanceof CoreElementColumnResolverInterface =>
+                $resolver->resolveForCoreElement($column, $databaseElement),
+            $element !== null && $resolver instanceof StudioElementColumnResolverInterface =>
+                $resolver->resolveForStudioElement($column, $element),
+            default =>
+                throw new InvalidArgumentException(
+                    'Resolver must implement either StudioElementColumnResolverInterface or
+                    CoreElementColumnResolverInterface'
+                ),
+        };
     }
 
     /**

--- a/src/Grid/Service/GridService.php
+++ b/src/Grid/Service/GridService.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service;
 
 use Exception;
+use Pimcore\Bundle\StaticResolverBundle\Lib\ToolResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\LocalizedFieldResolverInterface;
@@ -87,6 +88,7 @@ final class GridService implements GridServiceInterface
         private readonly LocalizedFieldResolverInterface $localizedFieldResolver,
         private readonly LoggerInterface $pimcoreLogger,
         private readonly DataObjectServiceResolverInterface $dataObjectServiceResolver,
+        private readonly ToolResolverInterface $toolResolver,
     ) {
     }
 
@@ -115,7 +117,26 @@ final class GridService implements GridServiceInterface
             return true;
         }
 
-        return array_key_exists($locale, $allowedView);
+        if (!array_key_exists($locale, $allowedView)) {
+            return false;
+        }
+
+        // An empty value for an allowed locale can silently fall back to the default language
+        // (LocalizedValueTrait::getLocalizedValue()). If that fallback language isn't permitted,
+        // the column must be treated as not viewable - otherwise a denied language's value could
+        // still leak out through the fallback.
+        if ($this->localizedFieldResolver->doGetFallbackValues()) {
+            $defaultLanguage = $this->toolResolver->getDefaultLanguage();
+            $fallbackLanguageIsDenied = $defaultLanguage !== null
+                && $defaultLanguage !== $locale
+                && !array_key_exists($defaultLanguage, $allowedView);
+
+            if ($fallbackLanguageIsDenied) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Grid/Service/GridServiceInterface.php
+++ b/src/Grid/Service/GridServiceInterface.php
@@ -43,12 +43,19 @@ interface GridServiceInterface
     /**
      * Whether the given (or, if omitted, the current) user is allowed to view the given locale
      * for the given element, based on the "Viewable Languages" workspace permission. Non-object
-     * elements and columns without a locale are always considered viewable.
+     * elements are always considered viewable.
+     *
+     * Callers reading a localized field MUST pass $isLocalizedField = true: a localized field
+     * read without an explicit locale implicitly resolves to the current request locale or the
+     * default language (Localizedfield::getLanguage()), so a null $locale is then authorized
+     * against that effective locale instead of being skipped. Only for non-localized fields
+     * ($isLocalizedField = false) does a null $locale mean no language is involved at all.
      */
     public function isLocaleViewableForElement(
         ElementInterface $element,
         ?string $locale,
         ?UserInterface $user = null,
+        bool $isLocalizedField = false,
     ): bool;
 
     /**

--- a/src/Grid/Service/GridServiceInterface.php
+++ b/src/Grid/Service/GridServiceInterface.php
@@ -28,6 +28,7 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Collection\ColumnCollection;
 use Pimcore\Bundle\StudioBackendBundle\Response\Collection;
 use Pimcore\Bundle\StudioBackendBundle\Response\StudioElementInterface;
 use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\UserInterface;
 
 /**
@@ -38,6 +39,17 @@ interface GridServiceInterface
     public function getDocumentGridColumns(): ColumnCollection;
 
     public function getDataObjectGridColumns(ClassDefinition $classDefinition): ColumnCollection;
+
+    /**
+     * Whether the given (or, if omitted, the current) user is allowed to view the given locale
+     * for the given element, based on the "Viewable Languages" workspace permission. Non-object
+     * elements and columns without a locale are always considered viewable.
+     */
+    public function isLocaleViewableForElement(
+        ElementInterface $element,
+        ?string $locale,
+        ?UserInterface $user = null,
+    ): bool;
 
     /**
      * @throws InvalidArgumentException|NotFoundException

--- a/tests/Unit/Grid/Column/Resolver/DataObject/AdvancedColumnResolverTest.php
+++ b/tests/Unit/Grid/Column/Resolver/DataObject/AdvancedColumnResolverTest.php
@@ -53,6 +53,7 @@ final class AdvancedColumnResolverTest extends Unit
             $this->makeEmpty(TransformerLoaderInterface::class, ['loadTransformers' => []]),
             $this->makeEmpty(GridServiceInterface::class, [
                 'getColumnResolvers' => ['dataobject.classificationstore' => $classificationStoreResolver],
+                'isLocaleViewableForElement' => true,
             ]),
             $this->makeEmpty(ResolverTypeGuesserInterface::class, [
                 'guessType' => 'dataobject.classificationstore',

--- a/tests/Unit/Grid/Column/Resolver/DataObject/AdvancedColumnResolverTest.php
+++ b/tests/Unit/Grid/Column/Resolver/DataObject/AdvancedColumnResolverTest.php
@@ -143,4 +143,67 @@ final class AdvancedColumnResolverTest extends Unit
 
         self::assertSame([], $result->getValue());
     }
+
+    /**
+     * A localizable sub-field that inherits a null locale from its parent column is implicitly
+     * read in the request/default locale by core. The resolver must tell the grid service that
+     * the field is localized so the implicit locale gets authorized - passing a null locale
+     * without that flag would silently skip the language permission check.
+     *
+     * @see https://pimcore.atlassian.net/browse/PEES-1063
+     */
+    public function testResolveForCoreElementFlagsLocalizableFieldWithoutExplicitLocale(): void
+    {
+        $capturedArgs = null;
+
+        $subResolver = $this->makeEmpty(CoreElementColumnResolverInterface::class, [
+            'resolveForCoreElement' => Expected::never(),
+        ]);
+
+        $resolver = new AdvancedColumnResolver(
+            $this->makeEmpty(TransformerLoaderInterface::class, ['loadTransformers' => []]),
+            $this->makeEmpty(GridServiceInterface::class, [
+                'getColumnResolvers' => ['dataobject.input' => $subResolver],
+                'isLocaleViewableForElement' => static function (
+                    $element,
+                    ?string $locale,
+                    $user = null,
+                    bool $isLocalizedField = false
+                ) use (&$capturedArgs): bool {
+                    $capturedArgs = ['locale' => $locale, 'isLocalizedField' => $isLocalizedField];
+
+                    return false;
+                },
+            ]),
+            $this->makeEmpty(ResolverTypeGuesserInterface::class, [
+                'guessType' => 'dataobject.input',
+                'isLocalizable' => true,
+            ]),
+            $this->makeEmpty(ToolResolverInterface::class),
+            $this->makeEmpty(LocalizedFieldResolverInterface::class),
+        );
+
+        $column = new Column(
+            key: 'advanced',
+            locale: null,
+            type: 'dataobject.advanced',
+            group: ['advanced'],
+            config: [
+                'advancedColumns' => [
+                    [
+                        'key' => 'simpleField',
+                        'config' => ['field' => 'name'],
+                    ],
+                ],
+                'transformers' => [],
+            ],
+        );
+
+        $element = $this->makeEmpty(Concrete::class, ['getClassId' => 'CAR']);
+
+        $result = $resolver->resolveForCoreElement($column, $element);
+
+        self::assertSame([], $result->getValue());
+        self::assertSame(['locale' => null, 'isLocalizedField' => true], $capturedArgs);
+    }
 }

--- a/tests/Unit/Grid/Column/Resolver/DataObject/AdvancedColumnResolverTest.php
+++ b/tests/Unit/Grid/Column/Resolver/DataObject/AdvancedColumnResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Column\Resolver\DataObject;
 
+use Codeception\Stub\Expected;
 use Codeception\Test\Unit;
 use Pimcore\Bundle\StaticResolverBundle\Lib\ToolResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\LocalizedFieldResolverInterface;
@@ -91,5 +92,55 @@ final class AdvancedColumnResolverTest extends Unit
         $this->assertSame('input', $values[0]->getType());
         $this->assertSame('csstore', $values[0]->getFieldName());
         $this->assertNull($values[0]->getRelation());
+    }
+
+    /**
+     * A denied locale for a simple field must skip that field entirely and never reach its
+     * sub-resolver - otherwise the "advanced" column would leak values for languages a role's
+     * "Viewable Languages" workspace permission restricts.
+     *
+     * @see https://pimcore.atlassian.net/browse/PEES-1063
+     */
+    public function testResolveForCoreElementSkipsFieldWhenLocaleNotViewable(): void
+    {
+        $subResolver = $this->makeEmpty(CoreElementColumnResolverInterface::class, [
+            'resolveForCoreElement' => Expected::never(),
+        ]);
+
+        $resolver = new AdvancedColumnResolver(
+            $this->makeEmpty(TransformerLoaderInterface::class, ['loadTransformers' => []]),
+            $this->makeEmpty(GridServiceInterface::class, [
+                'getColumnResolvers' => ['dataobject.input' => $subResolver],
+                'isLocaleViewableForElement' => false,
+            ]),
+            $this->makeEmpty(ResolverTypeGuesserInterface::class, [
+                'guessType' => 'dataobject.input',
+                'isLocalizable' => true,
+            ]),
+            $this->makeEmpty(ToolResolverInterface::class),
+            $this->makeEmpty(LocalizedFieldResolverInterface::class),
+        );
+
+        $column = new Column(
+            key: 'advanced',
+            locale: 'de',
+            type: 'dataobject.advanced',
+            group: ['advanced'],
+            config: [
+                'advancedColumns' => [
+                    [
+                        'key' => 'simpleField',
+                        'config' => ['field' => 'name'],
+                    ],
+                ],
+                'transformers' => [],
+            ],
+        );
+
+        $element = $this->makeEmpty(Concrete::class, ['getClassId' => 'CAR']);
+
+        $result = $resolver->resolveForCoreElement($column, $element);
+
+        self::assertSame([], $result->getValue());
     }
 }

--- a/tests/Unit/Grid/Service/ClassDefinitionServiceTest.php
+++ b/tests/Unit/Grid/Service/ClassDefinitionServiceTest.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Service;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ClassDefinitionService;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Layout;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\User;
+
+/**
+ * @internal
+ */
+final class ClassDefinitionServiceTest extends Unit
+{
+    /**
+     * enrichLayoutDefinition() cannot be given a Concrete $object here (the layout is
+     * class-level, not object-level), but the resolved folder/object is still the correct
+     * permission subject for "Viewable/Editable Languages" enforcement (PEES-1063). It must be
+     * handed through context['object'] instead of being silently dropped.
+     *
+     * @see https://pimcore.atlassian.net/browse/PEES-1063
+     */
+    public function testGetFilteredLayoutDefinitionsPassesResolvedObjectViaContext(): void
+    {
+        $folderId = 42;
+        $user = new User();
+        $layout = $this->makeEmpty(Layout::class);
+        $resolvedObject = $this->makeEmpty(Concrete::class);
+        $capturedContext = null;
+
+        $service = $this->createService(
+            classDefinitionResolver: $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+                'getById' => new ClassDefinition(),
+            ]),
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getCustomLayoutDefinitionForGridColumnConfig' => ['layoutDefinition' => $layout],
+                'enrichLayoutDefinition' => function (
+                    mixed $layoutArg,
+                    mixed $objectArg = null,
+                    array $context = [],
+                    mixed $userArg = null
+                ) use (&$capturedContext): void {
+                    $capturedContext = $context;
+                },
+            ]),
+            dataObjectResolver: $this->makeEmpty(DataObjectResolverInterface::class, [
+                'getById' => $resolvedObject,
+            ]),
+        );
+
+        $result = $service->getFilteredLayoutDefinitions('classId', $folderId, $user);
+
+        self::assertSame($layout, $result);
+        self::assertIsArray($capturedContext);
+        self::assertSame($resolvedObject, $capturedContext['object']);
+        self::assertSame('gridconfig', $capturedContext['purpose']);
+    }
+
+    /**
+     * A folder id of 0 (no folder context) means there is no permission subject to resolve -
+     * context['object'] must stay null rather than resolving object id 0.
+     */
+    public function testGetFilteredLayoutDefinitionsPassesNullObjectWhenFolderIdIsZero(): void
+    {
+        $layout = $this->makeEmpty(Layout::class);
+        $capturedContext = null;
+
+        $service = $this->createService(
+            classDefinitionResolver: $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+                'getById' => new ClassDefinition(),
+            ]),
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getCustomLayoutDefinitionForGridColumnConfig' => ['layoutDefinition' => $layout],
+                'enrichLayoutDefinition' => function (
+                    mixed $layoutArg,
+                    mixed $objectArg = null,
+                    array $context = [],
+                    mixed $userArg = null
+                ) use (&$capturedContext): void {
+                    $capturedContext = $context;
+                },
+            ]),
+            dataObjectResolver: $this->makeEmpty(DataObjectResolverInterface::class),
+        );
+
+        $service->getFilteredLayoutDefinitions('classId', 0, new User());
+
+        self::assertIsArray($capturedContext);
+        self::assertNull($capturedContext['object']);
+    }
+
+    private function createService(
+        ClassDefinitionResolverInterface $classDefinitionResolver,
+        DataObjectServiceResolverInterface $dataObjectServiceResolver,
+        DataObjectResolverInterface $dataObjectResolver,
+    ): ClassDefinitionService {
+        return new ClassDefinitionService(
+            $classDefinitionResolver,
+            $dataObjectServiceResolver,
+            $dataObjectResolver,
+        );
+    }
+}

--- a/tests/Unit/Grid/Service/GridServiceTest.php
+++ b/tests/Unit/Grid/Service/GridServiceTest.php
@@ -21,15 +21,22 @@ use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\LocalizedFieldResolver
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\DataObjectSearchResult;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Grid\GridSearchInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\CoreElementColumnResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\MappedParameter\GridParameter;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnCollectorLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnDefinitionLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnResolverLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\GridService;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Collection\ColumnCollection;
 use Pimcore\Bundle\StudioBackendBundle\Response\StudioElementInterface;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\User;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -206,6 +213,71 @@ final class GridServiceTest extends Unit
     }
 
     /**
+     * End-to-end wiring check for the actual grid data path: a denied locale must make
+     * getGridDataForElement() return a null value AND must never invoke the column's resolver.
+     * The isLocaleViewableForElement() unit tests above cover the permission logic in isolation,
+     * but an inversion or removal of the guard around the resolver call would not be caught by
+     * those alone.
+     *
+     * @see https://pimcore.atlassian.net/browse/PEES-1063
+     */
+    public function testGetGridDataForElementRedactsValueForDeniedLocaleAndNeverCallsResolver(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(Concrete::class);
+        $column = new Column(key: 'name', locale: 'de', type: 'dataobject.input', group: null, config: []);
+
+        // A plain implementation (rather than a mocked interface) so it can implement both
+        // ColumnResolverInterface and CoreElementColumnResolverInterface, exactly like a real
+        // column resolver does, and track whether it was actually invoked.
+        $deniedResolver = new class implements ColumnResolverInterface, CoreElementColumnResolverInterface {
+            public bool $wasCalled = false;
+
+            public function getType(): string
+            {
+                return 'dataobject.input';
+            }
+
+            public function supportedElementTypes(): array
+            {
+                return [ElementTypes::TYPE_OBJECT];
+            }
+
+            public function resolveForCoreElement(Column $column, ElementInterface $element): ColumnData
+            {
+                $this->wasCalled = true;
+
+                return new ColumnData(key: 'name', locale: $column->getLocale(), value: 'LEAKED', fieldType: 'input');
+            }
+        };
+
+        $service = $this->createService(
+            serviceResolver: $this->makeEmpty(ServiceResolverInterface::class, [
+                'getElementById' => $element,
+            ]),
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => ['en' => 1],
+            ]),
+            securityService: $this->makeEmpty(SecurityServiceInterface::class),
+            columnResolverLoader: $this->makeEmpty(ColumnResolverLoaderInterface::class, [
+                'loadColumnResolvers' => ['dataobject.input' => $deniedResolver],
+            ]),
+        );
+
+        $data = $service->getGridDataForElement(
+            new ColumnCollection([$column]),
+            null,
+            ElementTypes::TYPE_OBJECT,
+            1,
+            false,
+            $user,
+        );
+
+        self::assertNull($data['columns'][0]->getValue());
+        self::assertFalse($deniedResolver->wasCalled, 'the resolver must not be invoked for a denied locale');
+    }
+
+    /**
      * User is final and cannot be doubled - a real instance with just the admin flag set is
      * enough for the permission checks under test here.
      */
@@ -223,10 +295,11 @@ final class GridServiceTest extends Unit
         ?LoggerInterface $logger = null,
         ?DataObjectServiceResolverInterface $dataObjectServiceResolver = null,
         ?SecurityServiceInterface $securityService = null,
+        ?ColumnResolverLoaderInterface $columnResolverLoader = null,
     ): GridService {
         return new GridService(
             $this->makeEmpty(ColumnDefinitionLoaderInterface::class),
-            $this->makeEmpty(ColumnResolverLoaderInterface::class),
+            $columnResolverLoader ?? $this->makeEmpty(ColumnResolverLoaderInterface::class),
             $this->makeEmpty(ColumnCollectorLoaderInterface::class),
             $gridSearch ?? $this->makeEmpty(GridSearchInterface::class),
             $this->makeEmpty(EventDispatcherInterface::class),

--- a/tests/Unit/Grid/Service/GridServiceTest.php
+++ b/tests/Unit/Grid/Service/GridServiceTest.php
@@ -35,7 +35,11 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Util\Collection\ColumnCollection;
 use Pimcore\Bundle\StudioBackendBundle\Response\StudioElementInterface;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Localization\LocaleServiceInterface;
 use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\User;
@@ -217,9 +221,10 @@ final class GridServiceTest extends Unit
     }
 
     /**
-     * Columns without a locale (e.g. system columns) are never subject to language filtering.
+     * Non-localized columns without a locale (e.g. system columns) carry no language data
+     * and are never subject to language filtering.
      */
-    public function testIsLocaleViewableForElementReturnsTrueWhenColumnHasNoLocale(): void
+    public function testIsLocaleViewableForElementReturnsTrueWhenNonLocalizedColumnHasNoLocale(): void
     {
         $user = $this->buildUser(isAdmin: false);
         $element = $this->makeEmpty(Concrete::class);
@@ -230,7 +235,92 @@ final class GridServiceTest extends Unit
             ]),
         );
 
-        self::assertTrue($service->isLocaleViewableForElement($element, null, $user));
+        self::assertTrue($service->isLocaleViewableForElement($element, null, $user, isLocalizedField: false));
+    }
+
+    /**
+     * A localized field read without an explicit locale is implicitly served in the current
+     * request locale (Localizedfield::getLanguage()). Omitting the locale from the column
+     * configuration must therefore authorize that effective locale - otherwise a user
+     * restricted to e.g. "fr" could read another language's value by simply leaving the
+     * locale out of the client-supplied column config.
+     *
+     * @see https://pimcore.atlassian.net/browse/PEES-1063
+     */
+    public function testIsLocaleViewableForElementChecksImplicitRequestLocaleForLocalizedField(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(Concrete::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => ['fr' => 1],
+            ]),
+            toolResolver: $this->makeEmpty(ToolResolverInterface::class, [
+                'isValidLanguage' => true,
+            ]),
+            localeService: $this->makeEmpty(LocaleServiceInterface::class, [
+                'getLocale' => 'de',
+            ]),
+        );
+
+        self::assertFalse($service->isLocaleViewableForElement($element, null, $user, isLocalizedField: true));
+    }
+
+    /**
+     * Without a (valid) request locale, core resolves an implicit read to the default
+     * language - that language must be authorized as well.
+     */
+    public function testIsLocaleViewableForElementChecksImplicitDefaultLanguageForLocalizedField(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(Concrete::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => ['fr' => 1],
+            ]),
+            toolResolver: $this->makeEmpty(ToolResolverInterface::class, [
+                'isValidLanguage' => false,
+                'getDefaultLanguage' => 'de',
+            ]),
+        );
+
+        self::assertFalse($service->isLocaleViewableForElement($element, null, $user, isLocalizedField: true));
+
+        $allowedService = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => ['de' => 1],
+            ]),
+            toolResolver: $this->makeEmpty(ToolResolverInterface::class, [
+                'isValidLanguage' => false,
+                'getDefaultLanguage' => 'de',
+            ]),
+        );
+
+        self::assertTrue($allowedService->isLocaleViewableForElement($element, null, $user, isLocalizedField: true));
+    }
+
+    /**
+     * When no implicit locale can be resolved at all (no request locale, no default language
+     * configured), there is no language to authorize and the value stays viewable.
+     */
+    public function testIsLocaleViewableForElementReturnsTrueForLocalizedFieldWithoutResolvableLocale(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(Concrete::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => Expected::never(),
+            ]),
+            toolResolver: $this->makeEmpty(ToolResolverInterface::class, [
+                'isValidLanguage' => false,
+                'getDefaultLanguage' => null,
+            ]),
+        );
+
+        self::assertTrue($service->isLocaleViewableForElement($element, null, $user, isLocalizedField: true));
     }
 
     /**
@@ -338,6 +428,91 @@ final class GridServiceTest extends Unit
     }
 
     /**
+     * The client controls the column configuration, so it can simply omit the locale for a
+     * localized field: the resolver then calls the bare getter and core implicitly serves the
+     * request locale or the default language. The grid data path must detect that the column
+     * targets a localized field and authorize the implicit locale - otherwise the explicit-locale
+     * guard above is trivially bypassed.
+     *
+     * @see https://pimcore.atlassian.net/browse/PEES-1063
+     */
+    public function testGetGridDataForElementRedactsLocalizedFieldColumnWithoutExplicitLocale(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+
+        // "name" is a localized class field: not a direct field definition, but present inside
+        // the localizedfields container - exactly how core resolves an implicit localized read.
+        $localizedFields = $this->makeEmpty(Localizedfields::class, [
+            'getFieldDefinition' => $this->makeEmpty(Data::class),
+        ]);
+        // ClassDefinition is final and cannot be doubled - a real instance seeded through
+        // addFieldDefinition() behaves exactly like a loaded definition for this lookup.
+        $classDefinition = new ClassDefinition();
+        $classDefinition->addFieldDefinition('localizedfields', $localizedFields);
+        $element = $this->makeEmpty(Concrete::class, [
+            'getClass' => $classDefinition,
+        ]);
+
+        $column = new Column(key: 'name', locale: null, type: 'dataobject.input', group: null, config: []);
+
+        $deniedResolver = new class implements ColumnResolverInterface, CoreElementColumnResolverInterface {
+            public bool $wasCalled = false;
+
+            public function getType(): string
+            {
+                return 'dataobject.input';
+            }
+
+            public function supportedElementTypes(): array
+            {
+                return [ElementTypes::TYPE_OBJECT];
+            }
+
+            public function resolveForCoreElement(Column $column, ElementInterface $element): ColumnData
+            {
+                $this->wasCalled = true;
+
+                return new ColumnData(key: 'name', locale: $column->getLocale(), value: 'LEAKED', fieldType: 'input');
+            }
+        };
+
+        $service = $this->createService(
+            serviceResolver: $this->makeEmpty(ServiceResolverInterface::class, [
+                'getElementById' => $element,
+            ]),
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => ['fr' => 1],
+            ]),
+            securityService: $this->makeEmpty(SecurityServiceInterface::class),
+            columnResolverLoader: $this->makeEmpty(ColumnResolverLoaderInterface::class, [
+                'loadColumnResolvers' => ['dataobject.input' => $deniedResolver],
+            ]),
+            toolResolver: $this->makeEmpty(ToolResolverInterface::class, [
+                'isValidLanguage' => true,
+            ]),
+            localeService: $this->makeEmpty(LocaleServiceInterface::class, [
+                // The implicit read locale "de" is not among the user's viewable languages.
+                'getLocale' => 'de',
+            ]),
+        );
+
+        $data = $service->getGridDataForElement(
+            new ColumnCollection([$column]),
+            null,
+            ElementTypes::TYPE_OBJECT,
+            1,
+            false,
+            $user,
+        );
+
+        self::assertNull($data['columns'][0]->getValue());
+        self::assertFalse(
+            $deniedResolver->wasCalled,
+            'the resolver must not be invoked when the implicit locale of a localized field is denied'
+        );
+    }
+
+    /**
      * User is final and cannot be doubled - a real instance with just the admin flag set is
      * enough for the permission checks under test here.
      */
@@ -358,6 +533,7 @@ final class GridServiceTest extends Unit
         ?ColumnResolverLoaderInterface $columnResolverLoader = null,
         ?LocalizedFieldResolverInterface $localizedFieldResolver = null,
         ?ToolResolverInterface $toolResolver = null,
+        ?LocaleServiceInterface $localeService = null,
     ): GridService {
         return new GridService(
             $this->makeEmpty(ColumnDefinitionLoaderInterface::class),
@@ -372,6 +548,7 @@ final class GridServiceTest extends Unit
             $logger ?? $this->makeEmpty(LoggerInterface::class),
             $dataObjectServiceResolver ?? $this->makeEmpty(DataObjectServiceResolverInterface::class),
             $toolResolver ?? $this->makeEmpty(ToolResolverInterface::class),
+            $localeService ?? $this->makeEmpty(LocaleServiceInterface::class),
         );
     }
 }

--- a/tests/Unit/Grid/Service/GridServiceTest.php
+++ b/tests/Unit/Grid/Service/GridServiceTest.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Service;
 use Codeception\Stub\Expected;
 use Codeception\Test\Unit;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\LocalizedFieldResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\DataObjectSearchResult;
@@ -28,6 +29,8 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Service\GridService;
 use Pimcore\Bundle\StudioBackendBundle\Response\StudioElementInterface;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\User;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -84,10 +87,142 @@ final class GridServiceTest extends Unit
         $this->assertSame(2, $result->getTotalItems());
     }
 
+    /**
+     * A non-admin user restricted to "en" for viewing must not receive values for other
+     * locales, regardless of which column resolver would have produced them.
+     *
+     * @see https://pimcore.atlassian.net/browse/PEES-1063
+     */
+    public function testIsLocaleViewableForElementReturnsFalseWhenLocaleNotAllowed(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(Concrete::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => ['en' => 1],
+            ]),
+            securityService: $this->makeEmpty(SecurityServiceInterface::class, [
+                'getCurrentUser' => $user,
+            ]),
+        );
+
+        self::assertFalse($service->isLocaleViewableForElement($element, 'de', $user));
+        self::assertTrue($service->isLocaleViewableForElement($element, 'en', $user));
+    }
+
+    /**
+     * No workspace language restriction configured (null permission set) means every locale
+     * stays viewable - this mirrors the pre-existing Object Editor behaviour.
+     */
+    public function testIsLocaleViewableForElementReturnsTrueWhenNoRestrictionConfigured(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(Concrete::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => null,
+            ]),
+            securityService: $this->makeEmpty(SecurityServiceInterface::class, [
+                'getCurrentUser' => $user,
+            ]),
+        );
+
+        self::assertTrue($service->isLocaleViewableForElement($element, 'de', $user));
+    }
+
+    /**
+     * Admins are exempt from language-view restrictions.
+     */
+    public function testIsLocaleViewableForElementReturnsTrueForAdminUser(): void
+    {
+        $user = $this->buildUser(isAdmin: true);
+        $element = $this->makeEmpty(Concrete::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => Expected::never(),
+            ]),
+        );
+
+        self::assertTrue($service->isLocaleViewableForElement($element, 'de', $user));
+    }
+
+    /**
+     * Columns without a locale (e.g. system columns) are never subject to language filtering.
+     */
+    public function testIsLocaleViewableForElementReturnsTrueWhenColumnHasNoLocale(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(Concrete::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => Expected::never(),
+            ]),
+        );
+
+        self::assertTrue($service->isLocaleViewableForElement($element, null, $user));
+    }
+
+    /**
+     * Only concrete data objects carry per-locale workspace permissions; other element types
+     * (assets, documents) are unaffected by this check.
+     */
+    public function testIsLocaleViewableForElementReturnsTrueForNonDataObjectElements(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(AbstractObject::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => Expected::never(),
+            ]),
+        );
+
+        self::assertTrue($service->isLocaleViewableForElement($element, 'de', $user));
+    }
+
+    /**
+     * When no user is passed explicitly, the current session user is resolved and used for
+     * the permission check - this is what the default grid-browsing path relies on.
+     */
+    public function testIsLocaleViewableForElementFallsBackToCurrentUser(): void
+    {
+        $currentUser = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(Concrete::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => ['en' => 1],
+            ]),
+            securityService: $this->makeEmpty(SecurityServiceInterface::class, [
+                'getCurrentUser' => $currentUser,
+            ]),
+        );
+
+        self::assertFalse($service->isLocaleViewableForElement($element, 'de'));
+    }
+
+    /**
+     * User is final and cannot be doubled - a real instance with just the admin flag set is
+     * enough for the permission checks under test here.
+     */
+    private function buildUser(bool $isAdmin): User
+    {
+        $user = new User();
+        $user->setAdmin($isAdmin);
+
+        return $user;
+    }
+
     private function createService(
         ?GridSearchInterface $gridSearch = null,
         ?ServiceResolverInterface $serviceResolver = null,
         ?LoggerInterface $logger = null,
+        ?DataObjectServiceResolverInterface $dataObjectServiceResolver = null,
+        ?SecurityServiceInterface $securityService = null,
     ): GridService {
         return new GridService(
             $this->makeEmpty(ColumnDefinitionLoaderInterface::class),
@@ -95,11 +230,12 @@ final class GridServiceTest extends Unit
             $this->makeEmpty(ColumnCollectorLoaderInterface::class),
             $gridSearch ?? $this->makeEmpty(GridSearchInterface::class),
             $this->makeEmpty(EventDispatcherInterface::class),
-            $this->makeEmpty(SecurityServiceInterface::class),
+            $securityService ?? $this->makeEmpty(SecurityServiceInterface::class),
             $serviceResolver ?? $this->makeEmpty(ServiceResolverInterface::class),
             $this->makeEmpty(ClassDefinitionResolverInterface::class),
             $this->makeEmpty(LocalizedFieldResolverInterface::class),
             $logger ?? $this->makeEmpty(LoggerInterface::class),
+            $dataObjectServiceResolver ?? $this->makeEmpty(DataObjectServiceResolverInterface::class),
         );
     }
 }

--- a/tests/Unit/Grid/Service/GridServiceTest.php
+++ b/tests/Unit/Grid/Service/GridServiceTest.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Service;
 
 use Codeception\Stub\Expected;
 use Codeception\Test\Unit;
+use Pimcore\Bundle\StaticResolverBundle\Lib\ToolResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\DataObjectServiceResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\LocalizedFieldResolverInterface;
@@ -115,6 +116,65 @@ final class GridServiceTest extends Unit
         );
 
         self::assertFalse($service->isLocaleViewableForElement($element, 'de', $user));
+        self::assertTrue($service->isLocaleViewableForElement($element, 'en', $user));
+    }
+
+    /**
+     * An allowed locale with an empty value can silently fall back to the default language
+     * (LocalizedValueTrait::getLocalizedValue()). If that fallback language is not itself
+     * permitted, the column must be denied - otherwise a restricted language's value could leak
+     * out through the fallback even though the requested locale was legitimately allowed.
+     *
+     * @see https://pimcore.atlassian.net/browse/PEES-1063
+     */
+    public function testIsLocaleViewableForElementReturnsFalseWhenFallbackLanguageIsDenied(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(Concrete::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                // Only "en" is allowed - "de" (the system default language) is not.
+                'getLanguagePermissions' => ['en' => 1],
+            ]),
+            securityService: $this->makeEmpty(SecurityServiceInterface::class, [
+                'getCurrentUser' => $user,
+            ]),
+            localizedFieldResolver: $this->makeEmpty(LocalizedFieldResolverInterface::class, [
+                'doGetFallbackValues' => true,
+            ]),
+            toolResolver: $this->makeEmpty(ToolResolverInterface::class, [
+                'getDefaultLanguage' => 'de',
+            ]),
+        );
+
+        self::assertFalse($service->isLocaleViewableForElement($element, 'en', $user));
+    }
+
+    /**
+     * When fallback is enabled but the default language is itself allowed (or is the same as
+     * the requested locale), there is no additional exposure and the column stays viewable.
+     */
+    public function testIsLocaleViewableForElementReturnsTrueWhenFallbackLanguageIsAllowed(): void
+    {
+        $user = $this->buildUser(isAdmin: false);
+        $element = $this->makeEmpty(Concrete::class);
+
+        $service = $this->createService(
+            dataObjectServiceResolver: $this->makeEmpty(DataObjectServiceResolverInterface::class, [
+                'getLanguagePermissions' => ['en' => 1, 'de' => 1],
+            ]),
+            securityService: $this->makeEmpty(SecurityServiceInterface::class, [
+                'getCurrentUser' => $user,
+            ]),
+            localizedFieldResolver: $this->makeEmpty(LocalizedFieldResolverInterface::class, [
+                'doGetFallbackValues' => true,
+            ]),
+            toolResolver: $this->makeEmpty(ToolResolverInterface::class, [
+                'getDefaultLanguage' => 'de',
+            ]),
+        );
+
         self::assertTrue($service->isLocaleViewableForElement($element, 'en', $user));
     }
 
@@ -296,6 +356,8 @@ final class GridServiceTest extends Unit
         ?DataObjectServiceResolverInterface $dataObjectServiceResolver = null,
         ?SecurityServiceInterface $securityService = null,
         ?ColumnResolverLoaderInterface $columnResolverLoader = null,
+        ?LocalizedFieldResolverInterface $localizedFieldResolver = null,
+        ?ToolResolverInterface $toolResolver = null,
     ): GridService {
         return new GridService(
             $this->makeEmpty(ColumnDefinitionLoaderInterface::class),
@@ -306,9 +368,10 @@ final class GridServiceTest extends Unit
             $securityService ?? $this->makeEmpty(SecurityServiceInterface::class),
             $serviceResolver ?? $this->makeEmpty(ServiceResolverInterface::class),
             $this->makeEmpty(ClassDefinitionResolverInterface::class),
-            $this->makeEmpty(LocalizedFieldResolverInterface::class),
+            $localizedFieldResolver ?? $this->makeEmpty(LocalizedFieldResolverInterface::class),
             $logger ?? $this->makeEmpty(LoggerInterface::class),
             $dataObjectServiceResolver ?? $this->makeEmpty(DataObjectServiceResolverInterface::class),
+            $toolResolver ?? $this->makeEmpty(ToolResolverInterface::class),
         );
     }
 }


### PR DESCRIPTION
## Summary
- The grid data-serving path never checked a role's "Viewable Languages" workspace permission, so a user restricted to e.g. EN/DE could still see (and, via the advanced column's relation resolution, discover) values for any other language directly from GridView - unlike the Object Editor, which already enforces this.
- Added `GridServiceInterface::isLocaleViewableForElement()`, backed by the existing `lView` language-permission resolver (already used elsewhere for edit-time enforcement), and wired it into the two places grid values are produced for a locale-bound column:
  - `GridService::getGridDataForElement()` - the main per-column resolution path used by both the grid listing and export/`getGridValuesForElement`.
  - `AdvancedColumnResolver` - the "advanced" composite column resolves simple and relation sub-fields directly against sub-resolvers, bypassing `GridService`'s own column loop.
- Non-admin users without view permission for a column's locale get a redacted/omitted value instead of the resolver's real output. Admins and unrestricted workspaces are unaffected.
- The check authorizes the *effective* locale, not just the client-supplied one: a localized field whose column config omits the locale is implicitly read in the request locale or default language (`Localizedfield::getLanguage()`), so that locale is checked instead of skipping the guard; and when fallback languages are enabled, a denied default language blocks the fallback path too. Non-localized columns without a locale remain unaffected.

Scope note: grid *column-configuration* filtering (which language columns are even offered for configuration) is not addressed here - it's blocked by a core API that requires a concrete object rather than a folder ID, which Studio's config endpoint doesn't have. This PR closes the actual data leak (values shown/editable for restricted languages) regardless of which columns are configurable.

Related: https://pimcore.atlassian.net/browse/PEES-1063
Companion fix in pimcore/pimcore: pimcore/pimcore#19322

## Test plan
- [x] Added unit tests in `tests/Unit/Grid/Service/GridServiceTest.php` covering `isLocaleViewableForElement()`: locale not allowed, no restriction configured, admin bypass, no-locale columns, non-object elements, current-user fallback, the implicit request-locale/default-language paths for localized fields, and an end-to-end grid-data test asserting the resolver is never invoked when the implicit locale is denied.
- [x] Updated `tests/Unit/Grid/Column/Resolver/DataObject/AdvancedColumnResolverTest.php`'s mock for the new dependency and added a test that localizable sub-fields without an explicit locale flag their localizability to the permission check.
- [x] Full `vendor/bin/codecept run Unit` suite passes (454 tests, 1023 assertions).
- [x] `vendor/bin/phpstan analyse` clean on all changed files.

Co-Authored-By: Claude <noreply@anthropic.com>
