### PR TITLE
[Symfony 8] Inject RateLimiterFactoryInterface instead of the concrete factory

### DIFF
--- a/doc/02_Installation_and_Configuration/05_Upgrade.md
+++ b/doc/02_Installation_and_Configuration/05_Upgrade.md
@@ -2,6 +2,37 @@
 
 The following steps are necessary during updating to newer versions.
 
+## Upgrade to 2026.3.0
+
+### `RateLimiterInterface::check()` now expects `RateLimiterFactoryInterface`
+
+Symfony 8.0 removes the autowiring aliases for the concrete
+`Symfony\Component\RateLimiter\RateLimiterFactory`. All injections of that class in this bundle were
+changed to `Symfony\Component\RateLimiter\RateLimiterFactoryInterface`, including the public
+`Pimcore\Bundle\StudioBackendBundle\User\RateLimiter\RateLimiterInterface`:
+
+```diff
+-public function check(RateLimiterFactory $rateLimiterFactory): void;
++public function check(RateLimiterFactoryInterface $rateLimiterFactory): void;
+```
+
+**[Code BC break] If you implement `RateLimiterInterface` yourself, you have to widen the parameter type
+as well** — keeping the concrete `RateLimiterFactory` violates parameter contravariance and PHP raises a
+fatal error (`Declaration of ... must be compatible with ...`). The service is swappable via
+`config/users.yaml`, so custom implementations are a supported scenario.
+
+```php
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+public function check(RateLimiterFactoryInterface $rateLimiterFactory): void
+```
+
+**Callers are not affected.** `RateLimiterFactory` implements `RateLimiterFactoryInterface`, so any code
+passing a limiter factory into `check()` keeps working unchanged.
+
+Behaviour is unchanged otherwise: `RateLimiterFactoryInterface` exists since Symfony 7.3 and its only
+method, `create()`, is signature-identical to the concrete class's.
+
 ## Upgrade to 2025.4.6
 - [GDPR Objects Export] Fixed: the data object export now includes inherited values (including inherited localized fields).
 

--- a/src/EventSubscriber/RateLimitSubscriber.php
+++ b/src/EventSubscriber/RateLimitSubscriber.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\RateLimiter\RateLimit;
-use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 
 /**
  * @internal
@@ -33,8 +33,8 @@ final class RateLimitSubscriber implements EventSubscriberInterface
 
     public function __construct(
         private readonly string $urlPrefix,
-        private readonly RateLimiterFactory $studioApiGeneralLimiter,
-        private readonly RateLimiterFactory $studioMcpGeneralLimiter,
+        private readonly RateLimiterFactoryInterface $studioApiGeneralLimiter,
+        private readonly RateLimiterFactoryInterface $studioMcpGeneralLimiter,
         private readonly bool $enabled = true,
     ) {
     }
@@ -83,7 +83,7 @@ final class RateLimitSubscriber implements EventSubscriberInterface
      * traffic, where a single agent server can serve every chat in the installation from one
      * address, so the Studio UI's per-user budget does not describe them.
      */
-    private function resolveLimiterFactory(string $path): ?RateLimiterFactory
+    private function resolveLimiterFactory(string $path): ?RateLimiterFactoryInterface
     {
         return match (true) {
             $this->isStudioBackendPath($path, $this->urlPrefix) => $this->studioApiGeneralLimiter,

--- a/src/Security/RateLimiter/McpLoginRateLimiter.php
+++ b/src/Security/RateLimiter/McpLoginRateLimiter.php
@@ -17,7 +17,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Security\RateLimiter;
 use Symfony\Component\HttpFoundation\RateLimiter\AbstractRequestRateLimiter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\RateLimiter\LimiterInterface;
-use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
@@ -28,7 +28,7 @@ final class McpLoginRateLimiter extends AbstractRequestRateLimiter implements Mc
     private const string UNKNOWN_CLIENT = 'unknown';
 
     public function __construct(
-        private readonly RateLimiterFactory $limiterFactory,
+        private readonly RateLimiterFactoryInterface $limiterFactory,
     ) {
     }
 

--- a/src/Setting/Admin/Controller/ThumbnailController.php
+++ b/src/Setting/Admin/Controller/ThumbnailController.php
@@ -27,7 +27,7 @@ use Pimcore\Bundle\StudioBackendBundle\Setting\Admin\Service\ThumbnailServiceInt
 use Pimcore\Bundle\StudioBackendBundle\User\RateLimiter\RateLimiterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -41,7 +41,7 @@ final class ThumbnailController extends AbstractApiController
         SerializerInterface $serializer,
         private readonly ThumbnailServiceInterface $thumbnailService,
         private readonly RateLimiterInterface $rateLimiter,
-        private readonly RateLimiterFactory $settingAdminThumbnailLimiter,
+        private readonly RateLimiterFactoryInterface $settingAdminThumbnailLimiter,
     ) {
         parent::__construct($serializer);
     }

--- a/src/User/Controller/ResetPasswordController.php
+++ b/src/User/Controller/ResetPasswordController.php
@@ -28,7 +28,7 @@ use Pimcore\Bundle\StudioBackendBundle\User\Service\UserLoginServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
-use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -42,7 +42,7 @@ final class ResetPasswordController extends AbstractApiController
         SerializerInterface $serializer,
         private readonly UserLoginServiceInterface $loginService,
         private readonly RateLimiterInterface $rateLimiter,
-        private readonly RateLimiterFactory $resetPasswordLimiter,
+        private readonly RateLimiterFactoryInterface $resetPasswordLimiter,
     ) {
         parent::__construct($serializer);
     }

