### PR TITLE
[Symfony 8] Add ?Vote argument to voteOnAttribute()

### DIFF
--- a/src/Security/Voter/AuthorizationVoter.php
+++ b/src/Security/Voter/AuthorizationVoter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Security\Voter;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 /**
@@ -31,7 +32,7 @@ final class AuthorizationVoter extends Voter
         return $attribute === self::SUPPORTED_ATTRIBUTE;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         return $attribute === self::SUPPORTED_ATTRIBUTE;
     }

--- a/src/Security/Voter/ElementTypePermissionVoter.php
+++ b/src/Security/Voter/ElementTypePermissionVoter.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\RequestTrait;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use function array_key_exists;
 
@@ -55,7 +56,7 @@ final class ElementTypePermissionVoter extends Voter
     /**
      * @throws AccessDeniedException
      */
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         $elementType = $this->getElementTypeFromRequest();
 

--- a/src/Security/Voter/HasOneOfUserPermissionVoter.php
+++ b/src/Security/Voter/HasOneOfUserPermissionVoter.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Security\Voter;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 /**
@@ -42,7 +43,7 @@ final class HasOneOfUserPermissionVoter extends Voter
     /**
      * @throws ForbiddenException
      */
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         foreach ($subject->getPermissionsToCheck() as $permissionToCheck) {
             if ($this->securityService->getCurrentUser()->isAllowed($permissionToCheck)) {

--- a/src/Security/Voter/PublicAuthorizationVoter.php
+++ b/src/Security/Voter/PublicAuthorizationVoter.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use function in_array;
 use function is_string;
@@ -63,7 +64,7 @@ final class PublicAuthorizationVoter extends Voter
     /**
      * @throws NoRequestException|NonPublicTranslationException
      */
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         if ($this->securityService->isLoggedIn()) {
             return true;

--- a/src/Security/Voter/UserPasswordVoter.php
+++ b/src/Security/Voter/UserPasswordVoter.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Trait\RequestTrait;
 use Pimcore\Helper\ParameterBagHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 /**
@@ -47,7 +48,7 @@ final class UserPasswordVoter extends Voter
     /**
      * @throws AccessDeniedException
      */
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         $userId = $this->getUserIdFromRequest();
 

--- a/src/Security/Voter/UserPermissionVoter.php
+++ b/src/Security/Voter/UserPermissionVoter.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\CacheKeys;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use function in_array;
 use function is_array;
@@ -52,7 +53,7 @@ final class UserPermissionVoter extends Voter
     /**
      * @throws ForbiddenException
      */
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         if (!$this->securityService->getCurrentUser()->isAllowed($attribute)) {
             throw new ForbiddenException(sprintf('User does not have permission: %s', $attribute));

--- a/src/Security/Voter/UserPerspectiveVoter.php
+++ b/src/Security/Voter/UserPerspectiveVoter.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\RequestTrait;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
@@ -50,7 +51,7 @@ final class UserPerspectiveVoter extends Voter
     /**
      * @throws ForbiddenException|UserNotFoundException|NoRequestException
      */
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         $user = $this->securityService->getCurrentUser();
         if ($user->isAllowed(UserPermissions::PERSPECTIVE_EDITOR->value)) {


### PR DESCRIPTION
## What

Adds the `?Vote $vote = null` parameter to every `voteOnAttribute()` override in this repo
(**7 voter(s)**), plus the matching `Vote` import.

- `src/Security/Voter/AuthorizationVoter.php`
- `src/Security/Voter/ElementTypePermissionVoter.php`
- `src/Security/Voter/HasOneOfUserPermissionVoter.php`
- `src/Security/Voter/PublicAuthorizationVoter.php`
- `src/Security/Voter/UserPasswordVoter.php`
- `src/Security/Voter/UserPermissionVoter.php`
- `src/Security/Voter/UserPerspectiveVoter.php`

Two edit kinds only — the import and the parameter. No voter body, docblock or service definition changes.

## Why

Symfony 8.0 adds a `$vote` argument to `Voter::voteOnAttribute()` (`UPGRADE-8.0.md`, Security).

**Landing it now is behaviour-neutral**, verified against the installed 7.4 tree
(`symfony/security-core v7.4.15`):

- `Authorization\Voter\Vote` has existed **since 7.3**, so the type-hint compiles today.
- 7.4's `AccessDecisionManager` **already constructs a `Vote` and passes it**; `Voter::vote()` recovers
  it via `func_get_arg(3)` and always calls `voteOnAttribute()` with four arguments. Overrides declaring
  three simply ignore it — so nothing about the voting behaviour changes, the voters just gain the ability
  to record reasons later.

Worth noting how this was found: **no deprecation is emitted** for the missing argument and PHPStan cannot
flag a new required parameter on a method you override. Grep found it during the platform analysis.
## Verification

The central check gained a `signature-scan (voter-vote-argument)` rule
(pimcore/workflows-collection-public#155, merged **before** this PR on purpose), so
**`signature-scan (voter-vote-argument)` on this PR is the test** — it was failing on this branch's base
and must be green here.

Locally, the gates ran the scan engine extracted from the merged central workflow: 7 declaration(s)
flagged before the edit, **0** after; `php -l` clean; the diff contains only the two expected edit kinds.

## Context

Sweep 2 of the Symfony 7.4 → 8 migration, from the readiness analysis of all 37 platform SBOM repos
(`pimcore/platform-version`, `migration-analysis/SUMMARY.md` §3, runbook `EXEC-VOTE.md`). 16 voters
across 3 repos, one PR each. Sweep 1 (`#[TaggedIterator]` → `#[AutowireIterator]`) is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
