### PR TITLE
[Telemetry] Outbox endpoints + Generic Data Index acceleration

### DIFF
--- a/config/event_subscribers.yaml
+++ b/config/event_subscribers.yaml
@@ -17,6 +17,10 @@ services:
     tags: [ 'kernel.event_subscriber' ]
     arguments: ['%pimcore_studio_backend.url_prefix%']
 
+  # captures studio.login_succeeded telemetry on interactive Studio logins (TelemetryInterface autowired)
+  Pimcore\Bundle\StudioBackendBundle\EventSubscriber\LoginTelemetrySubscriber:
+    tags: [ 'kernel.event_subscriber' ]
+
   Pimcore\Bundle\StudioBackendBundle\EventSubscriber\ApiExceptionSubscriber:
     tags: [ 'kernel.event_subscriber' ]
     arguments: ["%kernel.environment%", '%pimcore_studio_backend.url_prefix%']

--- a/config/telemetry.yaml
+++ b/config/telemetry.yaml
@@ -24,3 +24,13 @@ services:
     #
     Pimcore\Bundle\StudioBackendBundle\Telemetry\Hydrator\TelemetryHydratorInterface:
         class: Pimcore\Bundle\StudioBackendBundle\Telemetry\Hydrator\TelemetryHydrator
+
+    #
+    # Statistics — accelerate the heavy element-stats collectors via the Generic Data Index by
+    # decorating the core SQL provider; falls back to it (the decorated @.inner) when the search
+    # index is unavailable, errors, or is empty.
+    #
+    Pimcore\Bundle\StudioBackendBundle\Telemetry\Statistics\GdiElementStatisticsProvider:
+        decorates: Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface
+        arguments:
+            $inner: '@.inner'

--- a/config/telemetry.yaml
+++ b/config/telemetry.yaml
@@ -1,0 +1,26 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    # controllers are imported separately to make sure they're public
+    # and have a tag that allows actions to type-hint services
+    Pimcore\Bundle\StudioBackendBundle\Telemetry\Controller\:
+        resource: '../src/Telemetry/Controller'
+        public: true
+        tags: [ 'controller.service_arguments' ]
+
+    #
+    # Services
+    #
+    Pimcore\Bundle\StudioBackendBundle\Telemetry\Service\TelemetryServiceInterface:
+        class: Pimcore\Bundle\StudioBackendBundle\Telemetry\Service\TelemetryService
+        arguments:
+            $relayEndpoint: '%pimcore.telemetry.relay_endpoint%'
+
+    #
+    # Hydrators
+    #
+    Pimcore\Bundle\StudioBackendBundle\Telemetry\Hydrator\TelemetryHydratorInterface:
+        class: Pimcore\Bundle\StudioBackendBundle\Telemetry\Hydrator\TelemetryHydrator

--- a/src/EventSubscriber/LoginTelemetrySubscriber.php
+++ b/src/EventSubscriber/LoginTelemetrySubscriber.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\EventSubscriber;
+
+use Pimcore\Security\User\User;
+use Pimcore\Telemetry\TelemetryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
+use function in_array;
+
+/**
+ * Captures a content-never `studio.login_succeeded` event on each interactive Studio login
+ * (PM question #23: how many logins, how often - a usage/churn/upsell signal).
+ *
+ * Scoped to the two Studio login routes - credentials (`json_login` at `pimcore_studio_api_login`)
+ * and token (`pimcore_studio_api_token_login`). These are alternative methods on the stateful Studio
+ * firewall, so exactly one event fires per login: subsequent requests restore the token from the
+ * session without re-authenticating (no event), and MCP is a separate firewall. The only property
+ * is whether the user is an admin - never a username, email, or id.
+ *
+ * @internal
+ */
+final readonly class LoginTelemetrySubscriber implements EventSubscriberInterface
+{
+    private const EVENT_STUDIO_LOGIN = 'studio.login_succeeded';
+
+    private const LOGIN_ROUTES = [
+        'pimcore_studio_api_login',
+        'pimcore_studio_api_token_login',
+    ];
+
+    public function __construct(
+        private TelemetryInterface $telemetry,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LoginSuccessEvent::class => 'onLoginSuccess',
+        ];
+    }
+
+    public function onLoginSuccess(LoginSuccessEvent $event): void
+    {
+        if (!in_array($event->getRequest()->attributes->get('_route'), self::LOGIN_ROUTES, true)) {
+            return;
+        }
+
+        $this->telemetry->capture(self::EVENT_STUDIO_LOGIN, [
+            'is_admin' => $this->isAdmin($event),
+        ]);
+    }
+
+    private function isAdmin(LoginSuccessEvent $event): bool
+    {
+        $user = $event->getAuthenticatedToken()->getUser();
+
+        return $user instanceof User && $user->getUser()->isAdmin();
+    }
+}

--- a/src/OpenApi/Attribute/Response/NoContentResponse.php
+++ b/src/OpenApi/Attribute/Response/NoContentResponse.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response;
+
+use Attribute;
+use OpenApi\Attributes\Response;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class NoContentResponse extends Response
+{
+    public function __construct(string $description = 'No Content', ?array $headers = null)
+    {
+        parent::__construct(
+            response: HttpResponseCodes::NO_CONTENT->value,
+            description: $description,
+            headers: $headers,
+        );
+    }
+}

--- a/src/OpenApi/Config/Tags.php
+++ b/src/OpenApi/Config/Tags.php
@@ -139,6 +139,10 @@ use OpenApi\Attributes\Tag;
     description: 'tag_tags_for_element_description'
 )]
 #[Tag(
+    name: Tags::Telemetry->value,
+    description: 'tag_telemetry_description'
+)]
+#[Tag(
     name: Tags::Translation->value,
     description: 'tag_translation_description'
 )]
@@ -210,6 +214,7 @@ enum Tags: string
     case SettingsAdmin = 'Settings Admin';
     case Tags = 'Tags';
     case TagsForElement = 'Tags for Element';
+    case Telemetry = 'Telemetry';
     case Translation = 'Translation';
     case Units = 'Units';
     case User = 'User Management';

