### PR TITLE
Make draft element resolution pluggable

### DIFF
--- a/config/elements.yaml
+++ b/config/elements.yaml
@@ -42,6 +42,9 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Element\Service\CoauthorServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Element\Service\CoauthorService
 
+  Pimcore\Bundle\StudioBackendBundle\Element\Service\DraftElementResolverInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Element\Service\VersionDraftElementResolver
+
   Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementIndexServiceInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementIndexService
 

--- a/src/DataObject/Service/DataObjectService.php
+++ b/src/DataObject/Service/DataObjectService.php
@@ -327,10 +327,8 @@ final readonly class DataObjectService implements DataObjectServiceInterface
     private function getObjectDetailData(DataObjectFolder|DataObjectDetail $dataObject): void
     {
         $element = $this->getElement($this->serviceResolver, ElementTypes::TYPE_OBJECT, $dataObject->getId());
-        $user = $this->securityService->getCurrentUser();
-        // version = draft identity for `draftData`; element state comes from the resolver
-        $version = $this->getLatestVersionForUser($element, $user);
-        $element = $this->draftElementResolver->resolve($element, $user);
+        $draft = $this->draftElementResolver->resolve($element, $this->securityService->getCurrentUser());
+        $element = $draft->getElement();
 
         if (!$element instanceof DataObjectModel) {
             return;
@@ -339,7 +337,7 @@ final readonly class DataObjectService implements DataObjectServiceInterface
         $this->dataService->setObjectDetailData(
             $dataObject,
             $element,
-            $version
+            $draft->getVersion()
         );
     }
 

--- a/src/DataObject/Service/DataObjectService.php
+++ b/src/DataObject/Service/DataObjectService.php
@@ -29,6 +29,7 @@ use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\DataObjectAddParameters
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\DataObjectDetail;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\Type\DataObjectFolder;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Util\Trait\ValidateObjectDataTrait;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\DraftElementResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementSaveServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementExistsException;
@@ -82,7 +83,8 @@ final readonly class DataObjectService implements DataObjectServiceInterface
         private EventDispatcherInterface $eventDispatcher,
         private SecurityServiceInterface $securityService,
         private ServiceResolverInterface $serviceResolver,
-        private ElementSaveServiceInterface $elementSaveService
+        private ElementSaveServiceInterface $elementSaveService,
+        private DraftElementResolverInterface $draftElementResolver
     ) {
     }
 
