### PR TITLE
Do not require view permission on the element tree root

### DIFF
--- a/src/Element/Service/ElementService.php
+++ b/src/Element/Service/ElementService.php
@@ -106,11 +106,9 @@ final readonly class ElementService implements ElementServiceInterface
     ): ElementInterface {
         $element = $this->getElementByPath($this->serviceResolver, $elementType, $elementPath);
 
-        // The tree root is a traversal anchor, not an element a user gets a workspace on: element
-        // permissions are resolved from the workspaces relevant for the requested path, and no
-        // workspace below "/" is relevant for "/" itself, so the root always resolves to "no
-        // permissions" for non-admins. ElementTreeWidgetConfigHydrator::isDefaultRootFolder()
-        // already skips the lookup for the root path for the same reason.
+        // The root is used as a traversal anchor by tree operations. Descendant workspaces are not
+        // relevant to "/" itself, so users with access only to descendants cannot pass the root check.
+        // ElementTreeWidgetConfigHydrator::isDefaultRootFolder() already skips this lookup.
         if ($elementPath !== ElementFolderPaths::ROOT->value) {
             $this->securityService->hasElementPermission($element, $user, ElementPermissions::VIEW_PERMISSION);
         }

--- a/src/Element/Service/ElementService.php
+++ b/src/Element/Service/ElementService.php
@@ -23,6 +23,7 @@ use Pimcore\Bundle\StudioBackendBundle\Element\Schema\Subtype;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\ElementParameters;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementFolderPaths;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
@@ -104,7 +105,15 @@ final readonly class ElementService implements ElementServiceInterface
         UserInterface $user
     ): ElementInterface {
         $element = $this->getElementByPath($this->serviceResolver, $elementType, $elementPath);
-        $this->securityService->hasElementPermission($element, $user, ElementPermissions::VIEW_PERMISSION);
+
+        // The tree root is a traversal anchor, not an element a user gets a workspace on: element
+        // permissions are resolved from the workspaces relevant for the requested path, and no
+        // workspace below "/" is relevant for "/" itself, so the root always resolves to "no
+        // permissions" for non-admins. ElementTreeWidgetConfigHydrator::isDefaultRootFolder()
+        // already skips the lookup for the root path for the same reason.
+        if ($elementPath !== ElementFolderPaths::ROOT->value) {
+            $this->securityService->hasElementPermission($element, $user, ElementPermissions::VIEW_PERMISSION);
+        }
 
         return $element;
     }


### PR DESCRIPTION
Fixes pimcore/platform-version#313

## Problem

`ElementService::getAllowedElementByPath()` enforces `view` on the resolved element unconditionally. Two of its callers resolve the perspective's root folder `/` with it:

- `TreeQuery::handleTreeSorting()` — `src/DataIndex/Query/TreeQuery.php:128`
- `ElementTreeWidgetRepository::getParentElements()` — `src/Perspective/Repository/ElementTreeWidgetRepository.php:123`

Element permissions come from the workspaces relevant for the requested path — `WorkspaceService::getRelevantWorkspaces()` picks a workspace via `str_contains($path, $workspace->getPath())`. For the path `/`, no workspace below `/` is relevant, so the root resolves to "no permissions at all" for every non-admin:

| id | path | list | view |
|----|------|------|------|
| 1 | `/` | 0 | 0 |
| 4758 | `/SomeFolder` | 1 | 1 |
| 7221 | `/SomeFolder/Child/Leaf` | 1 | 1 |

The result is a 403 from `GET /element/tree-location` for every non-admin user — "show in tree" silently does nothing — even though the element the user asked for was already permission-checked. No workspace configuration fixes this short of granting an explicit workspace on `/`, and downgrading the check to `list` would not help either: the generic-data-index permission model has no implicit ancestor permission (only the legacy `User::isAllowed()` has).

## Fix

Skip the check when the requested path is the root path.

The root is only *traversed* in these calls — children sorting and the tree expansion path — never opened as an element, and the located element itself is still `view`-checked in `ElementLocationService::getElementLocation()`.

This mirrors an existing special case in the same bundle: `ElementTreeWidgetConfigHydrator::isDefaultRootFolder()` (`src/Perspective/Hydrator/ElementTreeWidgetConfigHydrator.php:82`) already short-circuits `''` and `/` to a hard-coded root node without any permission lookup — which is why the tree renders today while locating an element fails.

## Verification

`ElementLocationService::getElementLocation('data-object', 7221, 'studio_default_perspective')` as a non-admin user with object workspaces on `/SomeFolder`:

```
before: ForbiddenException: You dont have view permission   (SecurityService.php:87)
after:  OK widgetId=studio_data_object_tree_widget
          parentId=1    elementId=4758 page=1
          parentId=4758 elementId=7220 page=1
          parentId=7220 elementId=7221 page=1
```

Element-type agnostic, so it covers the asset and document trees as well.

## Notes

- The change touches the shared `getAllowedElementByPath()`, so it applies to all six call sites. Reviewed each: `ElementTreeWidgetConfigHydrator` never passes `/` (guarded by `isDefaultRootFolder()`), `SiteHydrator` resolves a site root document, and the remaining three (`getElementIdByPath()`, `TreeQuery`, `WidgetValidationService`) would previously fail for `/` for every non-admin. If you would rather keep the guard local to the tree traversal instead of in the shared method, say so and I will move it.
- No test added: there is currently no test covering `ElementService` in `tests/`, and reproducing this needs a non-admin user plus workspace rows. Happy to add one if you point me at the preferred place.
