### PR TITLE
[CI] Sync stabilized workflows from 2026.x

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,6 +13,9 @@ on:
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  # The steps MUST be defined inline here: the Copilot coding agent only reads `steps`
+  # (plus permissions/runs-on/services/snapshot/timeout-minutes) from this job, so a
+  # reusable-workflow `uses:` call would be ignored by Copilot.
   copilot-setup-steps:
     runs-on: ubuntu-latest
 
@@ -21,23 +24,28 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.1
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.3"
+          php-version: "8.4"
 
-      - name: Install SSH Key # this is necessary for Composer to be able to clone source from pimcore/ee-pimcore
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
-          known_hosts: ".... we add this in the next step ;-)"
-
-      - name: "Add authentication for private pimcore packages"
+      - name: "Configure private pimcore package repository"
         run: |
           composer config repositories.private-packagist '{"type": "composer", "url": "https://repo.pimcore.com/github-actions/", "canonical": true}'
-          composer config --global --auth http-basic.repo.pimcore.com github-actions ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"
+        # Pass the private-Packagist token via a step-scoped env var instead of
+        # writing it to Composer's global auth.json. A global credential would
+        # persist on the runner filesystem and remain readable by the Copilot
+        # coding agent after setup; COMPOSER_AUTH lives only for this step.
+        env:
+          COMPOSER_AUTH: '{"http-basic":{"repo.pimcore.com":{"username":"github-actions","password":"${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}"}}}'
+        with:
+          composer-options: "--no-scripts --ignore-platform-reqs"
+
+      - name: Restore composer.json
+        if: ${{ always() }}
+        run: git restore composer.json

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,14 @@
 name: "Documentation (Reusable)"
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "[0-9]+.[0-9]+"
       - "[0-9]+.x"
       - "docs_actions"
     paths:
       - "doc/**"
-      - ".github/workflows/new-docs.yml"
+      - ".github/workflows/docs.yml"
       - "README.md"
   push:
     branches:
@@ -17,7 +17,7 @@ on:
       - "docs_actions"
     paths:
       - "doc/**"
-      - ".github/workflows/new-docs.yml"
+      - ".github/workflows/docs.yml"
       - "README.md"
 
 permissions:
@@ -28,5 +28,3 @@ jobs:
     uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@main
     with:
       docs_path: "doc"
-    secrets:
-      DOCS_GENERATOR_ACCESS_TOKEN: ${{ secrets.DOCS_GENERATOR_ACCESS_TOKEN }}