--- a/src/Telemetry/Controller/AckController.php
+++ b/src/Telemetry/Controller/AckController.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Controller;
+
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Post;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Request\ReferenceRequestBody;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxAckParameters;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxAckResult;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Service\TelemetryServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class AckController extends AbstractApiController
+{
+    private const string ROUTE = '/telemetry/outbox/ack';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly TelemetryServiceInterface $telemetryService,
+    ) {
+        parent::__construct($serializer);
+    }
+
+    #[Route(self::ROUTE, name: 'pimcore_studio_api_telemetry_outbox_ack', methods: ['POST'])]
+    #[IsGranted(UserPermissions::PIMCORE_USER->value)]
+    #[Post(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'telemetry_outbox_ack',
+        description: 'telemetry_outbox_ack_description',
+        summary: 'telemetry_outbox_ack_summary',
+        tags: [Tags::Telemetry->value]
+    )]
+    #[ReferenceRequestBody(OutboxAckParameters::class)]
+    #[SuccessResponse(
+        description: 'telemetry_outbox_ack_success_response',
+        content: new JsonContent(ref: OutboxAckResult::class)
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+    ])]
+    public function ackBatch(
+        #[MapRequestPayload] OutboxAckParameters $parameters
+    ): JsonResponse {
+        return $this->jsonResponse($this->telemetryService->ackBatch($parameters->getNonce()));
+    }
+}

--- a/src/Telemetry/Controller/OutboxController.php
+++ b/src/Telemetry/Controller/OutboxController.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Controller;
+
+use OpenApi\Attributes\Get;
+use OpenApi\Attributes\JsonContent;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\NoContentResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxBatch;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Service\TelemetryServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class OutboxController extends AbstractApiController
+{
+    private const string ROUTE = '/telemetry/outbox';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly TelemetryServiceInterface $telemetryService,
+    ) {
+        parent::__construct($serializer);
+    }
+
+    #[Route(self::ROUTE, name: 'pimcore_studio_api_telemetry_outbox', methods: ['GET'])]
+    #[IsGranted(UserPermissions::PIMCORE_USER->value)]
+    #[Get(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'telemetry_outbox_next_batch',
+        description: 'telemetry_outbox_next_batch_description',
+        summary: 'telemetry_outbox_next_batch_summary',
+        tags: [Tags::Telemetry->value]
+    )]
+    #[SuccessResponse(
+        description: 'telemetry_outbox_next_batch_success_response',
+        content: new JsonContent(ref: OutboxBatch::class)
+    )]
+    #[NoContentResponse(description: 'telemetry_outbox_next_batch_no_content_response')]
+    #[DefaultResponses([
+        HttpResponseCodes::UNAUTHORIZED,
+    ])]
+    public function getNextBatch(): Response
+    {
+        $batch = $this->telemetryService->getNextBatch();
+
+        if (!$batch instanceof OutboxBatch) {
+            return new Response(status: HttpResponseCodes::NO_CONTENT->value);
+        }
+
+        return $this->jsonResponse($batch);
+    }
+}

--- a/src/Telemetry/Event/PreResponse/OutboxAckResultEvent.php
+++ b/src/Telemetry/Event/PreResponse/OutboxAckResultEvent.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Event\PreResponse;
+
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxAckResult;
+
+final class OutboxAckResultEvent extends AbstractPreResponseEvent
+{
+    public const string EVENT_NAME = 'pre_response.telemetry.outbox_ack_result';
+
+    public function __construct(
+        private readonly OutboxAckResult $outboxAckResult
+    ) {
+        parent::__construct($this->outboxAckResult);
+    }
+
+    public function getOutboxAckResult(): OutboxAckResult
+    {
+        return $this->outboxAckResult;
+    }
+}

--- a/src/Telemetry/Event/PreResponse/OutboxBatchEvent.php
+++ b/src/Telemetry/Event/PreResponse/OutboxBatchEvent.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Event\PreResponse;
+
+use Pimcore\Bundle\StudioBackendBundle\Event\AbstractPreResponseEvent;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxBatch;
+
+final class OutboxBatchEvent extends AbstractPreResponseEvent
+{
+    public const string EVENT_NAME = 'pre_response.telemetry.outbox_batch';
+
+    public function __construct(
+        private readonly OutboxBatch $outboxBatch
+    ) {
+        parent::__construct($this->outboxBatch);
+    }
+
+    public function getOutboxBatch(): OutboxBatch
+    {
+        return $this->outboxBatch;
+    }
+}

--- a/src/Telemetry/Hydrator/TelemetryHydrator.php
+++ b/src/Telemetry/Hydrator/TelemetryHydrator.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxAckResult;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxBatch;
+use Pimcore\Telemetry\Spool\EncryptedBatch;
+
+/**
+ * @internal
+ */
+final readonly class TelemetryHydrator implements TelemetryHydratorInterface
+{
+    private const int PROTOCOL_VERSION = 1;
+
+    public function hydrateOutboxBatch(EncryptedBatch $batch, string $relayEndpoint): OutboxBatch
+    {
+        return new OutboxBatch(
+            $batch->nonce,
+            $batch->instanceIdentifier,
+            self::PROTOCOL_VERSION,
+            $batch->ciphertext,
+            $relayEndpoint,
+        );
+    }
+
+    public function hydrateOutboxAckResult(int $acked): OutboxAckResult
+    {
+        return new OutboxAckResult($acked);
+    }
+}

--- a/src/Telemetry/Hydrator/TelemetryHydratorInterface.php
+++ b/src/Telemetry/Hydrator/TelemetryHydratorInterface.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Hydrator;
+
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxAckResult;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxBatch;
+use Pimcore\Telemetry\Spool\EncryptedBatch;
+
+/**
+ * @internal
+ */
+interface TelemetryHydratorInterface
+{
+    public function hydrateOutboxBatch(EncryptedBatch $batch, string $relayEndpoint): OutboxBatch;
+
+    public function hydrateOutboxAckResult(int $acked): OutboxAckResult;
+}

--- a/src/Telemetry/Schema/OutboxAckParameters.php
+++ b/src/Telemetry/Schema/OutboxAckParameters.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+
+/**
+ * @internal
+ */
+#[Schema(
+    schema: 'TelemetryOutboxAckParameters',
+    title: 'Telemetry Outbox Ack Parameters',
+    required: ['nonce'],
+    type: 'object'
+)]
+final readonly class OutboxAckParameters
+{
+    public function __construct(
+        #[Property(description: 'Lease nonce of the batch the relay has accepted', type: 'string')]
+        private string $nonce,
+    ) {
+    }
+
+    public function getNonce(): string
+    {
+        return $this->nonce;
+    }
+}

