### PR TITLE
[Telemetry] add missing OpenAPI examples for telemetry outbox schemas

### DIFF
--- a/src/Telemetry/Schema/OutboxAckParameters.php
+++ b/src/Telemetry/Schema/OutboxAckParameters.php
@@ -28,7 +28,11 @@ use OpenApi\Attributes\Schema;
 final readonly class OutboxAckParameters
 {
     public function __construct(
-        #[Property(description: 'Lease nonce of the batch the relay has accepted', type: 'string')]
+        #[Property(
+            description: 'Lease nonce of the batch the relay has accepted',
+            type: 'string',
+            example: '9b1c4f7a2e6d40318c5a7b9e0d2f4a61'
+        )]
         private string $nonce,
     ) {
     }

--- a/src/Telemetry/Schema/OutboxBatch.php
+++ b/src/Telemetry/Schema/OutboxBatch.php
@@ -32,21 +32,31 @@ final class OutboxBatch implements AdditionalAttributesInterface
     use AdditionalAttributesTrait;
 
     public function __construct(
-        #[Property(description: 'Lease nonce identifying the claimed batch, passed back on ack', type: 'string')]
+        #[Property(
+            description: 'Lease nonce identifying the claimed batch, passed back on ack',
+            type: 'string',
+            example: '9b1c4f7a2e6d40318c5a7b9e0d2f4a61'
+        )]
         private readonly string $nonce,
         #[Property(
             description: 'Cleartext instance identifier the relay uses to look up the product key',
-            type: 'string'
+            type: 'string',
+            example: 'my-pimcore-instance'
         )]
         private readonly string $instanceIdentifier,
         #[Property(description: 'Outbox payload protocol version', type: 'integer', example: 1)]
         private readonly int $v,
         #[Property(
             description: 'Opaque product-key encrypted envelope to forward verbatim to the relay',
-            type: 'string'
+            type: 'string',
+            example: 'AqiJ8s3TnQz1FQmSMHBZR2xlYXNlZC10ZWxlbWV0cnktZW52ZWxvcGU='
         )]
         private readonly string $ciphertext,
-        #[Property(description: 'Relay endpoint the browser must POST the ciphertext to', type: 'string')]
+        #[Property(
+            description: 'Relay endpoint the browser must POST the ciphertext to',
+            type: 'string',
+            example: 'https://relay.example.com/'
+        )]
         private readonly string $relayEndpoint,
     ) {
     }


### PR DESCRIPTION
## Changes in this pull request

The Postman schema validation suite (`Schema Validation / Verify Component Adherence`) requires an `example` on every schema property. Five telemetry outbox properties had none, failing five assertions:

- `TelemetryOutboxAckParameters.nonce`
- `TelemetryOutboxBatch.nonce`
- `TelemetryOutboxBatch.instanceIdentifier`
- `TelemetryOutboxBatch.ciphertext`
- `TelemetryOutboxBatch.relayEndpoint`

This adds an `example` to each `#[Property]` attribute. `TelemetryOutboxBatch.v` and `TelemetryOutboxAckResult.acked` already had one and are untouched.

The examples are synthetic placeholders that match the real value formats — a 32 character hex lease nonce (`bin2hex(random_bytes(16))` in `TelemetrySpool::uid()`), a base64 encoded envelope (`EnvelopeCipher::encrypt()`), and an RFC 2606 reserved placeholder relay host. No values were copied from a real instance, since examples are published in the OpenAPI spec.

## Additional info

Verified locally:

- Ran `OpenApi\Generator::scan()` over `src/Telemetry/Schema` — all 7 properties across the 3 telemetry schemas now emit an `example` in the generated spec (previously 5 were absent).
- `php-cs-fixer --dry-run` on `src/Telemetry/Schema`: 0 of 3 files need fixing.

Not verified locally:

- The Postman collection itself — `tests/Api/postman/collections` is not present in my checkout, so I could not reproduce the original run. The spec level check above covers exactly what those five assertions test; CI validates the rest.
- `codecept run Unit Telemetry` errors on 12 tests in my environment, but identically with this change reverted — the pinned `vendor/pimcore/pimcore` predates the core `lib/Telemetry` classes those tests mock. Pre-existing and unrelated.

No regression test is added: the Postman schema validation is itself the check that caught this, and it is already part of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)