### PR TITLE
[Bug] Fix PHPStan alreadyNarrowedType in FileNamesParameter

### DIFF
--- a/src/Asset/MappedParameter/FileNamesParameter.php
+++ b/src/Asset/MappedParameter/FileNamesParameter.php
@@ -39,7 +39,10 @@ final readonly class FileNamesParameter
     private array $fileNames;
 
     /**
-     * @param array<string> $fileNames
+     * The payload is bound straight from the request body, so the items are not
+     * guaranteed to be strings until they have been validated below.
+     *
+     * @param array<mixed> $fileNames
      *
      * @throws InvalidArgumentException
      */
@@ -60,6 +63,7 @@ final readonly class FileNamesParameter
             );
         }
 
+        $validatedFileNames = [];
         foreach ($fileNames as $fileName) {
             if (!is_string($fileName) || $fileName === '') {
                 throw new InvalidArgumentException('Each fileNames item must be a non-empty string.');
@@ -68,9 +72,11 @@ final readonly class FileNamesParameter
             if (str_contains($fileName, '/') || str_contains($fileName, '\\')) {
                 throw new InvalidArgumentException('Each fileNames item must be a single asset key.');
             }
+
+            $validatedFileNames[] = $fileName;
         }
 
-        $this->fileNames = $fileNames;
+        $this->fileNames = $validatedFileNames;
     }
 
     /**

--- a/src/Asset/MappedParameter/FileNamesParameter.php
+++ b/src/Asset/MappedParameter/FileNamesParameter.php
@@ -39,9 +39,6 @@ final readonly class FileNamesParameter
     private array $fileNames;
 
     /**
-     * The payload is bound straight from the request body, so the items are not
-     * guaranteed to be strings until they have been validated below.
-     *
      * @param array<mixed> $fileNames
      *
      * @throws InvalidArgumentException


### PR DESCRIPTION
Follow-up to #1990, which left static analysis red.

`FileNamesParameter` is bound via `#[MapRequestPayload]`, so the items are not guaranteed to be strings — the `@param array<string>` annotation made PHPStan flag the `is_string()` guard as redundant. Widened the annotation to match what actually arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)