--- a/src/Telemetry/Schema/OutboxAckResult.php
+++ b/src/Telemetry/Schema/OutboxAckResult.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+/**
+ * @internal
+ */
+#[Schema(
+    schema: 'TelemetryOutboxAckResult',
+    title: 'Telemetry Outbox Ack Result',
+    required: ['acked'],
+    type: 'object'
+)]
+final class OutboxAckResult implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(
+            description: 'Number of spooled events removed from the outbox by the ack',
+            type: 'integer',
+            example: 1
+        )]
+        private readonly int $acked,
+    ) {
+    }
+
+    public function getAcked(): int
+    {
+        return $this->acked;
+    }
+}

--- a/src/Telemetry/Schema/OutboxBatch.php
+++ b/src/Telemetry/Schema/OutboxBatch.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+use Pimcore\Bundle\StudioBackendBundle\Util\Schema\AdditionalAttributesInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Trait\AdditionalAttributesTrait;
+
+/**
+ * @internal
+ */
+#[Schema(
+    schema: 'TelemetryOutboxBatch',
+    title: 'Telemetry Outbox Batch',
+    required: ['nonce', 'instanceIdentifier', 'v', 'ciphertext', 'relayEndpoint'],
+    type: 'object'
+)]
+final class OutboxBatch implements AdditionalAttributesInterface
+{
+    use AdditionalAttributesTrait;
+
+    public function __construct(
+        #[Property(description: 'Lease nonce identifying the claimed batch, passed back on ack', type: 'string')]
+        private readonly string $nonce,
+        #[Property(
+            description: 'Cleartext instance identifier the relay uses to look up the product key',
+            type: 'string'
+        )]
+        private readonly string $instanceIdentifier,
+        #[Property(description: 'Outbox payload protocol version', type: 'integer', example: 1)]
+        private readonly int $v,
+        #[Property(
+            description: 'Opaque product-key encrypted envelope to forward verbatim to the relay',
+            type: 'string'
+        )]
+        private readonly string $ciphertext,
+        #[Property(description: 'Relay endpoint the browser must POST the ciphertext to', type: 'string')]
+        private readonly string $relayEndpoint,
+    ) {
+    }
+
+    public function getNonce(): string
+    {
+        return $this->nonce;
+    }
+
+    public function getInstanceIdentifier(): string
+    {
+        return $this->instanceIdentifier;
+    }
+
+    public function getV(): int
+    {
+        return $this->v;
+    }
+
+    public function getCiphertext(): string
+    {
+        return $this->ciphertext;
+    }
+
+    public function getRelayEndpoint(): string
+    {
+        return $this->relayEndpoint;
+    }
+}

--- a/src/Telemetry/Service/TelemetryService.php
+++ b/src/Telemetry/Service/TelemetryService.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Event\PreResponse\OutboxAckResultEvent;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Event\PreResponse\OutboxBatchEvent;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Hydrator\TelemetryHydratorInterface;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxAckResult;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxBatch;
+use Pimcore\Telemetry\Spool\EncryptedBatch;
+use Pimcore\Telemetry\Spool\TelemetryOutboxInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+final readonly class TelemetryService implements TelemetryServiceInterface
+{
+    public function __construct(
+        private TelemetryOutboxInterface $telemetryOutbox,
+        private TelemetryHydratorInterface $telemetryHydrator,
+        private EventDispatcherInterface $eventDispatcher,
+        private string $relayEndpoint,
+    ) {
+    }
+
+    public function getNextBatch(): ?OutboxBatch
+    {
+        // Without a relay endpoint the browser would have nowhere to forward to, so do not even
+        // claim/lease a batch (mirrors the maintenance RelayClient::isConfigured() guard). This
+        // keeps the default config (empty relay_endpoint) from churning leases with no delivery.
+        if ($this->relayEndpoint === '' || !$this->telemetryOutbox->isReady()) {
+            return null;
+        }
+
+        $batch = $this->telemetryOutbox->nextBatch();
+
+        if (!$batch instanceof EncryptedBatch) {
+            return null;
+        }
+
+        $outboxBatch = $this->telemetryHydrator->hydrateOutboxBatch($batch, $this->relayEndpoint);
+
+        $this->eventDispatcher->dispatch(
+            new OutboxBatchEvent($outboxBatch),
+            OutboxBatchEvent::EVENT_NAME
+        );
+
+        return $outboxBatch;
+    }
+
+    public function ackBatch(string $nonce): OutboxAckResult
+    {
+        $outboxAckResult = $this->telemetryHydrator->hydrateOutboxAckResult(
+            $this->telemetryOutbox->ack($nonce)
+        );
+
+        $this->eventDispatcher->dispatch(
+            new OutboxAckResultEvent($outboxAckResult),
+            OutboxAckResultEvent::EVENT_NAME
+        );
+
+        return $outboxAckResult;
+    }
+}

