### PR TITLE
[Element] Add hasViewAccess flag to RelatedElementData based on view permission

### DIFF
--- a/src/Element/Schema/RelatedElementData.php
+++ b/src/Element/Schema/RelatedElementData.php
@@ -38,7 +38,11 @@ final readonly class RelatedElementData
         private string $fullPath,
         #[Property(description: 'Is the element published', type: 'boolean', example: true)]
         private ?bool $isPublished = null,
-        #[Property(description: 'Whether the current user is allowed to view the element', type: 'boolean', example: true)]
+        #[Property(
+            description: 'Whether the current user is allowed to view the element',
+            type: 'boolean',
+            example: true
+        )]
         private bool $hasAccess = true,
     ) {
     }

--- a/src/Element/Schema/RelatedElementData.php
+++ b/src/Element/Schema/RelatedElementData.php
@@ -22,7 +22,7 @@ use OpenApi\Attributes\Schema;
 #[Schema(
     schema: 'RelatedElementData',
     title: 'RelatedElementData',
-    required: ['id', 'type', 'subtype', 'fullPath', 'isPublished', 'hasAccess'],
+    required: ['id', 'type', 'subtype', 'fullPath', 'isPublished', 'hasViewAccess'],
     type: 'object'
 )]
 final readonly class RelatedElementData
@@ -43,7 +43,7 @@ final readonly class RelatedElementData
             type: 'boolean',
             example: true
         )]
-        private bool $hasAccess = true,
+        private bool $hasViewAccess = true,
     ) {
     }
 
@@ -72,8 +72,8 @@ final readonly class RelatedElementData
         return $this->isPublished;
     }
 
-    public function getHasAccess(): bool
+    public function getHasViewAccess(): bool
     {
-        return $this->hasAccess;
+        return $this->hasViewAccess;
     }
 }

--- a/src/Element/Schema/RelatedElementData.php
+++ b/src/Element/Schema/RelatedElementData.php
@@ -22,7 +22,7 @@ use OpenApi\Attributes\Schema;
 #[Schema(
     schema: 'RelatedElementData',
     title: 'RelatedElementData',
-    required: ['id', 'type', 'subtype', 'fullPath', 'isPublished'],
+    required: ['id', 'type', 'subtype', 'fullPath', 'isPublished', 'hasAccess'],
     type: 'object'
 )]
 final readonly class RelatedElementData
@@ -38,6 +38,8 @@ final readonly class RelatedElementData
         private string $fullPath,
         #[Property(description: 'Is the element published', type: 'boolean', example: true)]
         private ?bool $isPublished = null,
+        #[Property(description: 'Whether the current user is allowed to view the element', type: 'boolean', example: true)]
+        private bool $hasAccess = true,
     ) {
     }
 
@@ -64,5 +66,10 @@ final readonly class RelatedElementData
     public function getIsPublished(): ?bool
     {
         return $this->isPublished;
+    }
+
+    public function getHasAccess(): bool
+    {
+        return $this->hasAccess;
     }
 }

