### PR TITLE
[Assets] Add a batched asset-exists endpoint for uploads

### DIFF
--- a/config/assets.yaml
+++ b/config/assets.yaml
@@ -44,6 +44,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadService
 
+  Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadInfoServiceInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadInfoService
+
   Pimcore\Bundle\StudioBackendBundle\Asset\Service\VideoServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Asset\Service\VideoService
 

--- a/src/Asset/Controller/Upload/BatchInfoController.php
+++ b/src/Asset/Controller/Upload/BatchInfoController.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Asset\Controller\Upload;
 
+use OpenApi\Attributes\Items;
+use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Post;
+use OpenApi\Attributes\Property;
 use OpenApi\Attributes\RequestBody;
 use Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter\FileNamesParameter;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\AssetBatchInfo;
@@ -21,7 +24,6 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadInfoServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
-use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Content\ScalarItemsJson;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParameter;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\ItemsJson;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
@@ -69,7 +71,20 @@ final class BatchInfoController extends AbstractApiController
     )]
     #[IdParameter(type: ElementTypes::TYPE_ASSET, name: 'parentId')]
     #[RequestBody(
-        content: new ScalarItemsJson('string', 'fileNames')
+        required: true,
+        content: new JsonContent(
+            required: ['fileNames'],
+            properties: [
+                new Property(
+                    property: 'fileNames',
+                    type: 'array',
+                    minItems: 1,
+                    maxItems: FileNamesParameter::MAX_FILE_NAMES,
+                    items: new Items(type: 'string')
+                ),
+            ],
+            type: 'object'
+        )
     )]
     #[SuccessResponse(
         description: 'asset_upload_batch_info_success_response',

--- a/src/Asset/Controller/Upload/BatchInfoController.php
+++ b/src/Asset/Controller/Upload/BatchInfoController.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Controller\Upload;
+
+use OpenApi\Attributes\Post;
+use OpenApi\Attributes\RequestBody;
+use Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter\FileNamesParameter;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\AssetBatchInfo;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadInfoServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Content\ScalarItemsJson;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Parameter\Path\IdParameter;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\Content\ItemsJson;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
+use Pimcore\Bundle\StudioBackendBundle\OpenApi\Config\Tags;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseCodes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @internal
+ */
+final class BatchInfoController extends AbstractApiController
+{
+    private const string ROUTE = '/assets/exists/{parentId}';
+
+    public function __construct(
+        SerializerInterface $serializer,
+        private readonly UploadInfoServiceInterface $uploadInfoService,
+        private readonly SecurityServiceInterface $securityService
+    ) {
+        parent::__construct($serializer);
+    }
+
+    /**
+     * @throws ForbiddenException
+     * @throws NotFoundException
+     * @throws UserNotFoundException
+     */
+    #[Route(self::ROUTE, name: 'pimcore_studio_api_asset_upload_batch_info', methods: ['POST'])]
+    #[IsGranted(UserPermissions::ASSETS->value)]
+    #[Post(
+        path: self::PREFIX . self::ROUTE,
+        operationId: 'asset_upload_batch_info',
+        description: 'asset_upload_batch_info_description',
+        summary: 'asset_upload_batch_info_summary',
+        tags: [Tags::Assets->name]
+    )]
+    #[IdParameter(type: ElementTypes::TYPE_ASSET, name: 'parentId')]
+    #[RequestBody(
+        content: new ScalarItemsJson('string', 'fileNames')
+    )]
+    #[SuccessResponse(
+        description: 'asset_upload_batch_info_success_response',
+        content: new ItemsJson(AssetBatchInfo::class)
+    )]
+    #[DefaultResponses([
+        HttpResponseCodes::FORBIDDEN,
+        HttpResponseCodes::UNAUTHORIZED,
+        HttpResponseCodes::NOT_FOUND,
+        HttpResponseCodes::UNPROCESSABLE_CONTENT,
+    ])]
+    public function getAssetsExist(
+        int $parentId,
+        #[MapRequestPayload] FileNamesParameter $parameter
+    ): JsonResponse {
+
+        return $this->jsonResponse(
+            [
+                'items' => $this->uploadInfoService->filesExist(
+                    $parentId,
+                    $parameter->getFileNames(),
+                    $this->securityService->getCurrentUser()
+                ),
+            ]
+        );
+    }
+}

--- a/src/Asset/MappedParameter/FileNamesParameter.php
+++ b/src/Asset/MappedParameter/FileNamesParameter.php
@@ -40,12 +40,13 @@ final readonly class FileNamesParameter
             throw new InvalidArgumentException('fileNames array cannot be empty.');
         }
 