--- a/src/User/RateLimiter/RateLimiter.php
+++ b/src/User/RateLimiter/RateLimiter.php
@@ -17,7 +17,7 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\RateLimitException;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\RequestTrait;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\RateLimiter\Exception\RateLimitExceededException;
-use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 
 final readonly class RateLimiter implements RateLimiterInterface
 {
@@ -32,7 +32,7 @@ final readonly class RateLimiter implements RateLimiterInterface
      * @throws RateLimitException
      */
     public function check(
-        RateLimiterFactory $rateLimiterFactory,
+        RateLimiterFactoryInterface $rateLimiterFactory,
     ): void {
         $request = $this->getCurrentRequest($this->requestStack);
 

--- a/src/User/RateLimiter/RateLimiterInterface.php
+++ b/src/User/RateLimiter/RateLimiterInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\User\RateLimiter;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\RateLimitException;
-use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 
 interface RateLimiterInterface
 {
@@ -22,6 +22,6 @@ interface RateLimiterInterface
      * @throws RateLimitException
      */
     public function check(
-        RateLimiterFactory $rateLimiterFactory,
+        RateLimiterFactoryInterface $rateLimiterFactory,
     ): void;
 }


### PR DESCRIPTION
## What

Replaces the concrete `Symfony\Component\RateLimiter\RateLimiterFactory` with
`RateLimiterFactoryInterface` — **7 site(s) across 6 file(s)** — plus the matching import.

- `doc/02_Installation_and_Configuration/05_Upgrade.md`
- `src/EventSubscriber/RateLimitSubscriber.php`
- `src/Security/RateLimiter/McpLoginRateLimiter.php`
- `src/Setting/Admin/Controller/ThumbnailController.php`
- `src/User/Controller/ResetPasswordController.php`
- `src/User/RateLimiter/RateLimiter.php`
- `src/User/RateLimiter/RateLimiterInterface.php`

Only three kinds of edit: the import, the type-hints, and (where present) a return type. No behaviour,
service definition or test changes.

## Why

Symfony 8.0 **removes the autowiring aliases** for the concrete `RateLimiterFactory`
(`UPGRADE-8.0.md`, FrameworkBundle and SecurityBundle; deprecated since 7.3).

**Behaviour is unchanged on 7.4**, verified against the installed tree (`symfony/rate-limiter v7.4.14`):
`RateLimiterFactoryInterface` has existed **since 7.3**, `final class RateLimiterFactory implements
RateLimiterFactoryInterface`, and its only method — `create(?string $key = null): LimiterInterface` — is
signature-identical. This code calls nothing but `create()`.

Worth being precise about the urgency: the injections here are bound explicitly to a `@limiter.*` service,
whose class stays `RateLimiterFactory` in 8.0, so this particular site would not break at the bump. The
swap is hygiene and future-proofing — a limiter reconfigured as a **compound** limiter is a
`CompoundRateLimiterFactory`, which does *not* extend the concrete class and would only satisfy the
interface type.

Neither PHPStan nor runtime deprecations flag this — the deprecation fires on the alias, and only for
autowired injections. It was found by grep during the platform analysis.

## ⚠️ This one touches public API (please carry into the release notes)

`data-hub-simple-rest` and `openid-connect` got the identical change on `@internal final` classes. Here,
one of the six files is public API:

`Pimcore\Bundle\StudioBackendBundle\User\RateLimiter\RateLimiterInterface` has **no `@internal` marker**,
and `config/users.yaml` maps it as a swappable service — so custom implementations are a supported
scenario. Its only method exposes the concrete factory directly:

```diff
-public function check(RateLimiterFactory $rateLimiterFactory): void;
+public function check(RateLimiterFactoryInterface $rateLimiterFactory): void;
```

**Impact — implementers, not callers:**

- **Callers keep working, unchanged.** `RateLimiterFactory` implements `RateLimiterFactoryInterface`, so
  every existing call site still type-checks. Verified: in-repo `ResetPasswordController` and
  `ThumbnailController`, and cross-repo `pimcore/openid-connect`'s `EndpointController` / `ScriptController`,
  which import this interface and call `check()`.
- **Third-party implementations break** — a narrower parameter type violates contravariance and PHP raises
  a fatal error. They must widen the parameter to `RateLimiterFactoryInterface` too.

**Why widen now rather than deprecate:** Symfony 8.0 does not force this particular signature — the class
survives, only its autowiring alias goes. But PHP cannot accept both signatures at once, so a deprecation
cycle cannot soften the change; it only delays it. Doing it in 2026.3 means integrators adjust once, on a
release that documents it, instead of during the Symfony 8 bump. Documented in
`doc/02_Installation_and_Configuration/05_Upgrade.md` (added in this PR).

A related follow-up, not done here: the analysis suggests marking this interface `@internal` in the next
major if custom rate limiters were never an intended extension point.
## Verification

The central check gained two rules for this in
pimcore/workflows-collection-public#156, merged **before** this PR on purpose, so
**`api-scan (ratelimiter-factory-typehint)` and `api-scan (ratelimiter-factory-import)` on this PR are
the test** — both were failing on this branch's base and must be green here.

Locally the gates ran all five central rules extracted from the merged workflow (clean after the edit),
plus `php -l`, a php-cs-fixer `ordered_imports` check, and a diff-shape check.

## Context

Sweep 3 of the Symfony 7.4 → 8 migration (`pimcore/platform-version`, `migration-analysis/SUMMARY.md` §3,
runbook `EXEC-RATELIMITER.md`): 11 sites across 9 files in 3 repos, one PR each. Sweeps 1 and 2
(`#[TaggedIterator]` → `#[AutowireIterator]`, and the voter `?Vote` argument) are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