--- a/src/Element/Service/ElementDataService.php
+++ b/src/Element/Service/ElementDataService.php
@@ -13,11 +13,16 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Permission\ElementPermissionServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Schema\RelatedElementData;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Document;
 use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\User;
 
 /**
  * @internal
@@ -26,6 +31,12 @@ final readonly class ElementDataService implements ElementDataServiceInterface
 {
     use ElementProviderTrait;
 
+    public function __construct(
+        private SecurityServiceInterface $securityService,
+        private ElementPermissionServiceInterface $elementPermissionService,
+    ) {
+    }
+
     public function getRelatedElementData(ElementInterface $element): RelatedElementData
     {
         return new RelatedElementData(
@@ -33,7 +44,27 @@ final readonly class ElementDataService implements ElementDataServiceInterface
             $this->getElementType($element, true),
             $this->getSubType($element),
             $element->getRealFullPath(),
-            $this->getPublished($element)
+            $this->getPublished($element),
+            $this->hasViewAccess($element)
+        );
+    }
+
+    private function hasViewAccess(ElementInterface $element): bool
+    {
+        try {
+            $user = $this->securityService->getCurrentUser();
+        } catch (UserNotFoundException) {
+            return false;
+        }
+
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        return $this->elementPermissionService->isAllowed(
+            ElementPermissions::VIEW_PERMISSION,
+            $element,
+            $user
         );
     }
 

--- a/src/Element/Service/ElementDataService.php
+++ b/src/Element/Service/ElementDataService.php
@@ -59,8 +59,6 @@ final readonly class ElementDataService implements ElementDataServiceInterface
             return false;
         }
 
-        // Core check instead of the GDI permission seam: this runs per relation row,
-        // and the GDI check normalizes the whole element per call.
         return $element->isAllowed(ElementPermissions::VIEW_PERMISSION, $user);
     }
 

--- a/src/Element/Service/ElementDataService.php
+++ b/src/Element/Service/ElementDataService.php
@@ -59,8 +59,8 @@ final readonly class ElementDataService implements ElementDataServiceInterface
             return false;
         }
 
-        // Intentionally the core check, not the GDI permission seam: this runs per relation row,
-        // and the GDI check normalizes the whole element per call (see PR #1983).
+        // Core check instead of the GDI permission seam: this runs per relation row,
+        // and the GDI check normalizes the whole element per call.
         return $element->isAllowed(ElementPermissions::VIEW_PERMISSION, $user);
     }
 

--- a/src/Element/Service/ElementDataService.php
+++ b/src/Element/Service/ElementDataService.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
 
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Permission\ElementPermissionServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Schema\RelatedElementData;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
@@ -33,7 +32,6 @@ final readonly class ElementDataService implements ElementDataServiceInterface
 
     public function __construct(
         private SecurityServiceInterface $securityService,
-        private ElementPermissionServiceInterface $elementPermissionService,
     ) {
     }
 
@@ -61,11 +59,9 @@ final readonly class ElementDataService implements ElementDataServiceInterface
             return false;
         }
 
-        return $this->elementPermissionService->isAllowed(
-            ElementPermissions::VIEW_PERMISSION,
-            $element,
-            $user
-        );
+        // Intentionally the core check, not the GDI permission seam: this runs per relation row,
+        // and the GDI check normalizes the whole element per call (see PR #1983).
+        return $element->isAllowed(ElementPermissions::VIEW_PERMISSION, $user);
     }
 
     private function getSubType(ElementInterface $element): string

--- a/tests/Unit/Element/Service/ElementDataServiceTest.php
+++ b/tests/Unit/Element/Service/ElementDataServiceTest.php
@@ -15,13 +15,11 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service;
 
 use Codeception\Test\Unit;
 use Exception;
-use Pimcore\Bundle\GenericDataIndexBundle\Service\Permission\ElementPermissionServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementDataService;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Model\Asset;
-use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\User;
 use Pimcore\Model\UserInterface;
 
@@ -35,12 +33,12 @@ final class ElementDataServiceTest extends Unit
      */
     public function testHasAccessTrueWhenViewIsAllowed(): void
     {
-        $service = $this->createService(isAllowed: true, calls: $calls);
+        $service = $this->createService();
 
-        $data = $service->getRelatedElementData($this->makeAsset());
+        $data = $service->getRelatedElementData($this->makeAsset(isAllowed: true, calls: $calls));
 
         $this->assertTrue($data->getHasAccess());
-        $this->assertSame([[ElementPermissions::VIEW_PERMISSION, 83]], $calls);
+        $this->assertSame([[ElementPermissions::VIEW_PERMISSION, true]], $calls);
         $this->assertSame(83, $data->getId());
         $this->assertSame('asset', $data->getType());
         $this->assertSame('image', $data->getSubtype());
@@ -53,12 +51,12 @@ final class ElementDataServiceTest extends Unit
      */
     public function testHasAccessFalseWhenViewIsDenied(): void
     {
-        $service = $this->createService(isAllowed: false, calls: $calls);
+        $service = $this->createService();
 
-        $data = $service->getRelatedElementData($this->makeAsset());
+        $data = $service->getRelatedElementData($this->makeAsset(isAllowed: false, calls: $calls));
 
         $this->assertFalse($data->getHasAccess());
-        $this->assertSame([[ElementPermissions::VIEW_PERMISSION, 83]], $calls);
+        $this->assertSame([[ElementPermissions::VIEW_PERMISSION, true]], $calls);
     }
 
     /**
@@ -71,14 +69,12 @@ final class ElementDataServiceTest extends Unit
                 throw new UserNotFoundException();
             },
         ]);
-        $service = new ElementDataService(
-            $securityService,
-            $this->makeEmpty(ElementPermissionServiceInterface::class)
-        );
+        $service = new ElementDataService($securityService);
 
-        $data = $service->getRelatedElementData($this->makeAsset());
+        $data = $service->getRelatedElementData($this->makeAsset(isAllowed: true, calls: $calls));
 
         $this->assertFalse($data->getHasAccess());
+        $this->assertSame([], $calls);
     }
 
     /**
@@ -89,53 +85,44 @@ final class ElementDataServiceTest extends Unit
         $securityService = $this->makeEmpty(SecurityServiceInterface::class, [
             'getCurrentUser' => $this->makeEmpty(UserInterface::class),
         ]);
-        $service = new ElementDataService(
-            $securityService,
-            $this->makeEmpty(ElementPermissionServiceInterface::class)
-        );
+        $service = new ElementDataService($securityService);
 
-        $data = $service->getRelatedElementData($this->makeAsset());
+        $data = $service->getRelatedElementData($this->makeAsset(isAllowed: true, calls: $calls));
 
         $this->assertFalse($data->getHasAccess());
+        $this->assertSame([], $calls);
     }
 
     /**
-     * @param array<int, array{string, int}>|null $calls
-     *
      * @throws Exception
      */
-    private function createService(bool $isAllowed, ?array &$calls = null): ElementDataService
+    private function createService(): ElementDataService
     {
-        $calls = [];
-
         $securityService = $this->makeEmpty(SecurityServiceInterface::class, [
             'getCurrentUser' => new User(),
         ]);
 
-        $elementPermissionService = $this->makeEmpty(ElementPermissionServiceInterface::class, [
-            'isAllowed' => function (
-                string $permission,
-                ElementInterface $element,
-                User $user
-            ) use (&$calls, $isAllowed): bool {
-                $calls[] = [$permission, $element->getId()];
-
-                return $isAllowed;
-            },
-        ]);
-
-        return new ElementDataService($securityService, $elementPermissionService);
+        return new ElementDataService($securityService);
     }
 
     /**
+     * @param array<int, array{string, bool}>|null $calls
+     *
      * @throws Exception
      */
-    private function makeAsset(): Asset
+    private function makeAsset(bool $isAllowed, ?array &$calls = null): Asset
     {
+        $calls = [];
+
         return $this->makeEmpty(Asset::class, [
             'getId' => 83,
             'getType' => 'image',
             'getRealFullPath' => '/path/to/asset.jpg',
+            'isAllowed' => function (string $type, ?User $user = null) use (&$calls, $isAllowed): bool {
+                $calls[] = [$type, $user instanceof User];
+
+                return $isAllowed;
+            },
         ]);
     }
 }