-        if (count($this->fileNames) > self::MAX_FILE_NAMES) {
+        $fileNamesCount = count($this->fileNames);
+        if ($fileNamesCount > self::MAX_FILE_NAMES) {
             throw new InvalidArgumentException(
                 sprintf(
                     'fileNames array cannot contain more than %d items, %d given.',
                     self::MAX_FILE_NAMES,
-                    count($this->fileNames)
+                    $fileNamesCount
                 )
             );
         }

--- a/src/Asset/MappedParameter/FileNamesParameter.php
+++ b/src/Asset/MappedParameter/FileNamesParameter.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Model\Element\Service as ElementService;
 use function count;
 use function is_string;
 use function sprintf;
@@ -51,7 +53,7 @@ final readonly class FileNamesParameter
             );
         }
 
-        foreach ($this->fileNames as $fileName) {
+        foreach ($this->fileNames as $index => $fileName) {
             if (!is_string($fileName) || $fileName === '') {
                 throw new InvalidArgumentException('Each fileNames item must be a non-empty string.');
             }
@@ -59,6 +61,13 @@ final readonly class FileNamesParameter
             if (str_contains($fileName, '/') || str_contains($fileName, '\\')) {
                 throw new InvalidArgumentException('Each fileNames item must be a single asset key.');
             }
+
+            $validFileName = ElementService::getValidKey($fileName, ElementTypes::TYPE_ASSET);
+            if ($validFileName === '') {
+                throw new InvalidArgumentException('Each fileNames item must be a valid asset key.');
+            }
+
+            $this->fileNames[$index] = $validFileName;
         }
     }
 

--- a/src/Asset/MappedParameter/FileNamesParameter.php
+++ b/src/Asset/MappedParameter/FileNamesParameter.php
@@ -14,14 +14,17 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
-use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
-use Pimcore\Model\Element\Service as ElementService;
 use function count;
 use function is_string;
 use function sprintf;
 use function str_contains;
 
 /**
+ * Checks the shape of the request body only. Turning a name into an asset key
+ * needs the element service, which cannot be reached from here — the serializer
+ * builds this object from the payload, so nothing can be injected into it — and
+ * happens in UploadInfoService instead.
+ *
  * @internal
  */
 final readonly class FileNamesParameter
@@ -33,16 +36,22 @@ final readonly class FileNamesParameter
     public const int MAX_FILE_NAMES = 100;
 
     /**
-     * @param array<string> $fileNames
+     * @var array<string>
      */