--- a/src/Telemetry/Service/TelemetryService.php
+++ b/src/Telemetry/Service/TelemetryService.php
@@ -37,10 +37,9 @@ final readonly class TelemetryService implements TelemetryServiceInterface
 
     public function getNextBatch(): ?OutboxBatch
     {
-        // Without a relay endpoint the browser would have nowhere to forward to, so do not even
-        // claim/lease a batch (mirrors the maintenance RelayClient::isConfigured() guard). This
-        // keeps the default config (empty relay_endpoint) from churning leases with no delivery.
-        if ($this->relayEndpoint === '' || !$this->telemetryOutbox->isReady()) {
+        // An instance that is not identified or has no product key cannot produce a decryptable
+        // batch, so do not claim/lease one (mirrors the maintenance drain task's guard).
+        if (!$this->telemetryOutbox->isReady()) {
             return null;
         }
 

--- a/src/Telemetry/Service/TelemetryServiceInterface.php
+++ b/src/Telemetry/Service/TelemetryServiceInterface.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxAckResult;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Schema\OutboxBatch;
+
+/**
+ * @internal
+ */
+interface TelemetryServiceInterface
+{
+    /**
+     * Returns the next encrypted outbox batch ready to be forwarded to the relay,
+     * or null when the outbox is not ready or the pool is empty.
+     */
+    public function getNextBatch(): ?OutboxBatch;
+
+    public function ackBatch(string $nonce): OutboxAckResult;
+}

--- a/src/Telemetry/Statistics/GdiElementStatisticsProvider.php
+++ b/src/Telemetry/Statistics/GdiElementStatisticsProvider.php
@@ -72,7 +72,10 @@ final readonly class GdiElementStatisticsProvider implements ElementStatisticsPr
     {
         try {
             $result = $this->aggregate($kind, [
-                new Aggregation('byType', ['terms' => ['field' => SystemField::TYPE->getPath(), 'size' => self::TERMS_SIZE]]),
+                new Aggregation(
+                    'byType',
+                    ['terms' => ['field' => SystemField::TYPE->getPath(), 'size' => self::TERMS_SIZE]]
+                ),
             ]);
 
             $byType = [];

--- a/src/Telemetry/Statistics/GdiElementStatisticsProvider.php
+++ b/src/Telemetry/Statistics/GdiElementStatisticsProvider.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Statistics;
+
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
+use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Aggregation\Aggregation;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\Telemetry\Snapshot\ElementTypeCounts;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface;
+use Pimcore\Telemetry\Snapshot\Statistics\TreeDepth;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Search-index-backed {@see ElementStatisticsProviderInterface} that decorates the core SQL provider.
+ *
+ * Two of the snapshot's data-volume-scaling statistics are the exact shape the Generic Data Index
+ * answers cheaply, and those are the ones served here: counts-by-type as a `terms` aggregation and
+ * folder fan-out as `terms(parentId, size:1, desc)` - instance-wide OpenSearch/Elasticsearch
+ * aggregations that never touch the transactional database and never scan.
+ *
+ * It is instance-wide by design, so it uses the low-level {@see SearchIndexServiceInterface} (not the
+ * permission/workspace-scoped element search services). Each accelerated method degrades to the
+ * decorated SQL provider ($inner) when the index is unavailable, errors, or is empty - so telemetry
+ * keeps working on instances without a healthy search cluster, and an index that lags the DB only
+ * affects the always-bucketed values within one bucket.
+ *
+ * The remaining methods delegate to SQL unconditionally, so that every instance emits the same
+ * number for the same data regardless of index health:
+ *  - Tree depth: the index cannot reproduce the emitted slash-count semantics - see
+ *    {@see self::treeDepth()}.
+ *  - The variant metrics need a `type = variant` filter and hit the indexed `objects.parentId`
+ *    cheaply in SQL anyway.
+ *
+ * Coverage note for what IS served from the index: a few element subtypes are not indexed (e.g.
+ * web-to-print documents); the values this collector emits are either bucketed or an exactly-indexed
+ * subtype, so emitted telemetry matches.
+ *
+ * @internal
+ */
+final readonly class GdiElementStatisticsProvider implements ElementStatisticsProviderInterface
+{
+    private const TERMS_SIZE = 1000;
+
+    public function __construct(
+        private ElementStatisticsProviderInterface $inner,
+        private SearchIndexServiceInterface $searchIndexService,
+        private SearchIndexConfigServiceInterface $indexConfig,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function typeCounts(ElementKind $kind): ElementTypeCounts
+    {
+        try {
+            $result = $this->aggregate($kind, [
+                new Aggregation('byType', ['terms' => ['field' => SystemField::TYPE->getPath(), 'size' => self::TERMS_SIZE]]),
+            ]);
+
+            $byType = [];
+            foreach ($result->getAggregation('byType')?->getBuckets() ?? [] as $bucket) {
+                $byType[(string) $bucket->getKey()] = $bucket->getDocCount();
+            }
+
+            // An empty result means the index isn't populated for this kind - prefer the SQL truth.
+            return $byType === [] ? $this->inner->typeCounts($kind) : new ElementTypeCounts($byType);
+        } catch (Throwable $e) {
+            $this->logFallback('typeCounts', $e);
+
+            return $this->inner->typeCounts($kind);
+        }
+    }
+
+    /**
+     * Delegated to SQL on purpose - the index cannot reproduce the emitted metric.
+     *
+     * The emitted depth is the slash count of an element's `path` column. `system_fields.pathLevel`
+     * is not a constant offset from that, because the index derives it differently per element:
+     * `getRealFullPath()` for folders (which includes the element's own key) but `getPath()` for
+     * everything else, so folders are already one segment deeper. Variants diverge again - their
+     * `path` column is empty, so SQL scores them 0 while the index gives them a real level. A single
+     * `+1` correction is therefore wrong for two element classes, and an instance with a healthy
+     * index would report different depths than one without - verified against live data.
+     *
+     * Reproducing the SQL semantics here would need per-type filtered aggregations; until that is
+     * worth doing, correctness and cross-instance comparability win over the saved scan. The
+     * inner provider is time-boxed, so the cost is bounded.
+     */
+    public function treeDepth(ElementKind $kind): TreeDepth
+    {
+        return $this->inner->treeDepth($kind);
+    }
+
+    public function objectsWithVariants(): int
+    {
+        return $this->inner->objectsWithVariants();
+    }
+
+    public function maxVariantsPerObject(): int
+    {
+        return $this->inner->maxVariantsPerObject();
+    }
+
+    public function maxObjectFanout(): int
+    {
+        try {
+            $result = $this->aggregate(ElementKind::DataObject, [
+                new Aggregation('topParent', ['terms' => [
+                    'field' => SystemField::PARENT_ID->getPath(),
+                    'size' => 1,
+                    'order' => ['_count' => 'desc'],
+                ]]),
+            ]);
+
+            $buckets = $result->getAggregation('topParent')?->getBuckets() ?? [];
+
+            return $buckets === [] ? $this->inner->maxObjectFanout() : $buckets[0]->getDocCount();
+        } catch (Throwable $e) {
+            $this->logFallback('maxObjectFanout', $e);
+
+            return $this->inner->maxObjectFanout();
+        }
+    }
+
+    /**
+     * @param Aggregation[] $aggregations
+     */
+    private function aggregate(ElementKind $kind, array $aggregations): SearchResult
+    {
+        $search = $this->searchIndexService->createPaginatedSearch(1, 0, true);
+        foreach ($aggregations as $aggregation) {
+            $search->addAggregation($aggregation);
+        }
+
+        return $this->searchIndexService->search($search, $this->indexName($kind));
+    }
+
+    private function indexName(ElementKind $kind): string
+    {
+        return $this->indexConfig->getIndexName(match ($kind) {
+            ElementKind::Asset => IndexName::ASSET->value,
+            ElementKind::Document => IndexName::DOCUMENT->value,
+            ElementKind::DataObject => IndexName::DATA_OBJECT->value,
+        });
+    }
+
+    private function logFallback(string $operation, Throwable $e): void
+    {
+        $this->logger->info('Telemetry: GDI statistics unavailable for {op}, falling back to SQL: {msg}', [
+            'op' => $operation,
+            'msg' => $e->getMessage(),
+        ]);
+    }
+}

--- a/src/Telemetry/Statistics/GdiElementStatisticsProvider.php
+++ b/src/Telemetry/Statistics/GdiElementStatisticsProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Telemetry\Statistics;
 
+use Exception;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\FieldCategory\SystemField;
 use Pimcore\Bundle\GenericDataIndexBundle\Enum\SearchIndex\IndexName;
 use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\Aggregation\Aggregation;
@@ -25,7 +26,6 @@ use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
 use Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface;
 use Pimcore\Telemetry\Snapshot\Statistics\TreeDepth;
 use Psr\Log\LoggerInterface;
-use Throwable;
 
 /**
  * Search-index-backed {@see ElementStatisticsProviderInterface} that decorates the core SQL provider.
@@ -37,7 +37,9 @@ use Throwable;
  *
  * It is instance-wide by design, so it uses the low-level {@see SearchIndexServiceInterface} (not the
  * permission/workspace-scoped element search services). Each accelerated method degrades to the
- * decorated SQL provider ($inner) when the index is unavailable, errors, or is empty - so telemetry
+ * decorated SQL provider ($inner) on an `Exception` - an unreachable cluster, a rejected query, an
+ * empty index. Errors are deliberately not caught: a defect here should surface at the snapshot
+ * boundary rather than masquerade as a healthy SQL-derived number - so telemetry
  * keeps working on instances without a healthy search cluster, and an index that lags the DB only
  * affects the always-bucketed values within one bucket.
  *
@@ -80,7 +82,7 @@ final readonly class GdiElementStatisticsProvider implements ElementStatisticsPr
 
             // An empty result means the index isn't populated for this kind - prefer the SQL truth.
             return $byType === [] ? $this->inner->typeCounts($kind) : new ElementTypeCounts($byType);
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             $this->logFallback('typeCounts', $e);
 
             return $this->inner->typeCounts($kind);
@@ -131,7 +133,7 @@ final readonly class GdiElementStatisticsProvider implements ElementStatisticsPr
             $buckets = $result->getAggregation('topParent')?->getBuckets() ?? [];
 
             return $buckets === [] ? $this->inner->maxObjectFanout() : $buckets[0]->getDocCount();
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             $this->logFallback('maxObjectFanout', $e);
 
             return $this->inner->maxObjectFanout();
@@ -160,7 +162,7 @@ final readonly class GdiElementStatisticsProvider implements ElementStatisticsPr
         });
     }
 
-    private function logFallback(string $operation, Throwable $e): void
+    private function logFallback(string $operation, Exception $e): void
     {
         $this->logger->info('Telemetry: GDI statistics unavailable for {op}, falling back to SQL: {msg}', [
             'op' => $operation,

--- a/src/Util/Constant/HttpResponseCodes.php
+++ b/src/Util/Constant/HttpResponseCodes.php
@@ -18,6 +18,7 @@ enum HttpResponseCodes: int
     case SUCCESS = 200;
     case CREATED = 201;
     case NOT_COMPLETED = 202;
+    case NO_CONTENT = 204;
     case MULTI_STATUS = 207;
     case REDIRECT = 302;
     case BAD_REQUEST = 400;

--- a/tests/Unit/EventSubscriber/LoginTelemetrySubscriberTest.php
+++ b/tests/Unit/EventSubscriber/LoginTelemetrySubscriberTest.php
@@ -1,0 +1,151 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\EventSubscriber;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\EventSubscriber\LoginTelemetrySubscriber;
+use Pimcore\Model\User;
+use Pimcore\Security\User\User as SecurityUser;
+use Pimcore\Telemetry\TelemetryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
+
+/**
+ * @internal
+ */
+final class LoginTelemetrySubscriberTest extends Unit
+{
+    /**
+     * @var list<array{event: string, properties: array<string, mixed>}>
+     */
+    private array $captured = [];
+
+    public function testSubscribesToLoginSuccess(): void
+    {
+        $this->assertSame(
+            [LoginSuccessEvent::class => 'onLoginSuccess'],
+            LoginTelemetrySubscriber::getSubscribedEvents()
+        );
+    }
+
+    /**
+     * The Studio firewall is stateful and MCP is a separate firewall, so scoping to the two login
+     * routes is what keeps this to exactly one event per login rather than one per request.
+     */
+    public function testIgnoresLoginsOnUnrelatedRoutes(): void
+    {
+        $this->subscriber()->onLoginSuccess($this->event('some_other_firewall_login', admin: true));
+        $this->subscriber()->onLoginSuccess($this->event(null, admin: true));
+
+        $this->assertSame([], $this->captured);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function studioLoginRoutes(): iterable
+    {
+        yield 'credentials login' => ['pimcore_studio_api_login'];
+        yield 'token login' => ['pimcore_studio_api_token_login'];
+    }
+
+    /**
+     * @dataProvider studioLoginRoutes
+     */
+    public function testCapturesExactlyOneEventPerStudioLogin(string $route): void
+    {
+        $this->subscriber()->onLoginSuccess($this->event($route, admin: true));
+
+        $this->assertCount(1, $this->captured);
+        $this->assertSame('studio.login_succeeded', $this->captured[0]['event']);
+    }
+
+    /**
+     * Content-never: the only thing that may leave the instance is whether the account is an admin -
+     * never a user id, name, email, role or session detail.
+     */
+    public function testCapturesOnlyTheIsAdminBoolean(): void
+    {
+        $this->subscriber()->onLoginSuccess($this->event('pimcore_studio_api_login', admin: true));
+
+        $this->assertSame(['is_admin'], array_keys($this->captured[0]['properties']));
+        $this->assertTrue($this->captured[0]['properties']['is_admin']);
+    }
+
+    public function testReportsNonAdminUsersAsSuch(): void
+    {
+        $this->subscriber()->onLoginSuccess($this->event('pimcore_studio_api_login', admin: false));
+
+        $this->assertFalse($this->captured[0]['properties']['is_admin']);
+    }
+
+    /**
+     * A token that carries something other than a Pimcore user must not be reported as an admin.
+     */
+    public function testAForeignUserObjectIsNotTreatedAsAdmin(): void
+    {
+        $this->subscriber()->onLoginSuccess($this->event('pimcore_studio_api_login', admin: null));
+
+        $this->assertFalse($this->captured[0]['properties']['is_admin']);
+    }
+
+    private function subscriber(): LoginTelemetrySubscriber
+    {
+        $telemetry = $this->createMock(TelemetryInterface::class);
+        $telemetry->method('capture')->willReturnCallback(
+            function (string $event, array $properties = []): void {
+                $this->captured[] = ['event' => $event, 'properties' => $properties];
+            }
+        );
+
+        return new LoginTelemetrySubscriber($telemetry);
+    }
+
+    /**
+     * @param bool|null $admin true/false for a Pimcore user, null for a non-Pimcore user object
+     */
+    private function event(?string $route, ?bool $admin): LoginSuccessEvent
+    {
+        $request = new Request();
+        if ($route !== null) {
+            $request->attributes->set('_route', $route);
+        }
+
+        if ($admin === null) {
+            $user = $this->createMock(UserInterface::class);
+        } else {
+            // Pimcore\Model\User is final, and both types are cheap value-ish objects, so build
+            // them for real rather than doubling.
+            $pimcoreUser = new User();
+            $pimcoreUser->setAdmin($admin);
+            $user = new SecurityUser($pimcoreUser);
+        }
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        return new LoginSuccessEvent(
+            $this->createMock(AuthenticatorInterface::class),
+            $this->createMock(Passport::class),
+            $token,
+            $request,
+            null,
+            'pimcore_studio'
+        );
+    }
+}

--- a/tests/Unit/Telemetry/Service/TelemetryServiceTest.php
+++ b/tests/Unit/Telemetry/Service/TelemetryServiceTest.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Telemetry\Service;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Event\PreResponse\OutboxAckResultEvent;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Event\PreResponse\OutboxBatchEvent;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Hydrator\TelemetryHydrator;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Service\TelemetryService;
+use Pimcore\Telemetry\Spool\EncryptedBatch;
+use Pimcore\Telemetry\Spool\TelemetryOutboxInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+final class TelemetryServiceTest extends Unit
+{
+    private const RELAY = 'https://license.pimcore.com/telemetry/v1/ingest';
+
+    /**
+     * An instance without an identity or product key cannot produce a decryptable batch, so the
+     * outbox must not even be claimed - claiming would lease rows that can never be delivered.
+     */
+    public function testAnOutboxThatIsNotReadyIsNeverClaimed(): void
+    {
+        $outbox = $this->createMock(TelemetryOutboxInterface::class);
+        $outbox->method('isReady')->willReturn(false);
+        $outbox->expects($this->never())->method('nextBatch');
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects($this->never())->method('dispatch');
+
+        $this->assertNull($this->service($outbox, $dispatcher)->getNextBatch());
+    }
+
+    public function testAnEmptyOutboxYieldsNoBatch(): void
+    {
+        $outbox = $this->createMock(TelemetryOutboxInterface::class);
+        $outbox->method('isReady')->willReturn(true);
+        $outbox->method('nextBatch')->willReturn(null);
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects($this->never())->method('dispatch');
+
+        $this->assertNull($this->service($outbox, $dispatcher)->getNextBatch());
+    }
+
+    /**
+     * The browser is only a courier: it receives the opaque ciphertext plus the relay address to
+     * post it to. The relay endpoint is server-side configuration and must be hydrated in here.
+     */
+    public function testAClaimedBatchIsHydratedWithTheRelayEndpointAndAnnounced(): void
+    {
+        $outbox = $this->createMock(TelemetryOutboxInterface::class);
+        $outbox->method('isReady')->willReturn(true);
+        $outbox->method('nextBatch')->willReturn(new EncryptedBatch('nonce-1', 'inst-1', 'opaque', 3));
+
+        $dispatched = null;
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                $this->isInstanceOf(OutboxBatchEvent::class),
+                OutboxBatchEvent::EVENT_NAME
+            )
+            ->willReturnCallback(static function (object $event) use (&$dispatched): object {
+                $dispatched = $event;
+
+                return $event;
+            });
+
+        $batch = $this->service($outbox, $dispatcher)->getNextBatch();
+
+        $this->assertNotNull($batch);
+        $this->assertSame('nonce-1', $batch->getNonce());
+        $this->assertSame('inst-1', $batch->getInstanceIdentifier());
+        $this->assertSame('opaque', $batch->getCiphertext());
+        $this->assertSame(self::RELAY, $batch->getRelayEndpoint());
+        $this->assertSame($batch, $dispatched?->getOutboxBatch());
+    }
+
+    public function testAckDelegatesToTheOutboxAndReportsHowManyEventsLeft(): void
+    {
+        $outbox = $this->createMock(TelemetryOutboxInterface::class);
+        $outbox->expects($this->once())->method('ack')->with('nonce-1')->willReturn(7);
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(OutboxAckResultEvent::class), OutboxAckResultEvent::EVENT_NAME)
+            ->willReturnArgument(0);
+
+        $result = $this->service($outbox, $dispatcher)->ackBatch('nonce-1');
+
+        $this->assertSame(7, $result->getAcked());
+    }
+
+    /**
+     * A storage failure is converted to 0 by the core outbox rather than thrown, so the endpoint
+     * answers "nothing was acked" instead of failing the request.
+     */
+    public function testAnAckThatRemovedNothingIsReportedAsZero(): void
+    {
+        $outbox = $this->createMock(TelemetryOutboxInterface::class);
+        $outbox->method('ack')->willReturn(0);
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->method('dispatch')->willReturnArgument(0);
+
+        $this->assertSame(0, $this->service($outbox, $dispatcher)->ackBatch('unknown')->getAcked());
+    }
+
+    private function service(
+        TelemetryOutboxInterface $outbox,
+        EventDispatcherInterface $dispatcher,
+    ): TelemetryService {
+        return new TelemetryService($outbox, new TelemetryHydrator(), $dispatcher, self::RELAY);
+    }
+}

--- a/tests/Unit/Telemetry/Service/TelemetryServiceTest.php
+++ b/tests/Unit/Telemetry/Service/TelemetryServiceTest.php
@@ -108,8 +108,10 @@ final class TelemetryServiceTest extends Unit
     }
 
     /**
-     * A storage failure is converted to 0 by the core outbox rather than thrown, so the endpoint
-     * answers "nothing was acked" instead of failing the request.
+     * 0 is the row count of a DELETE that matched nothing - an unknown nonce, or one whose lease
+     * expired and was released back to pending - not an error. It is reported as-is so the caller
+     * can tell "removed" from "already gone": a client that treats 0 as success would go on
+     * draining against a lease it no longer holds. A genuine storage failure throws instead.
      */
     public function testAnAckThatRemovedNothingIsReportedAsZero(): void
     {

--- a/tests/Unit/Telemetry/Statistics/GdiElementStatisticsProviderTest.php
+++ b/tests/Unit/Telemetry/Statistics/GdiElementStatisticsProviderTest.php
@@ -78,6 +78,34 @@ final class GdiElementStatisticsProviderTest extends Unit
         $this->assertSame(9, $this->provider($this->serviceReturning($result))->maxObjectFanout());
     }
 
+    /**
+     * A reachable but unpopulated index answers with an empty aggregation rather than an error. That
+     * must not be read as "this instance has no assets" - the SQL truth wins.
+     */
+    public function testTypeCountsFallsBackToInnerOnAnEmptyIndex(): void
+    {
+        $emptyIndex = $this->serviceReturning($this->resultWith([
+            new SearchResultAggregation('byType', [], 0, 0, []),
+        ]));
+
+        $counts = $this->provider($emptyIndex, $this->innerReturningSentinels())->typeCounts(ElementKind::Asset);
+
+        $this->assertSame(7, $counts->ofType('sentinel'), 'an empty index must not shadow the SQL count');
+    }
+
+    public function testMaxObjectFanoutFallsBackToInnerOnAnEmptyIndex(): void
+    {
+        $emptyIndex = $this->serviceReturning($this->resultWith([
+            new SearchResultAggregation('topParent', [], 0, 0, []),
+        ]));
+
+        $this->assertSame(
+            333,
+            $this->provider($emptyIndex, $this->innerReturningSentinels())->maxObjectFanout(),
+            'an empty index must not report a fan-out of zero'
+        );
+    }
+
     public function testDegradesToInnerWhenTheIndexThrows(): void
     {
         $service = $this->createMock(SearchIndexServiceInterface::class);

--- a/tests/Unit/Telemetry/Statistics/GdiElementStatisticsProviderTest.php
+++ b/tests/Unit/Telemetry/Statistics/GdiElementStatisticsProviderTest.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Telemetry\Statistics;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\DefaultSearch\DefaultSearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResult;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultAggregation;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\SearchResultAggregationBucket;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\SearchIndexServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\SearchIndex\SearchIndexConfigServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Telemetry\Statistics\GdiElementStatisticsProvider;
+use Pimcore\Telemetry\Snapshot\ElementTypeCounts;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface;
+use Pimcore\Telemetry\Snapshot\Statistics\TreeDepth;
+use Psr\Log\NullLogger;
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class GdiElementStatisticsProviderTest extends Unit
+{
+    public function testTypeCountsReadsTheTermsAggregation(): void
+    {
+        $result = $this->resultWith([
+            new SearchResultAggregation('byType', [
+                new SearchResultAggregationBucket('image', 10),
+                new SearchResultAggregationBucket('folder', 2),
+            ], 0, 0, []),
+        ]);
+
+        $counts = $this->provider($this->serviceReturning($result))->typeCounts(ElementKind::Asset);
+
+        $this->assertSame(12, $counts->total());
+        $this->assertSame(10, $counts->ofType('image'));
+        $this->assertSame(2, $counts->distinctTypes());
+    }
+
+    /**
+     * The index derives pathLevel differently for folders (getRealFullPath) than for other elements
+     * (getPath), and variants have an empty path column, so no constant offset reproduces the
+     * emitted slash-count. Depth must therefore come from SQL on every instance, healthy index or
+     * not - otherwise two installs report different depths for identical data.
+     */
+    public function testTreeDepthAlwaysComesFromSqlEvenWhenTheIndexIsHealthy(): void
+    {
+        $healthyIndex = $this->serviceReturning($this->resultWith([
+            new SearchResultAggregation('depthMax', [], 0, 0, ['value' => 3.0]),
+            new SearchResultAggregation('depthAvg', [], 0, 0, ['value' => 2.0]),
+        ]));
+
+        $depth = $this->provider($healthyIndex, $this->innerReturningSentinels())
+            ->treeDepth(ElementKind::DataObject);
+
+        $this->assertSame(99, $depth->max, 'depth must be the inner SQL value, not pathLevel+1');
+        $this->assertSame(88, $depth->avg);
+    }
+
+    public function testMaxObjectFanoutReadsTheTopParentBucket(): void
+    {
+        $result = $this->resultWith([
+            new SearchResultAggregation('topParent', [new SearchResultAggregationBucket(5, 9)], 0, 0, []),
+        ]);
+
+        $this->assertSame(9, $this->provider($this->serviceReturning($result))->maxObjectFanout());
+    }
+
+    public function testDegradesToInnerWhenTheIndexThrows(): void
+    {
+        $service = $this->createMock(SearchIndexServiceInterface::class);
+        $service->method('createPaginatedSearch')->willThrowException(new RuntimeException('cluster down'));
+
+        $provider = $this->provider($service, $this->innerReturningSentinels());
+
+        $this->assertSame(7, $provider->typeCounts(ElementKind::Asset)->ofType('sentinel'));
+        $this->assertSame(99, $provider->treeDepth(ElementKind::DataObject)->max);
+        $this->assertSame(333, $provider->maxObjectFanout());
+    }
+
+    public function testVariantMetricsAlwaysDelegateToInner(): void
+    {
+        $provider = $this->provider(
+            $this->createMock(SearchIndexServiceInterface::class),
+            $this->innerReturningSentinels(),
+        );
+
+        $this->assertSame(111, $provider->objectsWithVariants());
+        $this->assertSame(222, $provider->maxVariantsPerObject());
+    }
+
+    private function serviceReturning(SearchResult $result): SearchIndexServiceInterface
+    {
+        $search = $this->createMock(DefaultSearchInterface::class);
+        $search->method('addAggregation')->willReturnSelf();
+
+        $service = $this->createMock(SearchIndexServiceInterface::class);
+        $service->method('createPaginatedSearch')->willReturn($search);
+        $service->method('search')->willReturn($result);
+
+        return $service;
+    }
+
+    /**
+     * @param SearchResultAggregation[] $aggregations
+     */
+    private function resultWith(array $aggregations): SearchResult
+    {
+        return new SearchResult([], $aggregations, 0, null, $this->createMock(DefaultSearchInterface::class), []);
+    }
+
+    private function provider(
+        SearchIndexServiceInterface $service,
+        ?ElementStatisticsProviderInterface $inner = null,
+    ): GdiElementStatisticsProvider {
+        $config = $this->createMock(SearchIndexConfigServiceInterface::class);
+        $config->method('getIndexName')->willReturn('idx');
+
+        return new GdiElementStatisticsProvider(
+            $inner ?? $this->createMock(ElementStatisticsProviderInterface::class),
+            $service,
+            $config,
+            new NullLogger(),
+        );
+    }
+
+    private function innerReturningSentinels(): ElementStatisticsProviderInterface
+    {
+        $inner = $this->createMock(ElementStatisticsProviderInterface::class);
+        $inner->method('typeCounts')->willReturn(new ElementTypeCounts(['sentinel' => 7]));
+        $inner->method('treeDepth')->willReturn(new TreeDepth(99, 88));
+        $inner->method('objectsWithVariants')->willReturn(111);
+        $inner->method('maxVariantsPerObject')->willReturn(222);
+        $inner->method('maxObjectFanout')->willReturn(333);
+
+        return $inner;
+    }
+}

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -1133,6 +1133,7 @@ tag_schedule_description: Get schedules for an element
 tag_settings_description: Get System Settings
 tag_tags_description: Tag operations to get/list/create/update/delete tags
 tag_tags_for_element_description: Tag operations to get tags for an element
+tag_telemetry_description: Telemetry outbox operations to drain and acknowledge spooled telemetry batches
 tag_translation_description: Get translations either for a single key or multiple
   keys
 tag_unassign_from_element_description: |
@@ -1151,6 +1152,17 @@ tag_versions_description: Versions operations to get/list/publish/delete and cle
   versions
 tag_website_settings_description: Website settings operations to list/update/create/delete website settings
 tag_workflows_description: Workflows operations to get element workflow details
+telemetry_outbox_ack_description: |
+  Acknowledge a telemetry outbox batch that the relay has accepted, identified by the given <strong>{nonce}</strong>. <br>
+  Acknowledged events are permanently removed from the outbox pool.
+telemetry_outbox_ack_success_response: Number of spooled events removed from the outbox
+telemetry_outbox_ack_summary: Acknowledge a drained telemetry batch
+telemetry_outbox_next_batch_description: |
+  Get the next encrypted telemetry batch from the outbox so the browser can forward it to the relay. <br>
+  Returns <strong>204 No Content</strong> when the outbox is not ready or the pool is empty.
+telemetry_outbox_next_batch_no_content_response: No telemetry batch is currently available to drain
+telemetry_outbox_next_batch_success_response: Next encrypted telemetry batch ready to forward to the relay
+telemetry_outbox_next_batch_summary: Get the next telemetry outbox batch
 thumbnail_image_get_collection_description: |
   Get collection of thumbnails for images. <br>
   The thumbnails have to be defined as downloadable in order to be listed in the collection.


### PR DESCRIPTION
Part of https://github.com/pimcore/product-management/issues/1243

Studio-side half of server-side product telemetry. Companion to pimcore/pimcore#19336 — **that PR must merge first**, this builds on the interfaces it adds.

## Outbox endpoints

`GET /pimcore-studio/api/telemetry/outbox` hands the browser one encrypted batch (204 when there is nothing to send); `POST .../outbox/ack` confirms delivery. This is what lets an instance with no outbound internet access still report — the browser acts as courier. The payload is opaque: it is encrypted with the instance product key, so the page cannot read the telemetry it carries.

## Generic Data Index acceleration

The snapshot's heaviest figures are counts-by-type and folder fan-out over the element tables, which MySQL can only answer with full scans — `assets.type` and `documents.type` are not indexed. GDI already holds those as keyword fields, so `GdiElementStatisticsProvider` decorates core's `ElementStatisticsProviderInterface` and answers them with instance-wide aggregations that never touch the transactional database.

It uses the low-level `SearchIndexServiceInterface` rather than the element search services, which are permission-scoped and would under-report an instance-wide census. Each accelerated method falls back to the decorated SQL provider when the index is unavailable, errors, or is empty, so telemetry keeps working on instances without a healthy search cluster.

**Tree depth deliberately stays on SQL.** The index derives `pathLevel` from `getRealFullPath()` for folders but `getPath()` for everything else, and variants have an empty `path` column — so no constant offset reproduces the emitted slash-count. Verified against live data. Serving depth from one source keeps it comparable across instances regardless of index health.

## Notes

- `LoginTelemetrySubscriber` emits `studio.login_succeeded` with only an `is_admin` boolean — no user id, name, email or session data.
- Unit tests cover the aggregation parsing, the SQL-fallback path, and that depth never comes from the index.