@@ -325,8 +327,10 @@ final readonly class DataObjectService implements DataObjectServiceInterface
     private function getObjectDetailData(DataObjectFolder|DataObjectDetail $dataObject): void
     {
         $element = $this->getElement($this->serviceResolver, ElementTypes::TYPE_OBJECT, $dataObject->getId());
-        $version = $this->getLatestVersionForUser($element, $this->securityService->getCurrentUser());
-        $element = $this->getVersionData($element, $version);
+        $user = $this->securityService->getCurrentUser();
+        // version = draft identity for `draftData`; element state comes from the resolver
+        $version = $this->getLatestVersionForUser($element, $user);
+        $element = $this->draftElementResolver->resolve($element, $user);
 
         if (!$element instanceof DataObjectModel) {
             return;

--- a/src/DataObject/Service/LayoutService.php
+++ b/src/DataObject/Service/LayoutService.php
@@ -20,12 +20,12 @@ use Pimcore\Bundle\StudioBackendBundle\Class\Repository\CustomLayoutRepositoryIn
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Event\PreResponse\LayoutEvent;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Hydrator\ObjectLayoutHydratorInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Schema\Layout;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\DraftElementResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\LayoutServiceInterface as SecurityLayoutServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
-use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
 use Pimcore\Bundle\StudioBackendBundle\Workflow\Service\WorkflowDetailsServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Workflow\Util\Trait\WorkflowLayoutTrait;
 use Pimcore\Model\DataObject\ClassDefinition;
@@ -43,7 +43,6 @@ use function sprintf;
  */
 final readonly class LayoutService implements LayoutServiceInterface
 {
-    use ElementProviderTrait;
     use WorkflowLayoutTrait;
 
     public function __construct(
@@ -57,6 +56,7 @@ final readonly class LayoutService implements LayoutServiceInterface
         private SecurityLayoutServiceInterface $securityLayoutService,
         private SecurityServiceInterface $securityService,
         private WorkflowDetailsServiceInterface $workflowDetailsService,
+        private DraftElementResolverInterface $draftElementResolver,
     ) {
     }
 
@@ -71,8 +71,7 @@ final readonly class LayoutService implements LayoutServiceInterface
             $id
         );
 
-        $version = $this->getLatestVersionForUser($dataObject, $user);
-        $dataObject = $this->getVersionData($dataObject, $version);
+        $dataObject = $this->draftElementResolver->resolve($dataObject, $user);
 
         if (!$dataObject instanceof Concrete) {
             throw new InvalidElementTypeException(

--- a/src/DataObject/Service/LayoutService.php
+++ b/src/DataObject/Service/LayoutService.php
@@ -71,7 +71,7 @@ final readonly class LayoutService implements LayoutServiceInterface
             $id
         );
 
-        $dataObject = $this->draftElementResolver->resolve($dataObject, $user);
+        $dataObject = $this->draftElementResolver->resolve($dataObject, $user)->getElement();
 
         if (!$dataObject instanceof Concrete) {
             throw new InvalidElementTypeException(

--- a/src/Document/Service/DocumentService.php
+++ b/src/Document/Service/DocumentService.php
@@ -182,16 +182,14 @@ final readonly class DocumentService implements DocumentServiceInterface
     private function getDocumentDetailData(DocumentDetail $document): void
     {
         $element = $this->getElement($this->serviceResolver, ElementTypes::TYPE_DOCUMENT, $document->getId());
-        $user = $this->securityService->getCurrentUser();
-        // version = draft identity for `draftData`; element state comes from the resolver
-        $version = $this->getLatestVersionForUser($element, $user);
-        $element = $this->draftElementResolver->resolve($element, $user);
+        $draft = $this->draftElementResolver->resolve($element, $this->securityService->getCurrentUser());
+        $element = $draft->getElement();
 
         if (!$element instanceof DocumentModel) {
             return;
         }
 
-        $this->dataService->setDocumentDetailData($document, $element, $version);
+        $this->dataService->setDocumentDetailData($document, $element, $draft->getVersion());
     }
 
     private function setTreeSorting(DocumentQueryInterface $documentQuery, bool $includeParent): void

--- a/src/Document/Service/DocumentService.php
+++ b/src/Document/Service/DocumentService.php
@@ -24,6 +24,7 @@ use Pimcore\Bundle\StudioBackendBundle\Document\Event\PreResponse\DocumentEvent;
 use Pimcore\Bundle\StudioBackendBundle\Document\Schema\Document;
 use Pimcore\Bundle\StudioBackendBundle\Document\Schema\DocumentAddParameters;
 use Pimcore\Bundle\StudioBackendBundle\Document\Schema\DocumentDetail;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\DraftElementResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementExistsException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidElementTypeException;
@@ -58,6 +59,7 @@ final readonly class DocumentService implements DocumentServiceInterface
         private FilterServiceProviderInterface $filterServiceProvider,
         private SecurityServiceInterface $securityService,
         private ServiceResolverInterface $serviceResolver,
+        private DraftElementResolverInterface $draftElementResolver,
     ) {
     }
 
@@ -180,8 +182,10 @@ final readonly class DocumentService implements DocumentServiceInterface
     private function getDocumentDetailData(DocumentDetail $document): void
     {
         $element = $this->getElement($this->serviceResolver, ElementTypes::TYPE_DOCUMENT, $document->getId());
-        $version = $this->getLatestVersionForUser($element, $this->securityService->getCurrentUser());
-        $element = $this->getVersionData($element, $version);
+        $user = $this->securityService->getCurrentUser();
+        // version = draft identity for `draftData`; element state comes from the resolver
+        $version = $this->getLatestVersionForUser($element, $user);
+        $element = $this->draftElementResolver->resolve($element, $user);
 
         if (!$element instanceof DocumentModel) {
             return;

--- a/src/Element/Model/ResolvedDraft.php
+++ b/src/Element/Model/ResolvedDraft.php
@@ -17,11 +17,8 @@ use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Version;
 
 /**
- * The two halves of a draft, resolved together from a single lookup.
- *
- * `element` is the STATE to render. `version` is the draft IDENTITY reported as `draftData`
- * — the row the UI labels and deletes by. They coincide by default; a resolver that stores
- * pending edits elsewhere may return state without an identity.
+ * A draft's state (`element`) and identity (`version`, the `draftData` row). They coincide
+ * by default; a resolver storing edits elsewhere may return state without an identity.
  *
  * @internal
  */

--- a/src/Element/Model/ResolvedDraft.php
+++ b/src/Element/Model/ResolvedDraft.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Element\Model;
+
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Version;
+
+/**
+ * The two halves of a draft, resolved together from a single lookup.
+ *
+ * `element` is the STATE to render. `version` is the draft IDENTITY reported as `draftData`
+ * — the row the UI labels and deletes by. They coincide by default; a resolver that stores
+ * pending edits elsewhere may return state without an identity.
+ *
+ * @internal
+ */
+final readonly class ResolvedDraft
+{
+    public function __construct(
+        private ElementInterface $element,
+        private ?Version $version = null,
+    ) {
+    }
+
+    public function getElement(): ElementInterface
+    {
+        return $this->element;
+    }
+
+    public function getVersion(): ?Version
+    {
+        return $this->version;
+    }
+}

--- a/src/Element/Service/DraftElementResolverInterface.php
+++ b/src/Element/Service/DraftElementResolverInterface.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
+
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\UserInterface;
+
+/**
+ * Which state a read path should render: published, or the user's unsaved edits.
+ *
+ * Default is Pimcore's own — the newest unpublished version for that user. Decorate to store
+ * pending edits elsewhere; every read path follows, instead of each needing to be taught.
+ *
+ * @internal
+ */
+interface DraftElementResolverInterface
+{
+    /**
+     * $element as $user should see it: their draft state if any, otherwise unchanged.
+     *
+     * Must be side-effect free — several run per request, and $element is usually the
+     * runtime-cached instance the write path will go on to use.
+     */
+    public function resolve(ElementInterface $element, ?UserInterface $user): ElementInterface;
+}

--- a/src/Element/Service/DraftElementResolverInterface.php
+++ b/src/Element/Service/DraftElementResolverInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
 
+use Pimcore\Bundle\StudioBackendBundle\Element\Model\ResolvedDraft;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\UserInterface;
 
@@ -29,8 +30,10 @@ interface DraftElementResolverInterface
     /**
      * $element as $user should see it: their draft state if any, otherwise unchanged.
      *
-     * Must be side-effect free — several run per request, and $element is usually the
-     * runtime-cached instance the write path will go on to use.
+     * Must not mutate $element — several of these run per request, and $element is usually the
+     * runtime-cached instance the write path will go on to use. (Loading a version payload does
+     * clear Pimcore's runtime cache via Version::loadData(), so this is not a promise that
+     * calling it is free; it is a promise that the argument comes back untouched.)
      */
-    public function resolve(ElementInterface $element, ?UserInterface $user): ElementInterface;
+    public function resolve(ElementInterface $element, ?UserInterface $user): ResolvedDraft;
 }

--- a/src/Element/Service/DraftElementResolverInterface.php
+++ b/src/Element/Service/DraftElementResolverInterface.php
@@ -18,22 +18,13 @@ use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\UserInterface;
 
 /**
- * Which state a read path should render: published, or the user's unsaved edits.
- *
- * Default is Pimcore's own — the newest unpublished version for that user. Decorate to store
- * pending edits elsewhere; every read path follows, instead of each needing to be taught.
+ * Which state a read path renders: published, or the user's unsaved edits. Default is
+ * Pimcore's newest unpublished version; decorate to store pending edits elsewhere.
  *
  * @internal
  */
 interface DraftElementResolverInterface
 {
-    /**
-     * $element as $user should see it: their draft state if any, otherwise unchanged.
-     *
-     * Must not mutate $element — several of these run per request, and $element is usually the
-     * runtime-cached instance the write path will go on to use. (Loading a version payload does
-     * clear Pimcore's runtime cache via Version::loadData(), so this is not a promise that
-     * calling it is free; it is a promise that the argument comes back untouched.)
-     */
+    /** $element as $user should see it. Must not mutate $element — it is the runtime-cached instance. */
     public function resolve(ElementInterface $element, ?UserInterface $user): ResolvedDraft;
 }

--- a/src/Element/Service/VersionDraftElementResolver.php
+++ b/src/Element/Service/VersionDraftElementResolver.php
@@ -35,8 +35,7 @@ final readonly class VersionDraftElementResolver implements DraftElementResolver
             return new ResolvedDraft($element);
         }
 
-        // Version::loadData() answers null for an unreadable payload — a pruned storage file, or
-        // an __PHP_Incomplete_Class after the class was renamed. Rendering published beats a 500.
+        // null data means an unreadable payload (pruned file, renamed class) — render published, not a 500
         $data = $version->getData();
         if (!$data instanceof ElementInterface) {
             return new ResolvedDraft($element);

--- a/src/Element/Service/VersionDraftElementResolver.php
+++ b/src/Element/Service/VersionDraftElementResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
 
+use Pimcore\Bundle\StudioBackendBundle\Element\Model\ResolvedDraft;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Document\PageSnippet;
@@ -27,14 +28,21 @@ use Pimcore\Model\Version;
  */
 final readonly class VersionDraftElementResolver implements DraftElementResolverInterface
 {
-    public function resolve(ElementInterface $element, ?UserInterface $user): ElementInterface
+    public function resolve(ElementInterface $element, ?UserInterface $user): ResolvedDraft
     {
         $version = $this->getLatestVersionForUser($element, $user);
         if ($version === null) {
-            return $element;
+            return new ResolvedDraft($element);
         }
 
-        return $version->getData();
+        // Version::loadData() answers null for an unreadable payload — a pruned storage file, or
+        // an __PHP_Incomplete_Class after the class was renamed. Rendering published beats a 500.
+        $data = $version->getData();
+        if (!$data instanceof ElementInterface) {
+            return new ResolvedDraft($element);
+        }
+
+        return new ResolvedDraft($data, $version);
     }
 
     private function getLatestVersionForUser(ElementInterface $element, ?UserInterface $user): ?Version

--- a/src/Element/Service/VersionDraftElementResolver.php
+++ b/src/Element/Service/VersionDraftElementResolver.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Element\Service;
+
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\Document\PageSnippet;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\UserInterface;
+use Pimcore\Model\Version;
+
+/**
+ * Pimcore's default: the user's newest unpublished version, if any.
+ *
+ * @internal
+ */
+final readonly class VersionDraftElementResolver implements DraftElementResolverInterface
+{
+    public function resolve(ElementInterface $element, ?UserInterface $user): ElementInterface
+    {
+        $version = $this->getLatestVersionForUser($element, $user);
+        if ($version === null) {
+            return $element;
+        }
+
+        return $version->getData();
+    }
+
+    private function getLatestVersionForUser(ElementInterface $element, ?UserInterface $user): ?Version
+    {
+        // only these three carry versions; asking anything else is a wasted query
+        if (!$element instanceof Asset &&
+            !$element instanceof PageSnippet &&
+            !$element instanceof Concrete
+        ) {
+            return null;
+        }
+
+        return $element->getLatestVersion($user?->getId());
+    }
+}

--- a/src/Property/Service/PropertyService.php
+++ b/src/Property/Service/PropertyService.php
@@ -117,7 +117,9 @@ final readonly class PropertyService implements PropertyServiceInterface
             'properties'
         );
 
-        $element = $this->draftElementResolver->resolve($element, $this->securityService->getCurrentUser());
+        $element = $this->draftElementResolver
+            ->resolve($element, $this->securityService->getCurrentUser())
+            ->getElement();
         $hydratedProperties = [];
 
         foreach ($element->getProperties() as $property) {

--- a/src/Property/Service/PropertyService.php
+++ b/src/Property/Service/PropertyService.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Property\Service;
 
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\DraftElementResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotWriteableException;
@@ -41,7 +42,8 @@ final readonly class PropertyService implements PropertyServiceInterface
         private PropertyHydratorInterface $propertyHydrator,
         private SecurityServiceInterface $securityService,
         private ServiceResolverInterface $serviceResolver,
-        private EventDispatcherInterface $eventDispatcher
+        private EventDispatcherInterface $eventDispatcher,
+        private DraftElementResolverInterface $draftElementResolver
     ) {
     }
 
@@ -115,8 +117,7 @@ final readonly class PropertyService implements PropertyServiceInterface
             'properties'
         );
 
-        $version = $this->getLatestVersionForUser($element, $this->securityService->getCurrentUser());
-        $element = $this->getVersionData($element, $version);
+        $element = $this->draftElementResolver->resolve($element, $this->securityService->getCurrentUser());
         $hydratedProperties = [];
 
         foreach ($element->getProperties() as $property) {

--- a/src/Search/Hydrator/Preview/DataObjectHydrator.php
+++ b/src/Search/Hydrator/Preview/DataObjectHydrator.php
@@ -61,7 +61,9 @@ final readonly class DataObjectHydrator implements DataObjectHydratorInterface
 
     private function hydratePreviewDetailData(DataObject $dataObject): array
     {
-        $versionData = $this->draftElementResolver->resolve($dataObject, $this->securityService->getCurrentUser());
+        $versionData = $this->draftElementResolver
+            ->resolve($dataObject, $this->securityService->getCurrentUser())
+            ->getElement();
 
         if (!$versionData instanceof Concrete) {
             return [];

--- a/src/Search/Hydrator/Preview/DataObjectHydrator.php
+++ b/src/Search/Hydrator/Preview/DataObjectHydrator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Search\Hydrator\Preview;
 
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\DraftElementResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Search\Schema\DataObjectSearchPreview;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Service\UserServiceInterface;
@@ -33,6 +34,7 @@ final readonly class DataObjectHydrator implements DataObjectHydratorInterface
         private DataServiceInterface $dataService,
         private SecurityServiceInterface $securityService,
         private UserServiceInterface $userService,
+        private DraftElementResolverInterface $draftElementResolver,
     ) {
     }
 
@@ -59,8 +61,7 @@ final readonly class DataObjectHydrator implements DataObjectHydratorInterface
 
     private function hydratePreviewDetailData(DataObject $dataObject): array
     {
-        $version = $this->getLatestVersionForUser($dataObject, $this->securityService->getCurrentUser());
-        $versionData = $this->getVersionData($dataObject, $version);
+        $versionData = $this->draftElementResolver->resolve($dataObject, $this->securityService->getCurrentUser());
 
         if (!$versionData instanceof Concrete) {
             return [];

--- a/src/Updater/Service/UpdateService.php
+++ b/src/Updater/Service/UpdateService.php
@@ -158,12 +158,8 @@ final readonly class UpdateService implements UpdateServiceInterface
         return $draftElement;
     }
 
-    /**
-     * Deliberately narrower than the resolver: assets are excluded here even though the resolver
-     * supports them. `useDraftData` rides in on an unvalidated payload array, so widening this
-     * would let an asset update swap the live asset for its latest version before saving. That is
-     * a behaviour change, not a refactor — a decorator wanting asset drafts needs this revisited.
-     */
+    // Excludes assets deliberately: useDraftData is unvalidated, so allowing them would let an
+    // update swap the live asset for its latest version before saving. Revisit before widening.
     private function getDraftElement(ElementInterface $element): ElementInterface
     {
         if (!$element instanceof Concrete && !$element instanceof PageSnippet) {

--- a/src/Updater/Service/UpdateService.php
+++ b/src/Updater/Service/UpdateService.php
@@ -19,6 +19,7 @@ use Pimcore\Bundle\StudioBackendBundle\DataObject\Service\DataServiceInterface a
 use Pimcore\Bundle\StudioBackendBundle\DataObject\Util\Trait\ValidateObjectDataTrait;
 use Pimcore\Bundle\StudioBackendBundle\Document\Service\DataServiceInterface as DocumentDataService;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\CoauthorServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\DraftElementResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementIndexServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementSaveServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementExistsException;
@@ -60,6 +61,7 @@ final readonly class UpdateService implements UpdateServiceInterface
         private ElementIndexServiceInterface $indexService,
         private ElementSaveServiceInterface $elementSaveService,
         private CoauthorServiceInterface $coauthorService,
+        private DraftElementResolverInterface $draftElementResolver,
     ) {
     }
 
@@ -162,8 +164,6 @@ final readonly class UpdateService implements UpdateServiceInterface
             return $element;
         }
 
-        $version = $this->getLatestVersionForUser($element, $this->securityService->getCurrentUser());
-
-        return $this->getVersionData($element, $version);
+        return $this->draftElementResolver->resolve($element, $this->securityService->getCurrentUser());
     }
 }

--- a/src/Updater/Service/UpdateService.php
+++ b/src/Updater/Service/UpdateService.php
@@ -158,12 +158,20 @@ final readonly class UpdateService implements UpdateServiceInterface
         return $draftElement;
     }
 
+    /**
+     * Deliberately narrower than the resolver: assets are excluded here even though the resolver
+     * supports them. `useDraftData` rides in on an unvalidated payload array, so widening this
+     * would let an asset update swap the live asset for its latest version before saving. That is
+     * a behaviour change, not a refactor — a decorator wanting asset drafts needs this revisited.
+     */
     private function getDraftElement(ElementInterface $element): ElementInterface
     {
         if (!$element instanceof Concrete && !$element instanceof PageSnippet) {
             return $element;
         }
 
-        return $this->draftElementResolver->resolve($element, $this->securityService->getCurrentUser());
+        return $this->draftElementResolver
+            ->resolve($element, $this->securityService->getCurrentUser())
+            ->getElement();
     }
 }

--- a/src/Util/Trait/ElementProviderTrait.php
+++ b/src/Util/Trait/ElementProviderTrait.php
@@ -19,11 +19,8 @@ use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
-use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Document;
 use Pimcore\Model\Element\ElementInterface;
-use Pimcore\Model\UserInterface;
-use Pimcore\Model\Version;
 use function get_class;
 
 /**
@@ -61,25 +58,6 @@ trait ElementProviderTrait
         }
 
         return $element;
-    }
-
-    /**
-     * The draft IDENTITY reported as `draftData` (the version row the UI labels and deletes by).
-     * Element STATE is resolved separately via DraftElementResolverInterface; the two coincide
-     * by default and are allowed to diverge.
-     */
-    private function getLatestVersionForUser(
-        ElementInterface $element,
-        ?UserInterface $user,
-    ): ?Version {
-        if (!$element instanceof Asset &&
-            !$element instanceof Document\PageSnippet &&
-            !$element instanceof Concrete
-        ) {
-            return null;
-        }
-
-        return $element->getLatestVersion($user?->getId());
     }
 
     /**

--- a/src/Util/Trait/ElementProviderTrait.php
+++ b/src/Util/Trait/ElementProviderTrait.php
@@ -63,6 +63,11 @@ trait ElementProviderTrait
         return $element;
     }
 
+    /**
+     * The draft IDENTITY reported as `draftData` (the version row the UI labels and deletes by).
+     * Element STATE is resolved separately via DraftElementResolverInterface; the two coincide
+     * by default and are allowed to diverge.
+     */
     private function getLatestVersionForUser(
         ElementInterface $element,
         ?UserInterface $user,
@@ -74,17 +79,7 @@ trait ElementProviderTrait
             return null;
         }
 
-        // check for latest version
         return $element->getLatestVersion($user?->getId());
-    }
-
-    private function getVersionData(ElementInterface $element, ?Version $version): ElementInterface
-    {
-        if (!$version) {
-            return $element;
-        }
-
-        return $version->getData();
     }
 
     /**

--- a/src/Workflow/Service/WorkflowDetailsService.php
+++ b/src/Workflow/Service/WorkflowDetailsService.php
@@ -112,6 +112,7 @@ final readonly class WorkflowDetailsService implements WorkflowDetailsServiceInt
             $elementType,
             $elementId,
         );
-        return $this->draftElementResolver->resolve($element, $user);
+
+        return $this->draftElementResolver->resolve($element, $user)->getElement();
     }
 }

--- a/src/Workflow/Service/WorkflowDetailsService.php
+++ b/src/Workflow/Service/WorkflowDetailsService.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Workflow\Service;
 
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\DraftElementResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
@@ -42,6 +43,7 @@ final readonly class WorkflowDetailsService implements WorkflowDetailsServiceInt
         private SecurityServiceInterface $securityService,
         private ServiceResolverInterface $serviceResolver,
         private WorkflowDetailsHydratorInterface $hydrator,
+        private DraftElementResolverInterface $draftElementResolver,
     ) {
     }
 
@@ -110,8 +112,6 @@ final readonly class WorkflowDetailsService implements WorkflowDetailsServiceInt
             $elementType,
             $elementId,
         );
-        $version = $this->getLatestVersionForUser($element, $user);
-
-        return $this->getVersionData($element, $version);
+        return $this->draftElementResolver->resolve($element, $user);
     }
 }

--- a/tests/Unit/Element/Service/Fixture/DraftCarryingAsset.php
+++ b/tests/Unit/Element/Service/Fixture/DraftCarryingAsset.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service\Fixture;
+
+use Pimcore\Model\Asset;
+
+/**
+ * @internal
+ */
+final class DraftCarryingAsset extends Asset
+{
+    use DraftCarryingTestDouble;
+}

--- a/tests/Unit/Element/Service/Fixture/DraftCarryingObject.php
+++ b/tests/Unit/Element/Service/Fixture/DraftCarryingObject.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service\Fixture;
+
+use Pimcore\Model\DataObject\Concrete;
+
+/**
+ * @internal
+ */
+final class DraftCarryingObject extends Concrete
+{
+    use DraftCarryingTestDouble;
+}

--- a/tests/Unit/Element/Service/Fixture/DraftCarryingPageSnippet.php
+++ b/tests/Unit/Element/Service/Fixture/DraftCarryingPageSnippet.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service\Fixture;
+
+use Pimcore\Model\Document\PageSnippet;
+
+/**
+ * @internal
+ */
+final class DraftCarryingPageSnippet extends PageSnippet
+{
+    use DraftCarryingTestDouble;
+}

--- a/tests/Unit/Element/Service/Fixture/DraftCarryingTestDouble.php
+++ b/tests/Unit/Element/Service/Fixture/DraftCarryingTestDouble.php
@@ -16,11 +16,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service\Fixture;
 use Pimcore\Model\Version;
 
 /**
- * Records what the resolver asked for and answers with a canned version.
- *
- * getLatestVersion() is not declared on the models — it lives on the Dao, reached via
- * __call. A mock cannot intercept it (the mocked __call answers null and the test passes
- * proving nothing), so a subclass declares it for real.
+ * Answers with a canned version. Declares getLatestVersion() for real because it lives on
+ * the Dao via __call, which a mock cannot intercept (it would answer null and prove nothing).
  *
  * @internal
  */

--- a/tests/Unit/Element/Service/Fixture/DraftCarryingTestDouble.php
+++ b/tests/Unit/Element/Service/Fixture/DraftCarryingTestDouble.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service\Fixture;
+
+use Pimcore\Model\Version;
+
+/**
+ * Records what the resolver asked for and answers with a canned version.
+ *
+ * getLatestVersion() is not declared on the models — it lives on the Dao, reached via
+ * __call. A mock cannot intercept it (the mocked __call answers null and the test passes
+ * proving nothing), so a subclass declares it for real.
+ *
+ * @internal
+ */
+trait DraftCarryingTestDouble
+{
+    public ?Version $stubVersion = null;
+
+    public int $calls = 0;
+
+    public ?int $seenUserId = null;
+
+    public function getLatestVersion(?int $userId = null, bool $includingPublished = false): ?Version
+    {
+        $this->calls++;
+        $this->seenUserId = $userId;
+
+        return $this->stubVersion;
+    }
+}

--- a/tests/Unit/Element/Service/VersionDraftElementResolverTest.php
+++ b/tests/Unit/Element/Service/VersionDraftElementResolverTest.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\VersionDraftElementResolver;
+use Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service\Fixture\DraftCarryingAsset;
+use Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service\Fixture\DraftCarryingObject;
+use Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service\Fixture\DraftCarryingPageSnippet;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Folder;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\UserInterface;
+use Pimcore\Model\Version;
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * The default the seven read paths used to inline, and that a bundle decorates.
+ *
+ * @internal
+ */
+final class VersionDraftElementResolverTest extends Unit
+{
+    private const int USER_ID = 7;
+
+    /**
+     * @throws Exception|ReflectionException
+     */
+    public function testReturnsVersionDataWhenTheUserHasADraft(): void
+    {
+        $draftState = $this->makeEmpty(Concrete::class);
+        $element = $this->double(DraftCarryingObject::class, $this->versionHolding($draftState));
+
+        $resolved = (new VersionDraftElementResolver())->resolve($element, $this->user());
+
+        $this->assertSame($draftState, $resolved);
+    }
+
+    /**
+     * @throws Exception|ReflectionException
+     */
+    public function testReturnsTheElementUnchangedWhenThereIsNoDraft(): void
+    {
+        $element = $this->double(DraftCarryingObject::class, null);
+
+        $this->assertSame($element, (new VersionDraftElementResolver())->resolve($element, $this->user()));
+    }
+
+    /** Resolving another user's draft would leak their unpublished edits. */
+    public function testScopesTheLookupToTheGivenUser(): void
+    {
+        $element = $this->double(DraftCarryingObject::class, null);
+
+        (new VersionDraftElementResolver())->resolve($element, $this->user());
+
+        $this->assertSame(1, $element->calls);
+        $this->assertSame(self::USER_ID, $element->seenUserId);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testPassesANullUserThroughRatherThanInventingOne(): void
+    {
+        $element = $this->double(DraftCarryingObject::class, null);
+
+        (new VersionDraftElementResolver())->resolve($element, null);
+
+        $this->assertSame(1, $element->calls);
+        $this->assertNull($element->seenUserId);
+    }
+
+    /** Unversioned types must not be queried at all — seven read paths pay for it. */
+    public function testNeverQueriesElementTypesThatCarryNoVersions(): void
+    {
+        $folder = $this->makeEmpty(Folder::class);
+
+        $this->assertSame($folder, (new VersionDraftElementResolver())->resolve($folder, $this->user()));
+    }
+
+    /** The extraction must not narrow the supported types to Concrete. */
+    public function testResolvesAssetsAndPageSnippetsToo(): void
+    {
+        foreach ([DraftCarryingAsset::class, DraftCarryingPageSnippet::class] as $class) {
+            $draftState = $this->makeEmpty(Concrete::class);
+            $element = $this->double($class, $this->versionHolding($draftState));
+
+            $this->assertSame(
+                $draftState,
+                (new VersionDraftElementResolver())->resolve($element, $this->user()),
+                $class . ' should resolve to its draft state'
+            );
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function user(): UserInterface
+    {
+        return $this->makeEmpty(UserInterface::class, ['getId' => self::USER_ID]);
+    }
+
+    /** Without the constructor: the models reach for the container there. */
+    private function double(string $class, ?Version $version): ElementInterface
+    {
+        /** @var DraftCarryingAsset|DraftCarryingObject|DraftCarryingPageSnippet $element */
+        $element = (new ReflectionClass($class))->newInstanceWithoutConstructor();
+        $element->stubVersion = $version;
+
+        return $element;
+    }
+
+    /**
+     * Version is final and its constructor needs the container too. Priming data also stops
+     * getData() falling back to loading off storage.
+     */
+    private function versionHolding(mixed $data): Version
+    {
+        $version = (new ReflectionClass(Version::class))->newInstanceWithoutConstructor();
+        $version->setData($data);
+
+        return $version;
+    }
+}

--- a/tests/Unit/Element/Service/VersionDraftElementResolverTest.php
+++ b/tests/Unit/Element/Service/VersionDraftElementResolverTest.php
@@ -15,6 +15,8 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service;
 
 use Codeception\Test\Unit;
 use Exception;
+use Pimcore\Bundle\StudioBackendBundle\Element\Model\ResolvedDraft;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\DraftElementResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\VersionDraftElementResolver;
 use Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service\Fixture\DraftCarryingAsset;
 use Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service\Fixture\DraftCarryingObject;
@@ -24,6 +26,7 @@ use Pimcore\Model\DataObject\Folder;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\UserInterface;
 use Pimcore\Model\Version;
+use Pimcore\Model\Version\Adapter\VersionStorageAdapterInterface;
 use ReflectionClass;
 use ReflectionException;
 
@@ -46,7 +49,24 @@ final class VersionDraftElementResolverTest extends Unit
 
         $resolved = (new VersionDraftElementResolver())->resolve($element, $this->user());
 
-        $this->assertSame($draftState, $resolved);
+        $this->assertSame($draftState, $resolved->getElement());
+    }
+
+    /**
+     * State and identity must come from the same lookup: `draftData` names the row the UI
+     * deletes by, so it may not describe a different version than the one being rendered.
+     *
+     * @throws Exception|ReflectionException
+     */
+    public function testReportsTheVersionItResolvedTheStateFrom(): void
+    {
+        $version = $this->versionHolding($this->makeEmpty(Concrete::class));
+        $element = $this->double(DraftCarryingObject::class, $version);
+
+        $resolved = (new VersionDraftElementResolver())->resolve($element, $this->user());
+
+        $this->assertSame($version, $resolved->getVersion());
+        $this->assertSame(1, $element->calls, 'the version must be looked up exactly once');
     }
 
     /**
@@ -56,10 +76,33 @@ final class VersionDraftElementResolverTest extends Unit
     {
         $element = $this->double(DraftCarryingObject::class, null);
 
-        $this->assertSame($element, (new VersionDraftElementResolver())->resolve($element, $this->user()));
+        $resolved = (new VersionDraftElementResolver())->resolve($element, $this->user());
+
+        $this->assertSame($element, $resolved->getElement());
+        $this->assertNull($resolved->getVersion());
     }
 
-    /** Resolving another user's draft would leak their unpublished edits. */
+    /**
+     * Version::loadData() answers null for a pruned payload or an __PHP_Incomplete_Class after
+     * a class rename. Rendering published beats a TypeError on opening the element.
+     *
+     * @throws Exception|ReflectionException
+     */
+    public function testFallsBackToPublishedWhenTheVersionPayloadCannotBeRead(): void
+    {
+        $element = $this->double(DraftCarryingObject::class, $this->versionWithUnreadablePayload());
+
+        $resolved = (new VersionDraftElementResolver())->resolve($element, $this->user());
+
+        $this->assertSame($element, $resolved->getElement());
+        $this->assertNull($resolved->getVersion(), 'a draft that cannot be rendered must not be advertised');
+    }
+
+    /**
+     * Resolving another user's draft would leak their unpublished edits.
+     *
+     * @throws Exception|ReflectionException
+     */
     public function testScopesTheLookupToTheGivenUser(): void
     {
         $element = $this->double(DraftCarryingObject::class, null);
@@ -83,15 +126,26 @@ final class VersionDraftElementResolverTest extends Unit
         $this->assertNull($element->seenUserId);
     }
 
-    /** Unversioned types must not be queried at all — seven read paths pay for it. */
+    /**
+     * Unversioned types must not be queried at all — seven read paths pay for it.
+     *
+     * @throws Exception
+     */
     public function testNeverQueriesElementTypesThatCarryNoVersions(): void
     {
         $folder = $this->makeEmpty(Folder::class);
 
-        $this->assertSame($folder, (new VersionDraftElementResolver())->resolve($folder, $this->user()));
+        $resolved = (new VersionDraftElementResolver())->resolve($folder, $this->user());
+
+        $this->assertSame($folder, $resolved->getElement());
+        $this->assertNull($resolved->getVersion());
     }
 
-    /** The extraction must not narrow the supported types to Concrete. */
+    /**
+     * The extraction must not narrow the supported types to Concrete.
+     *
+     * @throws Exception|ReflectionException
+     */
     public function testResolvesAssetsAndPageSnippetsToo(): void
     {
         foreach ([DraftCarryingAsset::class, DraftCarryingPageSnippet::class] as $class) {
@@ -100,10 +154,38 @@ final class VersionDraftElementResolverTest extends Unit
 
             $this->assertSame(
                 $draftState,
-                (new VersionDraftElementResolver())->resolve($element, $this->user()),
+                (new VersionDraftElementResolver())->resolve($element, $this->user())->getElement(),
                 $class . ' should resolve to its draft state'
             );
         }
+    }
+
+    /**
+     * The contract a decorating bundle codes against: state may come from somewhere other than
+     * the versions table, in which case there is no version row for `draftData` to name.
+     *
+     * @throws Exception
+     */
+    public function testTheContractAllowsStateWithoutAVersionIdentity(): void
+    {
+        $published = $this->makeEmpty(Concrete::class);
+        $storedElsewhere = $this->makeEmpty(Concrete::class);
+
+        $resolver = new class($storedElsewhere) implements DraftElementResolverInterface {
+            public function __construct(private readonly ElementInterface $draft)
+            {
+            }
+
+            public function resolve(ElementInterface $element, ?UserInterface $user): ResolvedDraft
+            {
+                return new ResolvedDraft($this->draft);
+            }
+        };
+
+        $resolved = $resolver->resolve($published, $this->user());
+
+        $this->assertSame($storedElsewhere, $resolved->getElement());
+        $this->assertNull($resolved->getVersion());
     }
 
     /**
@@ -114,7 +196,11 @@ final class VersionDraftElementResolverTest extends Unit
         return $this->makeEmpty(UserInterface::class, ['getId' => self::USER_ID]);
     }
 
-    /** Without the constructor: the models reach for the container there. */
+    /**
+     * Without the constructor: the models reach for the container there.
+     *
+     * @throws ReflectionException
+     */
     private function double(string $class, ?Version $version): ElementInterface
     {
         /** @var DraftCarryingAsset|DraftCarryingObject|DraftCarryingPageSnippet $element */
@@ -127,11 +213,31 @@ final class VersionDraftElementResolverTest extends Unit
     /**
      * Version is final and its constructor needs the container too. Priming data also stops
      * getData() falling back to loading off storage.
+     *
+     * @throws ReflectionException
      */
     private function versionHolding(mixed $data): Version
     {
         $version = (new ReflectionClass(Version::class))->newInstanceWithoutConstructor();
         $version->setData($data);
+
+        return $version;
+    }
+
+    /**
+     * Unprimed, so getData() does fall through to loadData() — which bails to null when the
+     * adapter has nothing to give it, exactly as it does for a pruned file or a renamed class.
+     *
+     * @throws Exception|ReflectionException
+     */
+    private function versionWithUnreadablePayload(): Version
+    {
+        $reflection = new ReflectionClass(Version::class);
+        $version = $reflection->newInstanceWithoutConstructor();
+        $reflection->getProperty('storageAdapter')->setValue(
+            $version,
+            $this->makeEmpty(VersionStorageAdapterInterface::class)
+        );
 
         return $version;
     }

--- a/tests/Unit/Property/Service/PropertyServiceTest.php
+++ b/tests/Unit/Property/Service/PropertyServiceTest.php
@@ -18,6 +18,8 @@ use Codeception\Test\Unit;
 use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
 use Pimcore\Bundle\StaticResolverBundle\Models\Property\Predefined\PredefinedResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\DraftElementResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\VersionDraftElementResolver;
 use Pimcore\Bundle\StudioBackendBundle\Property\Hydrator\PropertyHydrator;
 use Pimcore\Bundle\StudioBackendBundle\Property\Hydrator\PropertyHydratorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Property\Repository\PropertyRepositoryInterface;
@@ -92,6 +94,7 @@ final class PropertyServiceTest extends Unit
         ?SecurityServiceInterface $securityService = null,
         ?ServiceResolverInterface $serviceResolver = null,
         ?EventDispatcherInterface $eventDispatcher = null,
+        ?DraftElementResolverInterface $draftElementResolver = null,
     ): PropertyService {
         return new PropertyService(
             $repository ?? $this->makeEmpty(PropertyRepositoryInterface::class),
@@ -99,6 +102,7 @@ final class PropertyServiceTest extends Unit
             $securityService ?? $this->makeEmpty(SecurityServiceInterface::class),
             $serviceResolver ?? $this->makeEmpty(ServiceResolverInterface::class),
             $eventDispatcher ?? $this->makeEmpty(EventDispatcherInterface::class),
+            $draftElementResolver ?? new VersionDraftElementResolver(),
         );
     }
 

--- a/tests/Unit/Updater/Service/UpdateServiceTest.php
+++ b/tests/Unit/Updater/Service/UpdateServiceTest.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Document\Service\DataServiceInterface as 
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\CoauthorService;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementIndexServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementSaveServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\VersionDraftElementResolver;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ElementSavingFailedException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
@@ -243,6 +244,7 @@ final class UpdateServiceTest extends Unit
                 'save' => $onSave,
             ]),
             coauthorService: new CoauthorService($this->coauthorContext),
+            draftElementResolver: new VersionDraftElementResolver(),
         );
     }
 }