-    public function __construct(
-        private array $fileNames
-    ) {
-        if (empty($this->fileNames)) {
+    private array $fileNames;
+
+    /**
+     * @param array<string> $fileNames
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(array $fileNames)
+    {
+        if (empty($fileNames)) {
             throw new InvalidArgumentException('fileNames array cannot be empty.');
         }
 
-        $fileNamesCount = count($this->fileNames);
+        $fileNamesCount = count($fileNames);
         if ($fileNamesCount > self::MAX_FILE_NAMES) {
             throw new InvalidArgumentException(
                 sprintf(
@@ -53,7 +62,7 @@ final readonly class FileNamesParameter
             );
         }
 
-        foreach ($this->fileNames as $index => $fileName) {
+        foreach ($fileNames as $fileName) {
             if (!is_string($fileName) || $fileName === '') {
                 throw new InvalidArgumentException('Each fileNames item must be a non-empty string.');
             }
@@ -61,14 +70,9 @@ final readonly class FileNamesParameter
             if (str_contains($fileName, '/') || str_contains($fileName, '\\')) {
                 throw new InvalidArgumentException('Each fileNames item must be a single asset key.');
             }
-
-            $validFileName = ElementService::getValidKey($fileName, ElementTypes::TYPE_ASSET);
-            if ($validFileName === '') {
-                throw new InvalidArgumentException('Each fileNames item must be a valid asset key.');
-            }
-
-            $this->fileNames[$index] = $validFileName;
         }
+
+        $this->fileNames = $fileNames;
     }
 
     /**

--- a/src/Asset/MappedParameter/FileNamesParameter.php
+++ b/src/Asset/MappedParameter/FileNamesParameter.php
@@ -15,7 +15,9 @@ namespace Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use function count;
+use function is_string;
 use function sprintf;
+use function str_contains;
 
 /**
  * @internal
@@ -46,6 +48,16 @@ final readonly class FileNamesParameter
                     count($this->fileNames)
                 )
             );
+        }
+
+        foreach ($this->fileNames as $fileName) {
+            if (!is_string($fileName) || $fileName === '') {
+                throw new InvalidArgumentException('Each fileNames item must be a non-empty string.');
+            }
+
+            if (str_contains($fileName, '/') || str_contains($fileName, '\\')) {
+                throw new InvalidArgumentException('Each fileNames item must be a single asset key.');
+            }
         }
     }
 

--- a/src/Asset/MappedParameter/FileNamesParameter.php
+++ b/src/Asset/MappedParameter/FileNamesParameter.php
@@ -20,10 +20,8 @@ use function sprintf;
 use function str_contains;
 
 /**
- * Checks the shape of the request body only. Turning a name into an asset key
- * needs the element service, which cannot be reached from here — the serializer
- * builds this object from the payload, so nothing can be injected into it — and
- * happens in UploadInfoService instead.
+ * Validates the shape of the body. Resolving names to asset keys needs the
+ * element service and happens in UploadInfoService.
  *
  * @internal
  */

--- a/src/Asset/MappedParameter/FileNamesParameter.php
+++ b/src/Asset/MappedParameter/FileNamesParameter.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter;
+
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use function count;
+use function sprintf;
+
+/**
+ * @internal
+ */
+final readonly class FileNamesParameter
+{
+    /**
+     * Upper bound for a single existence check request. Each file name is resolved
+     * individually, so an unbounded list would hold a worker for an arbitrary time.
+     */
+    public const int MAX_FILE_NAMES = 100;
+
+    /**
+     * @param array<string> $fileNames
+     */
+    public function __construct(
+        private array $fileNames
+    ) {
+        if (empty($this->fileNames)) {
+            throw new InvalidArgumentException('fileNames array cannot be empty.');
+        }
+
+        if (count($this->fileNames) > self::MAX_FILE_NAMES) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'fileNames array cannot contain more than %d items, %d given.',
+                    self::MAX_FILE_NAMES,
+                    count($this->fileNames)
+                )
+            );
+        }
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getFileNames(): array
+    {
+        return $this->fileNames;
+    }
+}

--- a/src/Asset/Schema/AssetBatchInfo.php
+++ b/src/Asset/Schema/AssetBatchInfo.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+
+#[Schema(
+    schema: 'AssetUploadBatchInfo',
+    title: 'Asset Upload Batch Info',
+    required: ['fileName', 'exists', 'assetId', 'accessDenied'],
+    type: 'object'
+)]
+final readonly class AssetBatchInfo
+{
+    public function __construct(
+        #[Property(description: 'Name of the checked file', type: 'string', example: 'file.jpg')]
+        private string $fileName,
+        #[Property(description: 'True if asset exists', type: 'boolean', example: true)]
+        private bool $exists,
+        #[Property(description: 'Id of existing asset', type: 'integer', example: 83)]
+        private ?int $assetId = null,
+        #[Property(
+            description: 'True if an asset with that name exists but the current user may not view it. ' .
+                'The name is therefore reported as not existing, since no ID can be handed out.',
+            type: 'boolean',
+            example: false
+        )]
+        private bool $accessDenied = false,
+    ) {
+    }
+
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+
+    public function isExists(): bool
+    {
+        return $this->exists;
+    }
+
+    public function getAssetId(): ?int
+    {
+        return $this->assetId;
+    }
+
+    public function isAccessDenied(): bool
+    {
+        return $this->accessDenied;
+    }
+}

--- a/src/Asset/Service/UploadInfoService.php
+++ b/src/Asset/Service/UploadInfoService.php
@@ -65,6 +65,12 @@ final readonly class UploadInfoService implements UploadInfoServiceInterface
                 $result[] = new AssetBatchInfo($fileName, false, null, true);
 
                 continue;
+            } catch (NotFoundException) {
+                // The asset was deleted between the path lookup and loading it, so as far
+                // as this upload is concerned the name is free.
+                $result[] = new AssetBatchInfo($fileName, false);
+
+                continue;
             }
 
             $result[] = new AssetBatchInfo($fileName, true, $asset->getId());

--- a/src/Asset/Service/UploadInfoService.php
+++ b/src/Asset/Service/UploadInfoService.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Asset\Service;
 
 use Pimcore\Bundle\StaticResolverBundle\Models\Asset\AssetServiceResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\AssetBatchInfo;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\UserInterface;
