### PR TITLE
[Bug]: Skip relation columns whose class definition no longer exists

### DIFF
--- a/src/Grid/Column/Collector/DataObject/AdvancedColumnCollector.php
+++ b/src/Grid/Column/Collector/DataObject/AdvancedColumnCollector.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Collector\DataObject;
 
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\Objectbrick\DefinitionResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ClassIdInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnCollectorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\FolderIdInterface;
@@ -293,7 +294,14 @@ final class AdvancedColumnCollector implements
         $fieldsByClass = [];
 
         foreach ($classes as $class) {
-            $classDefinition = $this->classRepository->getClassDefinition($class['classes']);
+            try {
+                $classDefinition = $this->classRepository->getClassDefinition($class['classes']);
+            } catch (NotFoundException) {
+                // The class configured on this relation no longer exists (e.g. it was renamed
+                // without updating other classes' relation field configuration) - skip it.
+                continue;
+            }
+
             $classIds[] = $classDefinition->getId();
             $fieldsByClass[] = $this->buildFieldForClassName($class['classes']);
         }

--- a/src/Grid/Service/ColumnConfigurationForRelationService.php
+++ b/src/Grid/Service/ColumnConfigurationForRelationService.php
@@ -95,9 +95,15 @@ final readonly class ColumnConfigurationForRelationService implements ColumnConf
         $availableConfigurationsForRelation = [];
 
         foreach ($classes as $class) {
-            $classId = $this->classDefinitionResolver->getByName(
-                $class['classes'],
-            )->getId();
+            $classDefinition = $this->classDefinitionResolver->getByName($class['classes']);
+
+            if ($classDefinition === null) {
+                // The class configured on this relation no longer exists (e.g. it was renamed
+                // without updating other classes' relation field configuration) - skip it.
+                continue;
+            }
+
+            $classId = $classDefinition->getId();
 
             $availableConfigurationsForRelation[$classId] = $this->columnConfigurationService
                 ->getAvailableDataObjectColumnConfiguration(
@@ -121,9 +127,17 @@ final readonly class ColumnConfigurationForRelationService implements ColumnConf
         AdvancedManyToManyObjectRelation $fieldDefinition,
         UserInterface $user
     ): array {
-        $classId = $this->classDefinitionResolver->getByName(
+        $classDefinition = $this->classDefinitionResolver->getByName(
             $fieldDefinition->getAllowedClassId()
-        )->getId();
+        );
+
+        if ($classDefinition === null) {
+            // The class configured on this relation no longer exists (e.g. it was renamed
+            // without updating other classes' relation field configuration).
+            return [];
+        }
+
+        $classId = $classDefinition->getId();
 
         $availableConfigurationsForRelation[$classId] = $this->columnConfigurationService
             ->getAvailableDataObjectColumnConfiguration(

--- a/tests/Unit/Grid/Column/Collector/DataObject/AdvancedColumnCollectorTest.php
+++ b/tests/Unit/Grid/Column/Collector/DataObject/AdvancedColumnCollectorTest.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Column\Collector\Da
 use Codeception\Test\Unit;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\Objectbrick\DefinitionResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\Collector\DataObject\AdvancedColumnCollector;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ClassDefinitionServiceInterface;
@@ -23,6 +24,7 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Service\SystemColumnServiceInterface
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\TransformerLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Util\SimpleField;
 use Pimcore\Bundle\StudioBackendBundle\ObjectBrick\Service\ObjectBrickServiceInterface;
+use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
 use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyObjectRelation;
@@ -98,6 +100,33 @@ final class AdvancedColumnCollectorTest extends Unit
         );
     }
 
+    public function testGetColumnConfigurationsSkipsRelationClassesThatNoLongerExist(): void
+    {
+        // Simulates a relation field still listing a class name that was since renamed away,
+        // e.g. leftover from https://github.com/pimcore/platform-version/issues/171
+        $relation = new ManyToManyObjectRelation();
+        $relation->setName('manufacturer');
+        $relation->setTitle('Manufacturer');
+        $relation->setClasses([
+            ['classes' => 'MissingClass'],
+        ]);
+
+        $classRepository = $this->makeEmpty(ClassDefinitionRepositoryInterface::class, [
+            'getClassDefinition' => function (string $className): ClassDefinition {
+                throw new NotFoundException('class definition', $className, 'class name');
+            },
+        ]);
+
+        $collector = $this->createCollector([$relation], $classRepository);
+
+        $config = $this->getAdvancedConfig($collector);
+
+        $relationFields = $config->getConfig()['relationField'];
+        $this->assertCount(1, $relationFields);
+        $this->assertSame([], $relationFields[0]->getClassIds());
+        $this->assertSame([], $relationFields[0]->getFields());
+    }
+
     private function createInput(string $name, string $title, bool $invisible): Input
     {
         $field = new Input();
@@ -111,8 +140,10 @@ final class AdvancedColumnCollectorTest extends Unit
     /**
      * @param array<int, mixed> $children
      */
-    private function createCollector(array $children): AdvancedColumnCollector
-    {
+    private function createCollector(
+        array $children,
+        ?ClassDefinitionRepositoryInterface $classRepository = null,
+    ): AdvancedColumnCollector {
         $layout = $this->makeEmpty(Layout::class, [
             'getChildren' => $children,
         ]);
@@ -121,7 +152,7 @@ final class AdvancedColumnCollectorTest extends Unit
             $this->makeEmpty(ClassDefinitionServiceInterface::class, [
                 'getFilteredLayoutDefinitions' => $layout,
             ]),
-            $this->makeEmpty(ClassDefinitionRepositoryInterface::class),
+            $classRepository ?? $this->makeEmpty(ClassDefinitionRepositoryInterface::class),
             $this->makeEmpty(TransformerLoaderInterface::class, [
                 'loadTransformers' => [],
             ]),

--- a/tests/Unit/Grid/Service/ColumnConfigurationForRelationServiceTest.php
+++ b/tests/Unit/Grid/Service/ColumnConfigurationForRelationServiceTest.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Service;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassDefinitionResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\FieldDefinition\FieldDefinitionWrapper;
+use Pimcore\Bundle\StudioBackendBundle\FieldDefinition\Parser\DotNotationParserInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnConfigurationForRelationService;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ColumnConfigurationServiceInterface;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation;
+use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyObjectRelation;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+final class ColumnConfigurationForRelationServiceTest extends Unit
+{
+    public function testManyToManyObjectRelationSkipsClassesThatNoLongerExist(): void
+    {
+        // A relation still listing a class name that was since renamed away,
+        // e.g. leftover from https://github.com/pimcore/platform-version/issues/171
+        $relation = new ManyToManyObjectRelation();
+        $relation->setName('manufacturer');
+        $relation->setClasses([
+            ['classes' => 'Manufacturer'],
+            ['classes' => 'MissingClass'],
+        ]);
+        $relation->setVisibleFields('title');
+
+        $existingClassDefinition = new ClassDefinition();
+        $existingClassDefinition->setId('MANUFACTURER');
+
+        $classResolver = $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+            'getById' => new ClassDefinition(),
+            'getByName' => static fn (string $name) => $name === 'Manufacturer' ? $existingClassDefinition : null,
+        ]);
+
+        $columnConfiguration = new ColumnConfiguration(
+            key: 'title',
+            group: [],
+            sortable: false,
+            editable: false,
+            exportable: false,
+            filterable: false,
+            localizable: false,
+            locale: null,
+            type: 'input',
+            frontendType: 'text',
+            config: []
+        );
+
+        $columnConfigurationService = $this->makeEmpty(ColumnConfigurationServiceInterface::class, [
+            'getAvailableDataObjectColumnConfiguration' => Expected::once([$columnConfiguration]),
+        ]);
+
+        $dotNotationParser = $this->makeEmpty(DotNotationParserInterface::class, [
+            'parseByClassId' => new FieldDefinitionWrapper($relation, 'object', 'manufacturer'),
+        ]);
+
+        $service = new ColumnConfigurationForRelationService(
+            $classResolver,
+            $columnConfigurationService,
+            $dotNotationParser
+        );
+
+        $result = $service->getAvailableDataObjectColumnConfigurationForRelation(
+            'CAR',
+            'manufacturer',
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertArrayHasKey('title', $result);
+        $this->assertSame($columnConfiguration, $result['title']);
+    }
+
+    public function testAdvancedManyToManyObjectRelationReturnsEmptyWhenClassNoLongerExists(): void
+    {
+        $relation = new AdvancedManyToManyObjectRelation();
+        $relation->setName('manufacturer');
+        $relation->setAllowedClassId('MissingClass');
+        $relation->setVisibleFields('title');
+
+        $classResolver = $this->makeEmpty(ClassDefinitionResolverInterface::class, [
+            'getById' => new ClassDefinition(),
+            'getByName' => null,
+        ]);
+
+        $columnConfigurationService = $this->makeEmpty(ColumnConfigurationServiceInterface::class, [
+            'getAvailableDataObjectColumnConfiguration' => Expected::never(),
+        ]);
+
+        $dotNotationParser = $this->makeEmpty(DotNotationParserInterface::class, [
+            'parseByClassId' => new FieldDefinitionWrapper($relation, 'object', 'manufacturer'),
+        ]);
+
+        $service = new ColumnConfigurationForRelationService(
+            $classResolver,
+            $columnConfigurationService,
+            $dotNotationParser
+        );
+
+        $result = $service->getAvailableDataObjectColumnConfigurationForRelation(
+            'CAR',
+            'manufacturer',
+            $this->makeEmpty(UserInterface::class)
+        );
+
+        $this->assertSame([], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- Renaming a Data Object class only updates that class itself; other classes' relation fields keep the old name in their `classes` allow-list.
- `AdvancedColumnCollector::buildRelationFields()` looked up every configured class unconditionally via `ClassDefinitionRepository::getClassDefinition()`, so a stale reference threw `NotFoundException` and crashed the whole `available-columns` / `available-columns-for-relation` request instead of just omitting that one class.
- Now the stale class entry is skipped, matching the existing `isFolderPseudoClass()` skip-and-continue precedent for a similar dangling-reference case.

Fixes https://github.com/pimcore/platform-version/issues/171

## Test plan
- Added `testGetColumnConfigurationsSkipsRelationClassesThatNoLongerExist`, which mocks `getClassDefinition()` to throw `NotFoundException` for a relation's configured class.
- Verified the new test fails with the exact reported error against the pre-fix code, and passes with the fix (ran the full `AdvancedColumnCollectorTest` suite via Codeception both ways).
- Reproduced the original bug live against a running 2025.4 instance (renamed a class with an inbound relation, hit the real `ColumnConfigurationService`, got the identical stack trace) before writing the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)