### PR TITLE
Fix: predefined property create/update 404 on read-back (#152)

### DIFF
--- a/src/Property/Controller/UpdateController.php
+++ b/src/Property/Controller/UpdateController.php
@@ -72,8 +72,6 @@ final class UpdateController extends AbstractApiController
         string $id,
         #[MapRequestPayload] UpdatePredefinedProperty $updatePredefinedProperty
     ): JsonResponse {
-        $this->propertyService->updatePredefinedProperty($id, $updatePredefinedProperty);
-
-        return $this->jsonResponse($this->propertyService->getPredefinedProperty($id));
+        return $this->jsonResponse($this->propertyService->updatePredefinedProperty($id, $updatePredefinedProperty));
     }
 }

--- a/src/Property/Repository/PropertyRepository.php
+++ b/src/Property/Repository/PropertyRepository.php
@@ -101,7 +101,7 @@ final readonly class PropertyRepository implements PropertyRepositoryInterface
     /**
      * @throws NotFoundException
      */
-    public function updatePredefinedProperty(string $id, UpdatePredefinedProperty $property): void
+    public function updatePredefinedProperty(string $id, UpdatePredefinedProperty $property): Predefined
     {
         $predefined = $this->getPredefinedProperty($id);
 
@@ -115,6 +115,8 @@ final readonly class PropertyRepository implements PropertyRepositoryInterface
         $predefined->setInheritable($property->isInheritable());
 
         $predefined->save();
+
+        return $predefined;
     }
 
     /**

--- a/src/Property/Repository/PropertyRepositoryInterface.php
+++ b/src/Property/Repository/PropertyRepositoryInterface.php
@@ -45,7 +45,7 @@ interface PropertyRepositoryInterface
     /**
      * @throws NotFoundException
      */
-    public function updatePredefinedProperty(string $id, UpdatePredefinedProperty $property): void;
+    public function updatePredefinedProperty(string $id, UpdatePredefinedProperty $property): Predefined;
 
     /**
      * @throws NotFoundException

--- a/src/Property/Service/PropertyService.php
+++ b/src/Property/Service/PropertyService.php
@@ -51,8 +51,14 @@ final readonly class PropertyService implements PropertyServiceInterface
     public function createPredefinedProperty(): PredefinedProperty
     {
         $predefined = $this->propertyRepository->createPredefinedProperty();
+        $predefinedProperty = $this->propertyHydrator->hydratePredefinedProperty($predefined);
 
-        return $this->getPredefinedProperty($predefined->getId());
+        $this->eventDispatcher->dispatch(
+            new PredefinedPropertyEvent($predefinedProperty),
+            PredefinedPropertyEvent::EVENT_NAME
+        );
+
+        return $predefinedProperty;
     }
 
     /**

--- a/src/Property/Service/PropertyService.php
+++ b/src/Property/Service/PropertyService.php
@@ -137,9 +137,17 @@ final readonly class PropertyService implements PropertyServiceInterface
     /**
      * @throws NotFoundException
      */
-    public function updatePredefinedProperty(string $id, UpdatePredefinedProperty $property): void
+    public function updatePredefinedProperty(string $id, UpdatePredefinedProperty $property): PredefinedProperty
     {
-        $this->propertyRepository->updatePredefinedProperty($id, $property);
+        $predefined = $this->propertyRepository->updatePredefinedProperty($id, $property);
+        $predefinedProperty = $this->propertyHydrator->hydratePredefinedProperty($predefined);
+
+        $this->eventDispatcher->dispatch(
+            new PredefinedPropertyEvent($predefinedProperty),
+            PredefinedPropertyEvent::EVENT_NAME
+        );
+
+        return $predefinedProperty;
     }
 
     /**

--- a/src/Property/Service/PropertyServiceInterface.php
+++ b/src/Property/Service/PropertyServiceInterface.php
@@ -51,7 +51,7 @@ interface PropertyServiceInterface
     /**
      * @throws NotFoundException
      */