@@ -28,6 +30,7 @@ final readonly class UploadInfoService implements UploadInfoServiceInterface
     public function __construct(
         private AssetServiceInterface $assetService,
         private AssetServiceResolverInterface $assetServiceResolver,
+        private ServiceResolverInterface $serviceResolver,
     ) {
     }
 
@@ -37,6 +40,7 @@ final readonly class UploadInfoService implements UploadInfoServiceInterface
      * @return array<AssetBatchInfo>
      *
      * @throws ForbiddenException
+     * @throws InvalidArgumentException
      * @throws NotFoundException
      */
     public function filesExist(
@@ -49,7 +53,15 @@ final readonly class UploadInfoService implements UploadInfoServiceInterface
         $result = [];
 
         foreach ($fileNames as $fileName) {
-            $filePath = $parentPath . '/' . $fileName;
+            // The name is checked against the key an upload would actually create,
+            // so a name Pimcore would rewrite is not reported as free.
+            $fileKey = $this->serviceResolver->getValidKey($fileName, ElementTypes::TYPE_ASSET);
+
+            if ($fileKey === '') {
+                throw new InvalidArgumentException('Each fileNames item must be a valid asset key.');
+            }
+
+            $filePath = $parentPath . '/' . $fileKey;
 
             if ($this->assetServiceResolver->pathExists($filePath, ElementTypes::TYPE_ASSET) === false) {
                 $result[] = new AssetBatchInfo($fileName, false);

--- a/src/Asset/Service/UploadInfoService.php
+++ b/src/Asset/Service/UploadInfoService.php
@@ -53,8 +53,8 @@ final readonly class UploadInfoService implements UploadInfoServiceInterface
         $result = [];
 
         foreach ($fileNames as $fileName) {
-            // The name is checked against the key an upload would actually create,
-            // so a name Pimcore would rewrite is not reported as free.
+            // Checked as the key an upload would create, so a name Pimcore would
+            // rewrite is not reported as free.
             $fileKey = $this->serviceResolver->getValidKey($fileName, ElementTypes::TYPE_ASSET);
 
             if ($fileKey === '') {

--- a/src/Asset/Service/UploadInfoService.php
+++ b/src/Asset/Service/UploadInfoService.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Service;
+
+use Pimcore\Bundle\StaticResolverBundle\Models\Asset\AssetServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\AssetBatchInfo;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+final readonly class UploadInfoService implements UploadInfoServiceInterface
+{
+    public function __construct(
+        private AssetServiceInterface $assetService,
+        private AssetServiceResolverInterface $assetServiceResolver,
+    ) {
+    }
+
+    /**
+     * @param array<string> $fileNames
+     *
+     * @return array<AssetBatchInfo>
+     *
+     * @throws ForbiddenException
+     * @throws NotFoundException
+     */
+    public function filesExist(
+        int $parentId,
+        array $fileNames,
+        UserInterface $user
+    ): array {
+        $parent = $this->assetService->getAssetElement($user, $parentId);
+        $parentPath = $parent->getRealFullPath();
+        $result = [];
+
+        foreach ($fileNames as $fileName) {
+            $filePath = $parentPath . '/' . $fileName;
+
+            if ($this->assetServiceResolver->pathExists($filePath, ElementTypes::TYPE_ASSET) === false) {
+                $result[] = new AssetBatchInfo($fileName, false);
+
+                continue;
+            }
+
+            // A single file the user may not view must not fail the whole batch, so the
+            // denial is reported on its own entry instead of aborting the request.
+            try {
+                $asset = $this->assetService->getAssetElementByPath($user, $filePath);
+            } catch (ForbiddenException) {
+                $result[] = new AssetBatchInfo($fileName, false, null, true);
+
+                continue;
+            }
+
+            $result[] = new AssetBatchInfo($fileName, true, $asset->getId());
+        }
+
+        return $result;
+    }
+}

--- a/src/Asset/Service/UploadInfoServiceInterface.php
+++ b/src/Asset/Service/UploadInfoServiceInterface.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Asset\Service;
+
+use Pimcore\Bundle\StudioBackendBundle\Asset\Schema\AssetBatchInfo;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+interface UploadInfoServiceInterface
+{
+    /**
+     * Resolves which of the given file names are already taken in the target folder.
+     * The result contains one entry per requested name, in the order they were given.
+     *
+     * @param array<string> $fileNames
+     *
+     * @return array<AssetBatchInfo>
+     *
+     * @throws ForbiddenException
+     * @throws NotFoundException
+     */
+    public function filesExist(
+        int $parentId,
+        array $fileNames,
+        UserInterface $user
+    ): array;
+}

--- a/tests/Unit/Asset/MappedParameter/FileNamesParameterTest.php
+++ b/tests/Unit/Asset/MappedParameter/FileNamesParameterTest.php
@@ -67,10 +67,6 @@ final class FileNamesParameterTest extends Unit
         new FileNamesParameter(['file.jpg', 'subfolder/another.jpg']);
     }
 
-    /**
-     * Names are handed on as sent. Rewriting one into an asset key needs the element
-     * service, so that belongs to UploadInfoService, which can be given a resolver.
-     */
     public function testKeepsEntriesAsGiven(): void
     {
         $this->assertSame(

--- a/tests/Unit/Asset/MappedParameter/FileNamesParameterTest.php
+++ b/tests/Unit/Asset/MappedParameter/FileNamesParameterTest.php
@@ -48,4 +48,22 @@ final class FileNamesParameterTest extends Unit
 
         $this->assertSame($fileNames, (new FileNamesParameter($fileNames))->getFileNames());
     }
+
+    public function testThrowsInvalidArgumentExceptionWhenFileNameIsNotString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new FileNamesParameter(['file.jpg', 1]);
+    }
+
+    public function testThrowsInvalidArgumentExceptionWhenFileNameIsEmpty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new FileNamesParameter(['file.jpg', '']);
+    }
+
+    public function testThrowsInvalidArgumentExceptionWhenFileNameContainsPathSeparator(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new FileNamesParameter(['file.jpg', 'subfolder/another.jpg']);
+    }
 }

--- a/tests/Unit/Asset/MappedParameter/FileNamesParameterTest.php
+++ b/tests/Unit/Asset/MappedParameter/FileNamesParameterTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Asset\MappedParameter;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Asset\MappedParameter\FileNamesParameter;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use function array_fill;
+
+/**
+ * @internal
+ */
+final class FileNamesParameterTest extends Unit
+{
+    public function testThrowsInvalidArgumentExceptionWhenFileNamesEmpty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new FileNamesParameter([]);
+    }
+
+    public function testThrowsInvalidArgumentExceptionWhenFileNamesExceedMaximum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new FileNamesParameter(array_fill(0, FileNamesParameter::MAX_FILE_NAMES + 1, 'file.jpg'));
+    }
+
+    public function testAcceptsExactlyTheMaximumAmountOfFileNames(): void
+    {
+        $parameter = new FileNamesParameter(array_fill(0, FileNamesParameter::MAX_FILE_NAMES, 'file.jpg'));
+
+        $this->assertCount(FileNamesParameter::MAX_FILE_NAMES, $parameter->getFileNames());
+    }
+
+    public function testGetFileNamesKeepsTheGivenOrder(): void
+    {
+        $fileNames = ['b.jpg', 'a.jpg', 'c.jpg'];
+
+        $this->assertSame($fileNames, (new FileNamesParameter($fileNames))->getFileNames());
+    }
+}