--- a/tests/Unit/Element/Service/ElementDataServiceTest.php
+++ b/tests/Unit/Element/Service/ElementDataServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\Permission\ElementPermissionServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementDataService;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\UserNotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
+use Pimcore\Model\Asset;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\User;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+final class ElementDataServiceTest extends Unit
+{
+    /**
+     * @throws Exception
+     */
+    public function testHasAccessTrueWhenViewIsAllowed(): void
+    {
+        $service = $this->createService(isAllowed: true, calls: $calls);
+
+        $data = $service->getRelatedElementData($this->makeAsset());
+
+        $this->assertTrue($data->getHasAccess());
+        $this->assertSame([[ElementPermissions::VIEW_PERMISSION, 83]], $calls);
+        $this->assertSame(83, $data->getId());
+        $this->assertSame('asset', $data->getType());
+        $this->assertSame('image', $data->getSubtype());
+        $this->assertSame('/path/to/asset.jpg', $data->getFullPath());
+        $this->assertNull($data->getIsPublished());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testHasAccessFalseWhenViewIsDenied(): void
+    {
+        $service = $this->createService(isAllowed: false, calls: $calls);
+
+        $data = $service->getRelatedElementData($this->makeAsset());
+
+        $this->assertFalse($data->getHasAccess());
+        $this->assertSame([[ElementPermissions::VIEW_PERMISSION, 83]], $calls);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testHasAccessFalseWhenNoUserIsAuthenticated(): void
+    {
+        $securityService = $this->makeEmpty(SecurityServiceInterface::class, [
+            'getCurrentUser' => static function (): UserInterface {
+                throw new UserNotFoundException();
+            },
+        ]);
+        $service = new ElementDataService(
+            $securityService,
+            $this->makeEmpty(ElementPermissionServiceInterface::class)
+        );
+
+        $data = $service->getRelatedElementData($this->makeAsset());
+
+        $this->assertFalse($data->getHasAccess());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testHasAccessFalseWhenUserIsNotAPimcoreUser(): void
+    {
+        $securityService = $this->makeEmpty(SecurityServiceInterface::class, [
+            'getCurrentUser' => $this->makeEmpty(UserInterface::class),
+        ]);
+        $service = new ElementDataService(
+            $securityService,
+            $this->makeEmpty(ElementPermissionServiceInterface::class)
+        );
+
+        $data = $service->getRelatedElementData($this->makeAsset());
+
+        $this->assertFalse($data->getHasAccess());
+    }
+
+    /**
+     * @param array<int, array{string, int}>|null $calls
+     *
+     * @throws Exception
+     */
+    private function createService(bool $isAllowed, ?array &$calls = null): ElementDataService
+    {
+        $calls = [];
+
+        $securityService = $this->makeEmpty(SecurityServiceInterface::class, [
+            'getCurrentUser' => new User(),
+        ]);
+
+        $elementPermissionService = $this->makeEmpty(ElementPermissionServiceInterface::class, [
+            'isAllowed' => function (
+                string $permission,
+                ElementInterface $element,
+                User $user
+            ) use (&$calls, $isAllowed): bool {
+                $calls[] = [$permission, $element->getId()];
+
+                return $isAllowed;
+            },
+        ]);
+
+        return new ElementDataService($securityService, $elementPermissionService);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function makeAsset(): Asset
+    {
+        return $this->makeEmpty(Asset::class, [
+            'getId' => 83,
+            'getType' => 'image',
+            'getRealFullPath' => '/path/to/asset.jpg',
+        ]);
+    }
+}

--- a/tests/Unit/Element/Service/ElementDataServiceTest.php
+++ b/tests/Unit/Element/Service/ElementDataServiceTest.php
@@ -31,13 +31,13 @@ final class ElementDataServiceTest extends Unit
     /**
      * @throws Exception
      */
-    public function testHasAccessTrueWhenViewIsAllowed(): void
+    public function testHasViewAccessTrueWhenViewIsAllowed(): void
     {
         $service = $this->createService();
 
         $data = $service->getRelatedElementData($this->makeAsset(isAllowed: true, calls: $calls));
 
-        $this->assertTrue($data->getHasAccess());
+        $this->assertTrue($data->getHasViewAccess());
         $this->assertSame([[ElementPermissions::VIEW_PERMISSION, true]], $calls);
         $this->assertSame(83, $data->getId());
         $this->assertSame('asset', $data->getType());
@@ -49,20 +49,20 @@ final class ElementDataServiceTest extends Unit
     /**
      * @throws Exception
      */
-    public function testHasAccessFalseWhenViewIsDenied(): void
+    public function testHasViewAccessFalseWhenViewIsDenied(): void
     {
         $service = $this->createService();
 
         $data = $service->getRelatedElementData($this->makeAsset(isAllowed: false, calls: $calls));
 
-        $this->assertFalse($data->getHasAccess());
+        $this->assertFalse($data->getHasViewAccess());
         $this->assertSame([[ElementPermissions::VIEW_PERMISSION, true]], $calls);
     }
 
     /**
      * @throws Exception
      */
-    public function testHasAccessFalseWhenNoUserIsAuthenticated(): void
+    public function testHasViewAccessFalseWhenNoUserIsAuthenticated(): void
     {
         $securityService = $this->makeEmpty(SecurityServiceInterface::class, [
             'getCurrentUser' => static function (): UserInterface {
@@ -73,14 +73,14 @@ final class ElementDataServiceTest extends Unit
 
         $data = $service->getRelatedElementData($this->makeAsset(isAllowed: true, calls: $calls));
 
-        $this->assertFalse($data->getHasAccess());
+        $this->assertFalse($data->getHasViewAccess());
         $this->assertSame([], $calls);
     }
 
     /**
      * @throws Exception
      */
-    public function testHasAccessFalseWhenUserIsNotAPimcoreUser(): void
+    public function testHasViewAccessFalseWhenUserIsNotAPimcoreUser(): void
     {
         $securityService = $this->makeEmpty(SecurityServiceInterface::class, [
             'getCurrentUser' => $this->makeEmpty(UserInterface::class),
@@ -89,7 +89,7 @@ final class ElementDataServiceTest extends Unit
 
         $data = $service->getRelatedElementData($this->makeAsset(isAllowed: true, calls: $calls));
 
-        $this->assertFalse($data->getHasAccess());
+        $this->assertFalse($data->getHasViewAccess());
         $this->assertSame([], $calls);
     }
 


### PR DESCRIPTION
## Summary

- Adds a `hasViewAccess` boolean to the `RelatedElementData` schema (default `true`), telling the
  client whether the current user is allowed to **view** the referenced element.
- `ElementDataService` computes the flag via the core `$element->isAllowed('view', $user)` check —
  one indexed workspace query per row, no per-row element normalization (see performance note below).
- Denies by default when no user can be resolved.
- Ships a Codeception unit test covering allowed / denied / unauthenticated / non-Pimcore-user.

Enables pimcore/studio-ui-bundle#3898 (gate the per-row Open button on `hasViewAccess`).

## Relation to #1872

Reworked from #1872 (thanks @Jonathon-Meney-Torq!), addressing the review feedback there:

- **`ElementDataService` stays `final readonly`** — no subclassing needed.
- **No `GridSearch` change** — skipping workspace/user restrictions for `system.ids` filter
  queries would let any authenticated user read grid data for arbitrary elements outside their
  workspace; the endpoint cannot verify the IDs actually come from a relation the user is
  viewing. Dropped entirely.
- **No `canEdit` / `RelationNormalizationContext`** — the Remove action edits the *parent*
  object, and the Studio UI already disables it via the parent's save/publish permissions
  (`edit-form-provider`), so no per-row flag and no mutable normalization-context service is
  needed.

## Performance note (resolved)

The first iteration computed the flag through the GDI `ElementPermissionServiceInterface`, but that
transforms the full element per call — `DataObjectNormalizer::normalizeStandardFields()` walks every
field definition and triggers lazy loads, per relation row. Since this runs on the object-detail hot
path, 84d5f65f switched to the core `isAllowed()` check: one cheap indexed `users_workspaces_object`
query per row, constant cost regardless of class complexity, with precedent in
`WorkflowElementsService`. Actual security enforcement stays at the (GDI-based) element endpoints —
this flag is a rendering hint.

The unit test mocks the seam, so a later switch to an index-batched approach stays cheap.

## Naming

The flag is named `hasViewAccess` (not `hasAccess`) to state precisely which permission it reports,
matching the existing vocabulary (`Permissions` schema, `UserWorkspace::hasView()`) and keeping the
name unambiguous next to a possible future edit-side flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)