-    public function updatePredefinedProperty(string $id, UpdatePredefinedProperty $property): void;
+    public function updatePredefinedProperty(string $id, UpdatePredefinedProperty $property): PredefinedProperty;
 
     /**
      * @throws NotFoundException

--- a/tests/Unit/Property/Service/PropertyServiceTest.php
+++ b/tests/Unit/Property/Service/PropertyServiceTest.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Property\Service;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\Property\Predefined\PredefinedResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Property\Hydrator\PropertyHydrator;
+use Pimcore\Bundle\StudioBackendBundle\Property\Hydrator\PropertyHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\Property\Repository\PropertyRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Property\Schema\UpdatePredefinedProperty;
+use Pimcore\Bundle\StudioBackendBundle\Property\Service\PropertyService;
+use Pimcore\Bundle\StudioBackendBundle\Resolver\Element\ReferenceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Model\Property\Predefined;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+final class PropertyServiceTest extends Unit
+{
+    /**
+     * @throws Exception
+     */
+    public function testCreatePredefinedPropertyHydratesRepositoryResultDirectly(): void
+    {
+        $predefined = $this->getPredefined();
+
+        $repository = $this->makeEmpty(PropertyRepositoryInterface::class, [
+            'createPredefinedProperty' => $predefined,
+            'getPredefinedProperty' => Expected::never(),
+        ]);
+
+        $eventDispatcher = $this->makeEmpty(EventDispatcherInterface::class, [
+            'dispatch' => Expected::once(static fn (object $event): object => $event),
+        ]);
+
+        $service = $this->createService(repository: $repository, eventDispatcher: $eventDispatcher);
+
+        $result = $service->createPredefinedProperty();
+
+        $this->assertSame('new_id', $result->getId());
+        $this->assertSame('New Description', $result->getDescription());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testUpdatePredefinedPropertyHydratesRepositoryResultDirectly(): void
+    {
+        $predefined = $this->getPredefined();
+        $predefined->setDescription('Updated Description');
+
+        $repository = $this->makeEmpty(PropertyRepositoryInterface::class, [
+            'updatePredefinedProperty' => $predefined,
+            'getPredefinedProperty' => Expected::never(),
+        ]);
+
+        $eventDispatcher = $this->makeEmpty(EventDispatcherInterface::class, [
+            'dispatch' => Expected::once(static fn (object $event): object => $event),
+        ]);
+
+        $service = $this->createService(repository: $repository, eventDispatcher: $eventDispatcher);
+
+        $result = $service->updatePredefinedProperty('new_id', $this->getUpdatePayload());
+
+        $this->assertSame('new_id', $result->getId());
+        $this->assertSame('Updated Description', $result->getDescription());
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createService(
+        ?PropertyRepositoryInterface $repository = null,
+        ?PropertyHydratorInterface $hydrator = null,
+        ?SecurityServiceInterface $securityService = null,
+        ?ServiceResolverInterface $serviceResolver = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+    ): PropertyService {
+        return new PropertyService(
+            $repository ?? $this->makeEmpty(PropertyRepositoryInterface::class),
+            $hydrator ?? $this->realHydrator(),
+            $securityService ?? $this->makeEmpty(SecurityServiceInterface::class),
+            $serviceResolver ?? $this->makeEmpty(ServiceResolverInterface::class),
+            $eventDispatcher ?? $this->makeEmpty(EventDispatcherInterface::class),
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function realHydrator(): PropertyHydratorInterface
+    {
+        return new PropertyHydrator(
+            $this->makeEmpty(PredefinedResolverInterface::class),
+            $this->makeEmpty(ReferenceResolverInterface::class)
+        );
+    }
+
+    private function getPredefined(): Predefined
+    {
+        $property = new Predefined();
+        $property->setId('new_id');
+        $property->setCtype(ElementTypes::TYPE_DOCUMENT);
+        $property->setName('New Property');
+        $property->setKey('new_key');
+        $property->setType('text');
+        $property->setCreationDate(time());
+        $property->setModificationDate(time());
+        $property->setInheritable(true);
+        $property->setDescription('New Description');
+
+        return $property;
+    }
+
+    private function getUpdatePayload(): UpdatePredefinedProperty
+    {
+        return new UpdatePredefinedProperty(
+            'New Property',
+            'Updated Description',
+            'new_key',
+            'text',
+            null,
+            null,
+            ElementTypes::TYPE_DOCUMENT,
+            true
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Predefined property create and update both saved successfully but then 404'd, because the controllers immediately re-fetched the property by ID through `getPredefinedProperty()`, which reads via `LocationAwareConfigRepository`. With `write_target: symfony-config`, that read only ever sees `containerConfig` (compiled at container boot) or `SettingsStore` — never the YAML file just written to disk — so the read-back missed in the same request.
- Both `PropertyRepository::createPredefinedProperty()` and `updatePredefinedProperty()` already have the fully populated `Predefined` model in memory after `save()`, so the service/controller now hydrate and return that directly instead of round-tripping through a fresh lookup.
- `updatePredefinedProperty()` on the repository/service interfaces now returns the saved `Predefined`/`PredefinedProperty` instead of `void`, so `UpdateController` no longer needs a second `getPredefinedProperty()` call.
- Added `PropertyServiceTest` covering both the create and update paths, asserting `getPredefinedProperty()` is never called during either flow — this would have caught the regression.

resolves https://github.com/pimcore/platform-version/issues/152

## Test plan
- [x] `composer install` in the bundle, ran the full Codeception `Unit` suite: 472 tests / 1090 assertions passing, no regressions
- [x] New `PropertyServiceTest` (4 assertions across create/update) passes
- [x] `php -l` on all modified files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>