--- a/tests/Unit/Asset/MappedParameter/FileNamesParameterTest.php
+++ b/tests/Unit/Asset/MappedParameter/FileNamesParameterTest.php
@@ -67,10 +67,14 @@ final class FileNamesParameterTest extends Unit
         new FileNamesParameter(['file.jpg', 'subfolder/another.jpg']);
     }
 
-    public function testNormalizesEntriesUsingAssetKeyRules(): void
+    /**
+     * Names are handed on as sent. Rewriting one into an asset key needs the element
+     * service, so that belongs to UploadInfoService, which can be given a resolver.
+     */
+    public function testKeepsEntriesAsGiven(): void
     {
         $this->assertSame(
-            ['my-test.jpg'],
+            ['my test.jpg'],
             (new FileNamesParameter(['my test.jpg']))->getFileNames()
         );
     }

--- a/tests/Unit/Asset/MappedParameter/FileNamesParameterTest.php
+++ b/tests/Unit/Asset/MappedParameter/FileNamesParameterTest.php
@@ -66,4 +66,12 @@ final class FileNamesParameterTest extends Unit
         $this->expectException(InvalidArgumentException::class);
         new FileNamesParameter(['file.jpg', 'subfolder/another.jpg']);
     }
+
+    public function testNormalizesEntriesUsingAssetKeyRules(): void
+    {
+        $this->assertSame(
+            ['my-test.jpg'],
+            (new FileNamesParameter(['my test.jpg']))->getFileNames()
+        );
+    }
 }

