### PR TITLE
[Symfony 8] Replace deprecated #[TaggedIterator] with #[AutowireIterator]

### DIFF
--- a/.github/workflows/symfony8-compat.yaml
+++ b/.github/workflows/symfony8-compat.yaml
@@ -1,0 +1,10 @@
+name: "Symfony 8 compatibility"
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
+
+jobs:
+  symfony8-compat:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-symfony8-compat.yaml@main

--- a/src/DataIndex/Filter/Loader/TaggedIteratorAdapter.php
+++ b/src/DataIndex/Filter/Loader/TaggedIteratorAdapter.php
@@ -15,7 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\FilterLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Filter\Filters;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -31,13 +31,13 @@ final class TaggedIteratorAdapter implements FilterLoaderInterface
     public const FILTER_DOCUMENT_TAG = 'pimcore.studio_backend.search_index.document.filter';
 
     public function __construct(
-        #[TaggedIterator(self::FILTER_TAG)]
+        #[AutowireIterator(self::FILTER_TAG)]
         private readonly iterable $taggedFilters,
-        #[TaggedIterator(self::FILTER_ASSET_TAG)]
+        #[AutowireIterator(self::FILTER_ASSET_TAG)]
         private readonly iterable $taggedAssetFilters,
-        #[TaggedIterator(self::FILTER_DATA_OBJECT_TAG)]
+        #[AutowireIterator(self::FILTER_DATA_OBJECT_TAG)]
         private readonly iterable $taggedDataObjectFilters,
-        #[TaggedIterator(self::FILTER_DOCUMENT_TAG)]
+        #[AutowireIterator(self::FILTER_DOCUMENT_TAG)]
         private readonly iterable $taggedDocumentFilters
     ) {
     }

--- a/src/DataObject/Service/Loader/TaggedIteratorDataAdapter.php
+++ b/src/DataObject/Service/Loader/TaggedIteratorDataAdapter.php
@@ -16,7 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\DataObject\Service\Loader;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\SetterDataInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataAdapterLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use function get_class;
 use function sprintf;
 
