### PR TITLE
[Bug]: Skip relation columns whose class definition no longer exists

### DIFF
--- a/src/Grid/Column/Collector/DataObject/AdvancedColumnCollector.php
+++ b/src/Grid/Column/Collector/DataObject/AdvancedColumnCollector.php
@@ -15,6 +15,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Grid\Column\Collector\DataObject;
 
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\Objectbrick\DefinitionResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ClassIdInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\ColumnCollectorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\FolderIdInterface;
@@ -297,7 +298,14 @@ final class AdvancedColumnCollector implements
                 continue;
             }
 
-            $classDefinition = $this->classRepository->getClassDefinition($class['classes']);
+            try {
+                $classDefinition = $this->classRepository->getClassDefinition($class['classes']);
+            } catch (NotFoundException) {
+                // The class configured on this relation no longer exists (e.g. it was renamed
+                // without updating other classes' relation field configuration) - skip it.
+                continue;
+            }
+
             $classIds[] = $classDefinition->getId();
             $fieldsByClass[] = $this->buildFieldForClassName($class['classes']);
         }

--- a/tests/Unit/Grid/Column/Collector/DataObject/AdvancedColumnCollectorTest.php
+++ b/tests/Unit/Grid/Column/Collector/DataObject/AdvancedColumnCollectorTest.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Column\Collector\Da
 use Codeception\Test\Unit;
 use Pimcore\Bundle\StaticResolverBundle\Models\DataObject\Objectbrick\DefinitionResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Column\Collector\DataObject\AdvancedColumnCollector;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnConfiguration;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Service\ClassDefinitionServiceInterface;
@@ -125,6 +126,33 @@ final class AdvancedColumnCollectorTest extends Unit
         $this->assertSame(['123'], $relationFields[0]->getClassIds());
     }
 
+    public function testGetColumnConfigurationsSkipsRelationClassesThatNoLongerExist(): void
+    {
+        // A relation still listing a class name that was since renamed away,
+        // e.g. leftover from https://github.com/pimcore/platform-version/issues/171
+        $relation = new ManyToManyObjectRelation();
+        $relation->setName('manufacturer');
+        $relation->setTitle('Manufacturer');
+        $relation->setClasses([
+            ['classes' => 'MissingClass'],
+        ]);
+
+        $classRepository = $this->makeEmpty(ClassDefinitionRepositoryInterface::class, [
+            'getClassDefinition' => function (string $className): ClassDefinition {
+                throw new NotFoundException('class definition', $className, 'class name');
+            },
+        ]);
+
+        $collector = $this->createCollector([$relation], $classRepository);
+
+        $config = $this->getAdvancedConfig($collector);
+
+        $relationFields = $config->getConfig()['relationField'];
+        $this->assertCount(1, $relationFields);
+        $this->assertSame([], $relationFields[0]->getClassIds());
+        $this->assertSame([], $relationFields[0]->getFields());
+    }
+
     public function testGetColumnConfigurationsExposesClassificationStoreFieldAsMarkedSimpleField(): void
     {
         $simpleField = $this->createInput('name', 'Name', false);
@@ -173,8 +201,10 @@ final class AdvancedColumnCollectorTest extends Unit
     /**
      * @param array<int, mixed> $children
      */
-    private function createCollector(array $children): AdvancedColumnCollector
-    {
+    private function createCollector(
+        array $children,
+        ?ClassDefinitionRepositoryInterface $classRepository = null,
+    ): AdvancedColumnCollector {
         $layout = $this->makeEmpty(Layout::class, [
             'getChildren' => $children,
         ]);
@@ -183,7 +213,7 @@ final class AdvancedColumnCollectorTest extends Unit
             $this->makeEmpty(ClassDefinitionServiceInterface::class, [
                 'getFilteredLayoutDefinitions' => $layout,
             ]),
-            $this->makeEmpty(ClassDefinitionRepositoryInterface::class),
+            $classRepository ?? $this->makeEmpty(ClassDefinitionRepositoryInterface::class),
             $this->makeEmpty(TransformerLoaderInterface::class, [
                 'loadTransformers' => [],
             ]),


### PR DESCRIPTION
## Summary
- Same defect as #1995 (base `2025.4`), ported to `2026.2`. Renaming a Data Object class only updates that class itself; other classes' relation fields keep the old name in their `classes` allow-list.
- `AdvancedColumnCollector::buildRelationFields()` looked up every configured relation class unconditionally (aside from the existing `isFolderPseudoClass()` skip), so a stale reference threw `NotFoundException` and crashed the whole `available-columns` / `available-columns-for-relation` request instead of just omitting that one class.
- `ColumnConfigurationForRelationService` already handles this on `2026.2` (`resolveConfigurationForManyToManyObjectRelation()` / `resolveConfigurationForAdvancedManyToManyObjectRelation()` both null-check `getByName()`) — only `AdvancedColumnCollector` had the gap here.

Fixes https://github.com/pimcore/platform-version/issues/171

Not a forward-merge of #1995: `2025.4` and `2026.2` are divergent lines (`git merge-base --is-ancestor` confirms `2025.4` is not an ancestor of `2026.2`), so the fix is reapplied directly here rather than merged.

## Test plan
- Added `testGetColumnConfigurationsSkipsRelationClassesThatNoLongerExist` alongside the existing folder-pseudo-class tests in `AdvancedColumnCollectorTest`.
- Ran the full `AdvancedColumnCollectorTest` suite (6 tests) via Codeception in an isolated container checkout: all pass with the fix.
- Verified the new test fails with the exact `NotFoundException` against the pre-fix code, and that the 5 pre-existing tests (including the folder-pseudo-class cases) are unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)