--- a/.github/workflows/pr-guardrails.yml
+++ b/.github/workflows/pr-guardrails.yml
@@ -1,0 +1,30 @@
+name: PR Guardrails
+
+# Thin, generic trigger. All guardrail logic lives in the central collection
+# pimcore/workflows-collection-public. This file names no guardrails and no
+# secrets (secrets: inherit), so it is identical across every repo and never
+# needs editing when a guardrail or token is added/removed there.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, converted_to_draft, edited, synchronize]
+  check_suite:
+    types: [completed]
+
+concurrency:
+  # One lock per PR. On pull_request_target → PR number. On check_suite there is
+  # no PR number, so use the PR from the check_suite payload (present for
+  # same-repo PRs) to share the same lock; fall back to the commit SHA for fork
+  # PRs, then to run_id so the key is never empty.
+  # A guardrail can convert the PR to draft, which fires converted_to_draft;
+  # give that its own group so it does not cancel the run still acting on the PR.
+  group: pr-guardrails-${{ github.event.action == 'converted_to_draft' && 'retract-' || '' }}${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  guardrails:
+    uses: pimcore/workflows-collection-public/.github/workflows/parent-pr-guardrails.yml@main
+    secrets:
+      MEMBERSHIP_GUARD_TOKEN: ${{ secrets.MEMBERSHIP_GUARD_TOKEN }}
+      ISSUE_LINK_GUARD_TOKEN: ${{ secrets.ISSUE_LINK_GUARD_TOKEN }}
+      CI_GUARD_TOKEN: ${{ secrets.CI_GUARD_TOKEN }}

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,42 @@
+name: PR Policy
+
+# Enforces PR requirements before merge. Make the "Milestone assigned" check required
+# (repo ruleset / branch protection) so it actually blocks merging.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - milestoned
+      - demilestoned
+
+permissions:
+  contents: read
+
+jobs:
+  milestone:
+    name: Milestone assigned
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check milestone
+        env:
+          MILESTONE: ${{ github.event.pull_request.milestone.title }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # Automated sync PRs (repo-file-sync-action) never carry a milestone.
+          if [ "$AUTHOR" = "pimcore-deployments" ]; then
+            echo "Skipping milestone check for automated PR by $AUTHOR"
+            exit 0
+          fi
+
+          if [ -z "$MILESTONE" ]; then
+            echo "::error::A milestone must be assigned before this pull request can be merged."
+            exit 1
+          fi
+
+          echo "Milestone assigned: $MILESTONE"

--- a/.github/workflows/repo-guardrails.yml
+++ b/.github/workflows/repo-guardrails.yml
@@ -1,0 +1,28 @@
+name: Repo Guardrails
+
+# Thin, generic trigger for the REPO-level guardrails. All logic lives in the
+# central collection pimcore/workflows-collection-public. This file names no
+# guardrails, so it is identical across every repo and only needs editing if a
+# new event type or token is introduced there.
+#
+# Sibling of pr-guardrails.yml, which covers the pull-request guardrails.
+#
+# Managed centrally: this file is synced from
+# pimcore/workflows-collection-public (.github/sync-templates/repo-guardrails.yml).
+# Edit it there, not here.
+
+on:
+  issues:
+    types: [opened]
+
+concurrency:
+  # One lock per issue. Never cancel in progress: each run acts on a distinct
+  # issue, so a newer run must not abort an older one mid-decision.
+  group: repo-guardrails-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  guardrails:
+    uses: pimcore/workflows-collection-public/.github/workflows/parent-repo-guardrails.yml@main
+    secrets:
+      MEMBERSHIP_GUARD_TOKEN: ${{ secrets.MEMBERSHIP_GUARD_TOKEN }}

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 3 * * 1,3,5'
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [ opened, synchronize, reopened ]
     paths-ignore:
       - 'assets/**'


### PR DESCRIPTION
Part of pimcore/product-management#1305 — sync the stabilized default-branch workflows to the maintenance branches.

### Why

Since #1943 renamed the `new-*` workflows to their final names on `2026.x` only, **PHPStan has not run on any PR targeting this branch since July 10**: `pull_request_target` resolves workflow files from the *default* branch, where `new-static-analysis.yaml` no longer exists — and the renamed `static-analysis.yaml` (plain `pull_request` trigger, resolved from the merge ref) did not exist on this branch. PHPStan failures only surfaced after merge on the push run (which is what #1992 had to clean up).

### Changes

- Rename `new-static-analysis.yaml` → `static-analysis.yaml` and switch to the `pull_request` trigger — PHPStan runs on PRs targeting this branch again
- Rename `new-docs.yml` → `docs.yml` (same pattern, incl. dropped `DOCS_GENERATOR_ACCESS_TOKEN` pass no longer declared by the reusable workflow)
- Sync `copilot-setup-steps.yml` (step-scoped `COMPOSER_AUTH` instead of global auth.json / SSH key)
- `cla.yaml` needed no change here (already identical)
- Add `pr-guardrails.yml`, `pr-policy.yml`, `repo-guardrails.yml`


### Deliberately not synced

- `codeception.yaml` / `api-test.yaml` — untouched; already byte-identical to `2026.x` (the matrix is derived at runtime from `composer.json` + the central matrix config, so no branch-specific matrix is overwritten here)
- `symfony8-compat.yaml` — dev-line-only forward-compat gate, added directly on `2026.x` (Aug 5); running it on a maintenance line would add an irrelevant/failing required job. Shout if it should be included after all.

After this and the sibling `2025.4` PR (#1993) merge, `.github/workflows` is identical across `2025.4` / `2026.2` / `2026.x` (except `symfony8-compat.yaml`), so future forward-merges stay clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