@@ -26,7 +26,7 @@ use function sprintf;
 final readonly class TaggedIteratorDataAdapter implements DataAdapterLoaderInterface
 {
     public function __construct(
-        #[TaggedIterator(self::ADAPTER_TAG)]
+        #[AutowireIterator(self::ADAPTER_TAG)]
         private iterable $taggedAdapter,
     ) {
     }

--- a/src/Document/Service/Loader/TaggedIteratorTypeAdapter.php
+++ b/src/Document/Service/Loader/TaggedIteratorTypeAdapter.php
@@ -17,7 +17,7 @@ use Pimcore\Bundle\StudioBackendBundle\Document\Data\SetterDataInterface;
 use Pimcore\Bundle\StudioBackendBundle\Document\Service\TypeAdapterLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\AdapterLoader;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use function get_class;
 use function sprintf;
 
@@ -27,7 +27,7 @@ use function sprintf;
 final readonly class TaggedIteratorTypeAdapter implements TypeAdapterLoaderInterface
 {
     public function __construct(
-        #[TaggedIterator(AdapterLoader::DOCUMENT_TYPE_ADAPTER_TAG->value)]
+        #[AutowireIterator(AdapterLoader::DOCUMENT_TYPE_ADAPTER_TAG->value)]
         private iterable $taggedAdapter,
     ) {
     }

--- a/src/FieldDefinition/Service/Loader/TaggedIteratorResolverLoader.php
+++ b/src/FieldDefinition/Service/Loader/TaggedIteratorResolverLoader.php
@@ -15,7 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\FieldDefinition\Service\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\FieldDefinition\Parser\Resolver\ResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\FieldDefinition\Service\ResolverLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -28,7 +28,7 @@ final readonly class TaggedIteratorResolverLoader implements ResolverLoaderInter
      * @param iterable<ResolverInterface> $taggedFieldDefinitionResolvers
      */
     public function __construct(
-        #[TaggedIterator(self::FIELD_DEFINITION_RESOLVER_TAG)]
+        #[AutowireIterator(self::FIELD_DEFINITION_RESOLVER_TAG)]
         private iterable $taggedFieldDefinitionResolvers,
     ) {
     }

--- a/src/Filter/Service/Loader/TaggedIteratorAdapter.php
+++ b/src/Filter/Service/Loader/TaggedIteratorAdapter.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Filter\Service\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\Filter\Service\FilterServiceLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -24,7 +24,7 @@ final class TaggedIteratorAdapter implements FilterServiceLoaderInterface
     public const FILTER_SERVICE_TAG = 'pimcore.studio_backend.filter_service';
 
     public function __construct(
-        #[TaggedIterator(self::FILTER_SERVICE_TAG)]
+        #[AutowireIterator(self::FILTER_SERVICE_TAG)]
         private readonly iterable $taggedFilterServices,
     ) {
     }

--- a/src/Gdpr/Service/Loader/TaggedIteratorDataProviderLoader.php
+++ b/src/Gdpr/Service/Loader/TaggedIteratorDataProviderLoader.php
@@ -16,7 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Gdpr\Service\Loader;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Gdpr\Provider\DataProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Gdpr\Service\DataProviderLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 final readonly class TaggedIteratorDataProviderLoader implements DataProviderLoaderInterface
 {
     public function __construct(
-        #[TaggedIterator(self::DATA_PROVIDER_TAG)]
+        #[AutowireIterator(self::DATA_PROVIDER_TAG)]
         private iterable $providers,
     ) {
     }

--- a/src/Grid/Service/Loader/TaggedIteratorColumnCollectorLoader.php
+++ b/src/Grid/Service/Loader/TaggedIteratorColumnCollectorLoader.php
@@ -15,7 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnCollectorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnCollectorLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -28,7 +28,7 @@ final readonly class TaggedIteratorColumnCollectorLoader implements ColumnCollec
      * @param iterable<ColumnCollectorInterface> $taggedColumnCollectors
      */
     public function __construct(
-        #[TaggedIterator(self::GRID_COLUMN_COLLECTOR_TAG)]
+        #[AutowireIterator(self::GRID_COLUMN_COLLECTOR_TAG)]
         private iterable $taggedColumnCollectors,
     ) {
     }

--- a/src/Grid/Service/Loader/TaggedIteratorColumnDefinitionLoader.php
+++ b/src/Grid/Service/Loader/TaggedIteratorColumnDefinitionLoader.php
@@ -15,7 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnDefinitionInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnDefinitionLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -28,7 +28,7 @@ final readonly class TaggedIteratorColumnDefinitionLoader implements ColumnDefin
      * @param iterable<ColumnDefinitionInterface> $taggedColumnDefinitions
      */
     public function __construct(
-        #[TaggedIterator(self::COLUMN_DEFINITION_TAG)]
+        #[AutowireIterator(self::COLUMN_DEFINITION_TAG)]
         private iterable $taggedColumnDefinitions,
     ) {
     }

--- a/src/Grid/Service/Loader/TaggedIteratorColumnResolverLoader.php
+++ b/src/Grid/Service/Loader/TaggedIteratorColumnResolverLoader.php
@@ -15,7 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnResolverLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -28,7 +28,7 @@ final readonly class TaggedIteratorColumnResolverLoader implements ColumnResolve
      * @param iterable<ColumnResolverInterface> $taggedColumnResolvers
      */
     public function __construct(
-        #[TaggedIterator(self::COLUMN_RESOLVER_TAG)]
+        #[AutowireIterator(self::COLUMN_RESOLVER_TAG)]
         private iterable $taggedColumnResolvers,
     ) {
     }

--- a/src/Grid/Service/Loader/TaggedIteratorPhpCodeTransformerLoader.php
+++ b/src/Grid/Service/Loader/TaggedIteratorPhpCodeTransformerLoader.php
@@ -16,7 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service\Loader;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\PhpCodeTransformerInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\PhpCodeTransformerLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 final readonly class TaggedIteratorPhpCodeTransformerLoader implements PhpCodeTransformerLoaderInterface
 {
     public function __construct(
-        #[TaggedIterator(self::PHPCODE_TRANSFORMER_TAG)]
+        #[AutowireIterator(self::PHPCODE_TRANSFORMER_TAG)]
         private iterable $transformers,
     ) {
     }

--- a/src/Grid/Service/Loader/TaggedIteratorTransformerLoader.php
+++ b/src/Grid/Service/Loader/TaggedIteratorTransformerLoader.php
@@ -15,7 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Service\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\TransformerInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\TransformerLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -28,7 +28,7 @@ final readonly class TaggedIteratorTransformerLoader implements TransformerLoade
      * @param iterable<TransformerInterface> $taggedTransformers
      */
     public function __construct(
-        #[TaggedIterator(self::TRANSFORMER_TAG)]
+        #[AutowireIterator(self::TRANSFORMER_TAG)]
         private iterable $taggedTransformers,
     ) {
     }

--- a/src/Listing/Filter/Loader/TaggedIteratorAdapter.php
+++ b/src/Listing/Filter/Loader/TaggedIteratorAdapter.php
@@ -16,7 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Listing\Filter\Loader;
 use Pimcore\Bundle\StudioBackendBundle\Listing\Filter\FilterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Listing\Filter\FilterLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Listing\Filter\Filters;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -26,7 +26,7 @@ final class TaggedIteratorAdapter implements FilterLoaderInterface
     public const FILTER_TAG = 'pimcore.studio_backend.listing.filter';
 
     public function __construct(
-        #[TaggedIterator(self::FILTER_TAG)]
+        #[AutowireIterator(self::FILTER_TAG)]
         private readonly iterable $taggedFilters,
     ) {
     }

--- a/src/Mercure/Service/Loader/TaggedIteratorAdapter.php
+++ b/src/Mercure/Service/Loader/TaggedIteratorAdapter.php
@@ -16,7 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Mercure\Service\Loader;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Model\TopicCollection;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Provider\ClientTopicProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Provider\ServerTopicProviderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -26,7 +26,7 @@ final class TaggedIteratorAdapter implements TopicLoaderInterface
     public const TOPIC_LOADER_TAG = 'pimcore.studio_backend.mercure.topic.provider';
 
     public function __construct(
-        #[TaggedIterator(self::TOPIC_LOADER_TAG)]
+        #[AutowireIterator(self::TOPIC_LOADER_TAG)]
         private readonly iterable $taggedTopicProviders,
     ) {
     }

--- a/src/Metadata/Service/Loader/TaggedIteratorMetadataAdapter.php
+++ b/src/Metadata/Service/Loader/TaggedIteratorMetadataAdapter.php
@@ -17,7 +17,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Metadata\Data\MetaDataAdapterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Metadata\Service\DataAdapterLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\AdapterLoader;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use function get_class;
 use function sprintf;
 
@@ -27,7 +27,7 @@ use function sprintf;
 final readonly class TaggedIteratorMetadataAdapter implements DataAdapterLoaderInterface
 {
     public function __construct(
-        #[TaggedIterator(AdapterLoader::METADATA_ADAPTER_TAG->value)]
+        #[AutowireIterator(AdapterLoader::METADATA_ADAPTER_TAG->value)]
         private iterable $taggedAdapter,
     ) {
     }

--- a/src/OwnershipManagement/Service/Loader/TaggedIteratorProviderLoader.php
+++ b/src/OwnershipManagement/Service/Loader/TaggedIteratorProviderLoader.php
@@ -16,7 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\OwnershipManagement\Service\Loader;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\OwnershipManagement\Provider\OwnershipProviderInterface;
 use Pimcore\Bundle\StudioBackendBundle\OwnershipManagement\Service\ProviderLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -27,7 +27,7 @@ final readonly class TaggedIteratorProviderLoader implements ProviderLoaderInter
      * @param iterable<OwnershipProviderInterface> $providers
      */
     public function __construct(
-        #[TaggedIterator(self::OWNERSHIP_PROVIDER_TAG)]
+        #[AutowireIterator(self::OWNERSHIP_PROVIDER_TAG)]
         private iterable $providers,
     ) {
     }

--- a/src/Patcher/Service/Loader/TaggedIteratorAdapter.php
+++ b/src/Patcher/Service/Loader/TaggedIteratorAdapter.php
@@ -15,7 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Patcher\Service\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\Patcher\Adapter\PatchAdapterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Patcher\Service\AdapterLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use function in_array;
 
 /**
@@ -26,7 +26,7 @@ final class TaggedIteratorAdapter implements AdapterLoaderInterface
     public const ADAPTER_TAG = 'pimcore.studio_backend.patch_adapter';
 
     public function __construct(
-        #[TaggedIterator(self::ADAPTER_TAG)]
+        #[AutowireIterator(self::ADAPTER_TAG)]
         private readonly iterable $taggedAdapter,
     ) {
     }

--- a/src/Perspective/Service/Loader/Widget/TaggedIteratorHydrator.php
+++ b/src/Perspective/Service/Loader/Widget/TaggedIteratorHydrator.php
@@ -17,7 +17,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\MustImplementInterfaceException;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Hydrator\WidgetConfigHydratorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\MustImplementInterfaceTrait;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -29,7 +29,7 @@ final class TaggedIteratorHydrator implements ConfigHydratorLoaderInterface
     public const string HYDRATOR_TAG = 'pimcore.studio_backend.widget_hydrator';
 
     public function __construct(
-        #[TaggedIterator(self::HYDRATOR_TAG)]
+        #[AutowireIterator(self::HYDRATOR_TAG)]
         private readonly iterable $taggedHydratorClasses,
     ) {
     }

--- a/src/Perspective/Service/Loader/Widget/TaggedIteratorRepository.php
+++ b/src/Perspective/Service/Loader/Widget/TaggedIteratorRepository.php
@@ -17,7 +17,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\MustImplementInterfaceException;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Repository\WidgetConfigRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\MustImplementInterfaceTrait;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -29,7 +29,7 @@ final class TaggedIteratorRepository implements ConfigRepositoryLoaderInterface
     public const string REPOSITORY_TAG = 'pimcore.studio_backend.widget_repository';
 
     public function __construct(
-        #[TaggedIterator(self::REPOSITORY_TAG)]
+        #[AutowireIterator(self::REPOSITORY_TAG)]
         private readonly iterable $taggedRepositories,
     ) {
     }

--- a/src/Setting/Service/Loader/TaggedIteratorAdapter.php
+++ b/src/Setting/Service/Loader/TaggedIteratorAdapter.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Setting\Service\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\Setting\Service\SettingProviderLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -24,7 +24,7 @@ final class TaggedIteratorAdapter implements SettingProviderLoaderInterface
     public const SETTINGS_PROVIDER_TAG = 'pimcore.studio_backend.settings_provider';
 
     public function __construct(
-        #[TaggedIterator(self::SETTINGS_PROVIDER_TAG)]
+        #[AutowireIterator(self::SETTINGS_PROVIDER_TAG)]
         private readonly iterable $taggedSettingProviders,
     ) {
     }

--- a/src/Setting/Service/Loader/UpdateSettingsTaggedIteratorAdapter.php
+++ b/src/Setting/Service/Loader/UpdateSettingsTaggedIteratorAdapter.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Setting\Service\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\Setting\Service\UpdateSettingProviderLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
  * @internal
@@ -24,7 +24,7 @@ final class UpdateSettingsTaggedIteratorAdapter implements UpdateSettingProvider
     public const string UPDATE_SETTINGS_PROVIDER_TAG = 'pimcore.studio_backend.update_settings_provider';
 
     public function __construct(
-        #[TaggedIterator(self::UPDATE_SETTINGS_PROVIDER_TAG)]
+        #[AutowireIterator(self::UPDATE_SETTINGS_PROVIDER_TAG)]
         private readonly iterable $taggedSettingProviders,
     ) {
     }

--- a/src/Updater/Service/Loader/TaggedIteratorAdapter.php
+++ b/src/Updater/Service/Loader/TaggedIteratorAdapter.php
@@ -15,7 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Updater\Service\Loader;
 
 use Pimcore\Bundle\StudioBackendBundle\Updater\Adapter\UpdateAdapterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Updater\Service\AdapterLoaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use function in_array;
 
 /**
@@ -26,7 +26,7 @@ final class TaggedIteratorAdapter implements AdapterLoaderInterface
     public const string ADAPTER_TAG = 'pimcore.studio_backend.update_adapter';
 
     public function __construct(
-        #[TaggedIterator(self::ADAPTER_TAG)]
+        #[AutowireIterator(self::ADAPTER_TAG)]
         private readonly iterable $taggedAdapter,
     ) {
     }


### PR DESCRIPTION
## What

Replaces the deprecated `#[TaggedIterator]` attribute with `#[AutowireIterator]` — **24 usage(s)
across 21 file(s)** — and subscribes this repo to the new central Symfony 8 compatibility check.

- `src/DataIndex/Filter/Loader/TaggedIteratorAdapter.php` — 4 usage(s)
- `src/DataObject/Service/Loader/TaggedIteratorDataAdapter.php` — 1 usage(s)
- `src/Document/Service/Loader/TaggedIteratorTypeAdapter.php` — 1 usage(s)
- `src/FieldDefinition/Service/Loader/TaggedIteratorResolverLoader.php` — 1 usage(s)
- `src/Filter/Service/Loader/TaggedIteratorAdapter.php` — 1 usage(s)
- `src/Gdpr/Service/Loader/TaggedIteratorDataProviderLoader.php` — 1 usage(s)
- `src/Grid/Service/Loader/TaggedIteratorColumnCollectorLoader.php` — 1 usage(s)
- `src/Grid/Service/Loader/TaggedIteratorColumnDefinitionLoader.php` — 1 usage(s)
- `src/Grid/Service/Loader/TaggedIteratorColumnResolverLoader.php` — 1 usage(s)
- `src/Grid/Service/Loader/TaggedIteratorPhpCodeTransformerLoader.php` — 1 usage(s)
- `src/Grid/Service/Loader/TaggedIteratorTransformerLoader.php` — 1 usage(s)
- `src/Listing/Filter/Loader/TaggedIteratorAdapter.php` — 1 usage(s)
- `src/Mercure/Service/Loader/TaggedIteratorAdapter.php` — 1 usage(s)
- `src/Metadata/Service/Loader/TaggedIteratorMetadataAdapter.php` — 1 usage(s)
- `src/OwnershipManagement/Service/Loader/TaggedIteratorProviderLoader.php` — 1 usage(s)
- `src/Patcher/Service/Loader/TaggedIteratorAdapter.php` — 1 usage(s)
- `src/Perspective/Service/Loader/Widget/TaggedIteratorHydrator.php` — 1 usage(s)
- `src/Perspective/Service/Loader/Widget/TaggedIteratorRepository.php` — 1 usage(s)
- `src/Setting/Service/Loader/TaggedIteratorAdapter.php` — 1 usage(s)
- `src/Setting/Service/Loader/UpdateSettingsTaggedIteratorAdapter.php` — 1 usage(s)
- `src/Updater/Service/Loader/TaggedIteratorAdapter.php` — 1 usage(s)

Each file gets exactly two kinds of edit: the import line and the attribute name. **Arguments are
byte-identical**, and no class, file or service name is touched.

## Why

`Symfony\Component\DependencyInjection\Attribute\TaggedIterator` is deprecated since Symfony 7.1 and
**removed in Symfony 8.0** (`UPGRADE-8.0.md`, DependencyInjection).

The swap is a **pure rename**: `TaggedIterator` extends `AutowireIterator`, the constructors are
identical (`$tag, $indexAttribute, $defaultIndexMethod, $defaultPriorityMethod, $exclude, $excludeSelf`),
and `TaggedIterator::__construct()` does nothing but emit `trigger_deprecation()` and forward to its
parent. Behaviour on Symfony 7.4 is unchanged; the only runtime difference is one deprecation less.

## Staying compatible

Adds `.github/workflows/symfony8-compat.yaml`, a thin caller for the new central check
`pimcore/workflows-collection-public/.github/workflows/reusable-symfony8-compat.yaml@main`
(pimcore/workflows-collection-public#154, merged). Two rules are active today — the `#[TaggedIterator]`
attribute and its import — each as its own named check, annotating the offending line if it ever comes
back. The rule set grows centrally with every further Symfony 8 fix sweep, so no repo has to maintain its
own copy.

## Verification

- `#[TaggedIterator(` → **0**; `#[AutowireIterator(` → **24** (equal to the pre-change count)
- `use …\Attribute\TaggedIterator;` → **0**
- `php -l` clean on every changed file; the diff touches only the files listed above plus the new workflow
- remaining `TaggedIterator` matches in the repo are **class names / `#[AutoconfigureTag]` references** and
  were deliberately left untouched

## Context

Step 1 of the Symfony 7.4 → 8 migration, from the readiness analysis of all 37 platform SBOM repos
(`pimcore/platform-version`, `migration-analysis/SUMMARY.md`). Chosen first because it is the safest
mechanical change in the set. 40 usages across 9 repos are being fixed in one PR per repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