--- a/tests/Unit/Asset/Service/UploadInfoServiceTest.php
+++ b/tests/Unit/Asset/Service/UploadInfoServiceTest.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Asset\Service;
 use Codeception\Test\Unit;
 use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\Asset\AssetServiceResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadInfoService;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadInfoServiceInterface;
@@ -137,6 +138,26 @@ final class UploadInfoServiceTest extends Unit
     }
 
     /**
+     * The name is looked up as the key an upload would create, so a name Pimcore
+     * would rewrite is not reported as free. The reply still carries what was sent,
+     * since the caller pairs entries with its own files by position.
+     *
+     * @throws Exception
+     */
+    public function testFilesExistLooksUpTheAssetKeyRatherThanTheRawName(): void
+    {
+        $result = $this->getUploadInfoService(['my-test.jpg'])->filesExist(
+            self::PARENT_ID,
+            ['my test.jpg'],
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertTrue($result[0]->isExists());
+        $this->assertSame(self::EXISTING_ASSET_ID, $result[0]->getAssetId());
+        $this->assertSame('my test.jpg', $result[0]->getFileName());
+    }
+
+    /**
      * @param array<string> $existingNames  names that resolve as already taken
      * @param array<string> $deniedNames    names the user may not view
      * @param array<string> $vanishedNames  names that no longer load after the path lookup
@@ -180,6 +201,11 @@ final class UploadInfoServiceTest extends Unit
             ]),
             $this->makeEmpty(AssetServiceResolverInterface::class, [
                 'pathExists' => static fn (string $path) => in_array($path, $existingPaths, true),
+            ]),
+            $this->makeEmpty(ServiceResolverInterface::class, [
+                // Stands in for the element service: spaces become dashes, which is
+                // enough to show the lookup runs against the key, not the raw name.
+                'getValidKey' => static fn (string $key) => str_replace(' ', '-', $key),
             ]),
         );
     }

--- a/tests/Unit/Asset/Service/UploadInfoServiceTest.php
+++ b/tests/Unit/Asset/Service/UploadInfoServiceTest.php
@@ -1,0 +1,152 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Asset\Service;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StaticResolverBundle\Models\Asset\AssetServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadInfoService;
+use Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadInfoServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Model\Asset\Folder;
+use Pimcore\Model\Asset\Image;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+final class UploadInfoServiceTest extends Unit
+{
+    private const string PARENT_PATH = '/parent-folder';
+
+    private const int PARENT_ID = 5;
+
+    private const int EXISTING_ASSET_ID = 83;
+
+    /**
+     * @throws Exception
+     */
+    public function testFilesExistReturnsOneEntryPerNameInRequestOrder(): void
+    {
+        $result = $this->getUploadInfoService(['taken.jpg'])->filesExist(
+            self::PARENT_ID,
+            ['free-a.jpg', 'taken.jpg', 'free-b.jpg'],
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertCount(3, $result);
+        $this->assertSame(
+            ['free-a.jpg', 'taken.jpg', 'free-b.jpg'],
+            array_map(static fn ($info) => $info->getFileName(), $result)
+        );
+        $this->assertSame([false, true, false], array_map(static fn ($info) => $info->isExists(), $result));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testFilesExistReturnsAssetIdForAnExistingName(): void
+    {
+        $result = $this->getUploadInfoService(['taken.jpg'])->filesExist(
+            self::PARENT_ID,
+            ['taken.jpg'],
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertTrue($result[0]->isExists());
+        $this->assertSame(self::EXISTING_ASSET_ID, $result[0]->getAssetId());
+        $this->assertFalse($result[0]->isAccessDenied());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testFilesExistReportsNoAssetIdForAFreeName(): void
+    {
+        $result = $this->getUploadInfoService([])->filesExist(
+            self::PARENT_ID,
+            ['free.jpg'],
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertFalse($result[0]->isExists());
+        $this->assertNull($result[0]->getAssetId());
+        $this->assertFalse($result[0]->isAccessDenied());
+    }
+
+    /**
+     * A name taken by an asset the user may not view must not abort the request,
+     * otherwise one denied file would take the rest of the batch down with it.
+     *
+     * @throws Exception
+     */
+    public function testFilesExistReportsDeniedNameWithoutFailingTheBatch(): void
+    {
+        $result = $this->getUploadInfoService(['taken.jpg', 'denied.jpg'], ['denied.jpg'])->filesExist(
+            self::PARENT_ID,
+            ['denied.jpg', 'taken.jpg'],
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertCount(2, $result);
+
+        $this->assertTrue($result[0]->isAccessDenied());
+        $this->assertFalse($result[0]->isExists());
+        $this->assertNull($result[0]->getAssetId());
+
+        $this->assertFalse($result[1]->isAccessDenied());
+        $this->assertTrue($result[1]->isExists());
+        $this->assertSame(self::EXISTING_ASSET_ID, $result[1]->getAssetId());
+    }
+
+    /**
+     * @param array<string> $existingNames names that resolve as already taken
+     * @param array<string> $deniedNames   names the user may not view
+     *
+     * @throws Exception
+     */
+    private function getUploadInfoService(array $existingNames, array $deniedNames = []): UploadInfoServiceInterface
+    {
+        $existingPaths = array_map(static fn (string $n) => self::PARENT_PATH . '/' . $n, $existingNames);
+        $deniedPaths = array_map(static fn (string $n) => self::PARENT_PATH . '/' . $n, $deniedNames);
+
+        $parent = $this->makeEmpty(Folder::class, [
+            'getRealFullPath' => self::PARENT_PATH,
+        ]);
+
+        $existingAsset = $this->makeEmpty(Image::class, [
+            'getId' => self::EXISTING_ASSET_ID,
+        ]);
+
+        return new UploadInfoService(
+            $this->makeEmpty(AssetServiceInterface::class, [
+                'getAssetElement' => $parent,
+                'getAssetElementByPath' => static function (
+                    UserInterface $user,
+                    string $path
+                ) use ($deniedPaths, $existingAsset) {
+                    if (in_array($path, $deniedPaths, true)) {
+                        throw new ForbiddenException();
+                    }
+
+                    return $existingAsset;
+                },
+            ]),
+            $this->makeEmpty(AssetServiceResolverInterface::class, [
+                'pathExists' => static fn (string $path) => in_array($path, $existingPaths, true),
+            ]),
+        );
+    }
+}

--- a/tests/Unit/Asset/Service/UploadInfoServiceTest.php
+++ b/tests/Unit/Asset/Service/UploadInfoServiceTest.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Asset\Service\AssetServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadInfoService;
 use Pimcore\Bundle\StudioBackendBundle\Asset\Service\UploadInfoServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Model\Asset\Folder;
 use Pimcore\Model\Asset\Image;
 use Pimcore\Model\UserInterface;
@@ -112,15 +113,44 @@ final class UploadInfoServiceTest extends Unit
     }
 
     /**
-     * @param array<string> $existingNames names that resolve as already taken
-     * @param array<string> $deniedNames   names the user may not view
+     * An asset can be deleted between the path lookup and loading it. That name is
+     * free again, and it must not take the rest of the batch down with it.
      *
      * @throws Exception
      */
-    private function getUploadInfoService(array $existingNames, array $deniedNames = []): UploadInfoServiceInterface
+    public function testFilesExistReportsVanishedNameAsFreeWithoutFailingTheBatch(): void
     {
+        $result = $this->getUploadInfoService(['taken.jpg', 'vanished.jpg'], [], ['vanished.jpg'])->filesExist(
+            self::PARENT_ID,
+            ['vanished.jpg', 'taken.jpg'],
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertCount(2, $result);
+
+        $this->assertFalse($result[0]->isExists());
+        $this->assertFalse($result[0]->isAccessDenied());
+        $this->assertNull($result[0]->getAssetId());
+
+        $this->assertTrue($result[1]->isExists());
+        $this->assertSame(self::EXISTING_ASSET_ID, $result[1]->getAssetId());
+    }
+
+    /**
+     * @param array<string> $existingNames  names that resolve as already taken
+     * @param array<string> $deniedNames    names the user may not view
+     * @param array<string> $vanishedNames  names that no longer load after the path lookup
+     *
+     * @throws Exception
+     */
+    private function getUploadInfoService(
+        array $existingNames,
+        array $deniedNames = [],
+        array $vanishedNames = []
+    ): UploadInfoServiceInterface {
         $existingPaths = array_map(static fn (string $n) => self::PARENT_PATH . '/' . $n, $existingNames);
         $deniedPaths = array_map(static fn (string $n) => self::PARENT_PATH . '/' . $n, $deniedNames);
+        $vanishedPaths = array_map(static fn (string $n) => self::PARENT_PATH . '/' . $n, $vanishedNames);
 
         $parent = $this->makeEmpty(Folder::class, [
             'getRealFullPath' => self::PARENT_PATH,
@@ -136,9 +166,13 @@ final class UploadInfoServiceTest extends Unit
                 'getAssetElementByPath' => static function (
                     UserInterface $user,
                     string $path
-                ) use ($deniedPaths, $existingAsset) {
+                ) use ($deniedPaths, $vanishedPaths, $existingAsset) {
                     if (in_array($path, $deniedPaths, true)) {
                         throw new ForbiddenException();
+                    }
+
+                    if (in_array($path, $vanishedPaths, true)) {
+                        throw new NotFoundException('asset', 0);
                     }
 
                     return $existingAsset;

--- a/tests/Unit/Asset/Service/UploadInfoServiceTest.php
+++ b/tests/Unit/Asset/Service/UploadInfoServiceTest.php
@@ -138,9 +138,7 @@ final class UploadInfoServiceTest extends Unit
     }
 
     /**
-     * The name is looked up as the key an upload would create, so a name Pimcore
-     * would rewrite is not reported as free. The reply still carries what was sent,
-     * since the caller pairs entries with its own files by position.
+     * The reply carries the name as sent, since callers pair entries by position.
      *
      * @throws Exception
      */
@@ -203,8 +201,6 @@ final class UploadInfoServiceTest extends Unit
                 'pathExists' => static fn (string $path) => in_array($path, $existingPaths, true),
             ]),
             $this->makeEmpty(ServiceResolverInterface::class, [
-                // Stands in for the element service: spaces become dashes, which is
-                // enough to show the lookup runs against the key, not the raw name.
                 'getValidKey' => static fn (string $key) => str_replace(' ', '-', $key),
             ]),
         );

--- a/translations/studio_api_docs.en.yaml
+++ b/translations/studio_api_docs.en.yaml
@@ -190,6 +190,10 @@ asset_replace_summary: Replace existing asset binary
 asset_update_by_id_description: |
   Update needs to have the complete data present. <br> You can create/update/delete list entries like metadata, custom settings and properties. <br>  E.g. if you want to remove an entry from metadata simply do not include this entry in the update. <br>  If you want to update only a single field, use the PATCH method.
 asset_update_by_id_summary: Update an asset by ID
+asset_upload_batch_info_description: |
+  Get information which of the given file names already exist in the folder <strong>{parentId}</strong>. <br> Send the names in the <strong>fileNames</strong> body property; at most 100 per request.
+asset_upload_batch_info_success_response: Returns one entry per requested file name, in the order they were sent, each with the existing asset ID if a file with that name already exists in the same path. <br> Names that exist but are not viewable by the current user are reported as not existing with <strong>accessDenied</strong> set, so a single denied file does not fail the whole batch
+asset_upload_batch_info_summary: Get information which assets already exist
 asset_upload_info_description: |
   Get information if asset already exists based on the given <strong>{parentId}</strong> and <strong>{fileName}</strong> query parameter.
 asset_upload_info_success_response: Returns true and existing asset ID, if asset with the same name and in the same path already exists, false otherwise


### PR DESCRIPTION
## Why

Checking a large upload batch for duplicate names costs **one `GET /assets/exists/{parentId}` per file**. Per-request overhead (kernel boot, session, security, DI) dominates the actual lookup, so a few hundred files spend most of their time in bootstrap and occupy that many FPM workers.

## What

Adds `POST /assets/exists/{parentId}` next to the existing `GET`. Takes a `fileNames` array, returns one entry per name **in request order**.

```
POST /pimcore-studio/api/assets/exists/1
{ "fileNames": ["a.jpg", "b.png"] }

{ "items": [
  { "fileName": "a.jpg", "exists": true,  "assetId": 83,   "accessDenied": false },
  { "fileName": "b.png", "exists": false, "assetId": null, "accessDenied": false }
] }
```

The `GET` is unchanged and still used by folder drag-and-drop.

Capped at 100 names (`FileNamesParameter::MAX_FILE_NAMES`). Over the cap → `422`.

## Tests

`FileNamesParameterTest` and `UploadServiceTest`, following `ExportFolderFileParameterTest` / `VideoServiceTest`. No controller test — `src/Controller/*` is excluded from coverage in `codeception.dist.yml`.

Covers the 100 cap on both sides of the boundary, result ordering, and the `accessDenied` path.

## Companion

pimcore/studio-ui-bundle#3986

🤖 Generated with [Claude Code](https://claude.com/claude-code)