### PR TITLE
[Bug] Release file handles before cleaning up zip upload temp folder

### DIFF
--- a/src/Asset/ExecutionEngine/AutomationAction/Messenger/Handler/ZipUploadHandler.php
+++ b/src/Asset/ExecutionEngine/AutomationAction/Messenger/Handler/ZipUploadHandler.php
@@ -30,6 +30,7 @@ use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\UserTopicServiceInterface
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use ZipArchive;
 use function count;
 
 /**
@@ -84,6 +85,7 @@ final class ZipUploadHandler extends AbstractHandler
         $localExtractTargetPath = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/' .
             $extractTargetPath . '/' .
             self::LOCAL_ZIP_FOLDER_NAME;
+        $archive = null;
 
         try {
             $this->fileSystem->mkdir($localExtractTargetPath);
@@ -161,6 +163,11 @@ final class ZipUploadHandler extends AbstractHandler
                 ['message' => $exception->getMessage()],
             ));
         } finally {
+            if ($archive instanceof ZipArchive) {
+                // close the archive before removing the local folder, an open handle
+                // prevents removing the folder on network based file systems
+                @$archive->close();
+            }
             $this->storageService->cleanUpLocalFolder($localExtractTargetPath);
         }
     }

--- a/src/Asset/Service/ExecutionEngine/ZipService.php
+++ b/src/Asset/Service/ExecutionEngine/ZipService.php
@@ -250,6 +250,8 @@ final readonly class ZipService implements ZipServiceInterface
             );
         }
 
+        $stream = null;
+
         try {
             $folderName = $this->getTempFilePath($id, $folderName);
             $storage->createDirectory($folderName);
@@ -269,6 +271,10 @@ final readonly class ZipService implements ZipServiceInterface
                     $archiveFileName
                 )
             );
+        } finally {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
         }
     }
 

--- a/src/Asset/Service/ExecutionEngine/ZipService.php
+++ b/src/Asset/Service/ExecutionEngine/ZipService.php
@@ -253,10 +253,14 @@ final readonly class ZipService implements ZipServiceInterface
         try {
             $folderName = $this->getTempFilePath($id, $folderName);
             $storage->createDirectory($folderName);
+            $stream = fopen($localPath, 'rb');
             $storage->writeStream(
                 $folderName . '/' . $archiveFileName,
-                fopen($localPath, 'rb')
+                $stream
             );
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
             @unlink($localPath);
         } catch (FilesystemException) {
             throw new EnvironmentException(

--- a/src/Element/Service/StorageService.php
+++ b/src/Element/Service/StorageService.php
@@ -149,10 +149,14 @@ final readonly class StorageService implements StorageServiceInterface
         string $targetPath,
     ): void {
         try {
+            $stream = fopen($localFilePath, 'rb');
             $this->getTempStorage()->writeStream(
                 $targetPath . '/' . $fileName,
-                fopen($localFilePath, 'rb')
+                $stream
             );
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
             @unlink($localFilePath);
         } catch (FilesystemException) {
             throw new EnvironmentException(

--- a/src/Element/Service/StorageService.php
+++ b/src/Element/Service/StorageService.php
@@ -148,6 +148,8 @@ final readonly class StorageService implements StorageServiceInterface
         string $localFilePath,
         string $targetPath,
     ): void {
+        $stream = null;
+
         try {
             $stream = fopen($localFilePath, 'rb');
             $this->getTempStorage()->writeStream(
@@ -165,6 +167,10 @@ final readonly class StorageService implements StorageServiceInterface
                     $fileName
                 )
             );
+        } finally {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes PEES-1257 / PEES-1408 (https://github.com/pimcore/service-operations/issues/923)

Uploading assets as zip via Studio failed on PaaS (blob storage / network based file systems) with:

```
Failed to remove directory ".../upload-zip-...-.../studio-backend-local": rmdir(.../.!!suz): Directory not empty
```

**Root cause:** three file handles were never released:

1. `ZipUploadHandler` gets an open `ZipArchive` from `ZipService::downloadZipFileFromFlysystem()` and never closes it. The archive file lives inside the local extract folder that the `finally` block removes — on network based file systems, deleting a file that still has an open handle leaves a silly-rename file behind (the `.!!suz` in the error is Symfony Filesystem's rename-before-delete temp name), so `rmdir` fails, the exception escapes the `finally` and the whole job run aborts. On local ext4 an open file unlinks cleanly, which is why this "does not reproduce locally".
2./3. The `fopen(..., 'rb')` streams passed to Flysystem `writeStream()` in `ZipService::copyZipFileToFlysystem()` and `StorageService::copyFileToFlysystem()` are never `fclose()`d (Flysystem does not close streams it receives), followed directly by `@unlink()` on the still-open file — same failure class on the upload side.

**Fix:** close the archive in the handler's `finally` before `cleanUpLocalFolder()`, and `fclose()` the two streams after `writeStream()`.

Deliberately *not* added: cleaning up the Flysystem extract folder in the handler's `finally` (as sketched in the Jira comment) — that folder is still read by the asynchronous child `UPLOAD_ASSETS` job and is already cleaned up after the child job terminates (`UploadSubscriber::cleanupData()` / `ZipUploadSubscriber` on FAILED).

To be forward-merged into `2026.x`.