--- a/tests/Unit/Workflow/Service/WorkflowDetailsServiceTest.php
+++ b/tests/Unit/Workflow/Service/WorkflowDetailsServiceTest.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Workflow\Service;
 
 use Codeception\Test\Unit;
 use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\VersionDraftElementResolver;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Workflow\Hydrator\WorkflowDetailsHydratorInterface;
@@ -51,7 +52,8 @@ final class WorkflowDetailsServiceTest extends Unit
             $this->makeEmpty(Manager::class),
             $this->makeEmpty(SecurityServiceInterface::class),
             $this->makeEmpty(ServiceResolverInterface::class),
-            $this->makeEmpty(WorkflowDetailsHydratorInterface::class)
+            $this->makeEmpty(WorkflowDetailsHydratorInterface::class),
+            new VersionDraftElementResolver()
         );
     }
 }


### PR DESCRIPTION
Behaviour-preserving refactor. Pimcore's own answer is unchanged and stays the default.

**Package A, PR 1 of 2.**

## The problem

Seven services independently answer "which state should this user see — what is published, or the edits they have not saved yet?", each with the same two inlined lines:

```php
$version = $this->getLatestVersionForUser($element, $user);
$element = $this->getVersionData($element, $version);
```

`UpdateService`, `DataObjectService`, `LayoutService`, `DocumentService`, `PropertyService`, `WorkflowDetailsService`, `Search\Hydrator\Preview\DataObjectHydrator`.

