### PR TITLE
Require parentDocumentId for renderlet render endpoint

### DIFF
--- a/src/Document/Controller/Renderlet/RenderController.php
+++ b/src/Document/Controller/Renderlet/RenderController.php
@@ -88,7 +88,7 @@ final class RenderController extends AbstractApiController
         content: [new MediaType('text/html')],
         headers: [new ContentDisposition(HttpResponseHeaders::INLINE_TYPE->value, 'renderlet.html.twig')]
     )]
-    #[IdParameter(description: 'Parent document id of the renderlet', namePrefix: 'parentDocument', required: false)]
+    #[IdParameter(description: 'Parent document id of the renderlet', namePrefix: 'parentDocument')]
     #[TextFieldParameter(
         name: 'template',
         description: 'Renderlet template',

--- a/src/Document/MappedParameter/RenderletParameter.php
+++ b/src/Document/MappedParameter/RenderletParameter.php
@@ -32,7 +32,9 @@ final readonly class RenderletParameter
         private string $type,
         #[NotBlank(message: 'Controller is required')]
         private string $controller,
-        private ?int $parentDocumentId = null,
+        #[NotBlank(message: 'Parent document id is required')]
+        #[Positive]
+        private int $parentDocumentId,
         private ?string $template = null
     ) {
         if (!in_array($this->type, ElementTypes::ALLOWED_TYPES, true)) {
@@ -55,7 +57,7 @@ final readonly class RenderletParameter
         return $this->controller;
     }
 
-    public function getParentDocumentId(): ?int
+    public function getParentDocumentId(): int
     {
         return $this->parentDocumentId;
     }

--- a/src/Document/Service/RenderletService.php
+++ b/src/Document/Service/RenderletService.php
@@ -101,11 +101,7 @@ final readonly class RenderletService implements RenderletServiceInterface
 
     private function getAttributes(RenderletParameter $parameter, UserInterface $user): array
     {
-        $attributes = [];
-
-        if ($parameter->getParentDocumentId() !== null) {
-            $attributes = $this->getAttributesFromDocument($parameter->getParentDocumentId(), $user);
-        }
+        $attributes = $this->getAttributesFromDocument($parameter->getParentDocumentId(), $user);
 
         if ($parameter->getTemplate()) {
             $attributes[DynamicRouter::CONTENT_TEMPLATE] = $parameter->getTemplate();

--- a/tests/Unit/Document/MappedParameter/RenderletParameterTest.php
+++ b/tests/Unit/Document/MappedParameter/RenderletParameterTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Document\MappedParameter;
+
+use ArgumentCountError;
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Document\MappedParameter\RenderletParameter;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+
+/**
+ * @internal
+ */
+final class RenderletParameterTest extends Unit
+{
+    public function testParentDocumentIdIsRequired(): void
+    {
+        $this->expectException(ArgumentCountError::class);
+
+        /** @phpstan-ignore argument.missing */
+        new RenderletParameter(
+            id: 5,
+            type: ElementTypes::TYPE_DATA_OBJECT,
+            controller: 'App\Controller\MyController::renderAction',
+        );
+    }
+
+    public function testGetParentDocumentIdReturnsProvidedId(): void
+    {
+        $parameter = new RenderletParameter(
+            id: 5,
+            type: ElementTypes::TYPE_DATA_OBJECT,
+            controller: 'App\Controller\MyController::renderAction',
+            parentDocumentId: 38,
+        );
+
+        $this->assertSame(38, $parameter->getParentDocumentId());
+    }
+}

--- a/tests/Unit/Document/Service/RenderletServiceTest.php
+++ b/tests/Unit/Document/Service/RenderletServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Document\Service;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\Document\MappedParameter\RenderletParameter;
+use Pimcore\Bundle\StudioBackendBundle\Document\Service\RenderletService;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Document\Editable\EditableHandler;
+use Pimcore\Localization\LocaleServiceInterface;
+use Pimcore\Model\Document\PageSnippet;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\UserInterface;
+use Pimcore\Templating\Renderer\ActionRenderer;
+use Symfony\Bridge\Twig\Extension\HttpKernelRuntime;
+use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+
+/**
+ * @internal
+ */
+final class RenderletServiceTest extends Unit
+{
+    /**
+     * @throws Exception
+     */
+    public function testRenderForwardsParentDocumentAsContentDocumentAttribute(): void
+    {
+        $parentDocument = $this->makeEmpty(PageSnippet::class, [
+            'getTemplate' => null,
+            'getProperty' => null,
+        ]);
+
+        $capturedAttributes = null;
+        $service = $this->createService($parentDocument, $capturedAttributes);
+
+        $parameter = new RenderletParameter(
+            id: 5,
+            type: ElementTypes::TYPE_DATA_OBJECT,
+            controller: 'App\Controller\MyController::renderAction',
+            parentDocumentId: 38,
+        );
+
+        $service->render($parameter, []);
+
+        $this->assertSame($parentDocument, $capturedAttributes[DynamicRouter::CONTENT_KEY] ?? null);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createService(PageSnippet $parentDocument, ?array &$capturedAttributes = null): RenderletService
+    {
+        $capturedAttributes = null;
+
+        $targetElement = $this->makeEmpty(ElementInterface::class);
+
+        $elementService = $this->makeEmpty(ElementServiceInterface::class, [
+            'getAllowedElementById' => function (string $type, int $id, UserInterface $user) use ($targetElement, $parentDocument) {
+                return $type === ElementTypes::TYPE_DOCUMENT ? $parentDocument : $targetElement;
+            },
+        ]);
+
+        $editableHandler = $this->makeEmpty(EditableHandler::class, [
+            'renderAction' => function (string $controller, array $attributes, array $query) use (&$capturedAttributes) {
+                $capturedAttributes = $attributes;
+
+                return '<div></div>';
+            },
+        ]);
+
+        $actionRenderer = new ActionRenderer(
+            new HttpKernelRuntime($this->makeEmpty(FragmentHandler::class))
+        );
+
+        return new RenderletService(
+            $actionRenderer,
+            $editableHandler,
+            $elementService,
+            $this->makeEmpty(EventDispatcherInterface::class),
+            $this->makeEmpty(LocaleServiceInterface::class),
+            $this->makeEmpty(SecurityServiceInterface::class, [
+                'getCurrentUser' => fn () => $this->makeEmpty(UserInterface::class),
+            ]),
+        );
+    }
+}


### PR DESCRIPTION
The renderlet render endpoint only resolved and applied the parent document's attributes (including the content document) when a `parentDocumentId` query parameter happened to be present. Since the frontend always has a parent document available in edit mode, this makes the parameter required so the content document is always attached to the rendered sub-request.

Companion fix: pimcore/studio-ui-bundle#3994
Related: pimcore/service-operations#848

## Test plan
- [x] Added `RenderletParameterTest` covering the now-required parameter
- [x] Added `RenderletServiceTest` covering that the parent document's attributes are forwarded
- [x] `vendor/bin/codecept run Unit Document/` passes
- [x] `vendor/bin/phpstan analyse` clean on touched files