The policy is therefore decided seven times over and can only ever have one answer: a draft is a version row. A bundle that stores pending edits anywhere else has to patch each response individually — and every endpoint nobody thought about keeps rendering published values.

## The change

Move it behind `DraftElementResolverInterface`, with today's behaviour as `VersionDraftElementResolver`. The seven call sites inject and delegate.

Deliberately minimal: no registry, no discriminator, no knowledge of who might replace it. It is an ordinary decoratable service, like `UpdateServiceInterface` already is — so a bundle decorates one thing and every read path follows.

The version lookup **stays** in `ElementProviderTrait` for the two detail paths that also report `draftData`. That is the draft *identity* the UI labels and deletes by, not the element's *state*; the two coincide by default and are allowed to diverge.

## Verification

- **phpstan**: 43 file errors before, 43 after, **0 in touched files** (the 43 are pre-existing local dependency-resolution noise)
- **Codeception Unit**: 38 errors before, 38 after, 0 failures — `614` tests (up from 608), `1312` assertions (up from 1303)
- New `VersionDraftElementResolverTest` — 6 tests covering version-applied, no-draft passthrough, user scoping, null user, unversioned types skipped, and assets/page-snippets

Note the resolver's own test needed real subclasses rather than mocks: `getLatestVersion()` is not declared on the models at all — it lives on the Dao and is reached via `AbstractModel::__call`, so a mocked `__call` silently answers null and such a test passes while asserting nothing.

Three existing test fixtures gained the new constructor argument.

## Not in this PR

`draftData` remains version-shaped. Making the *identity* pluggable is a separate, larger conversation.