### PR TITLE
Harden the notification dispatcher and the channel gate

### DIFF
--- a/config/notifications.yaml
+++ b/config/notifications.yaml
@@ -34,6 +34,11 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationDispatcherInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationDispatcher
 
+  # Writing the bell row is its own collaborator so the dispatcher's routing decisions can be
+  # tested without a database — Notification::save() goes through a Dao.
+  Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationWriterInterface:
+    class: Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationWriter
+
   Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Registry\NotificationTypeRegistryInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Registry\NotificationTypeRegistry
 

--- a/config/notifications.yaml
+++ b/config/notifications.yaml
@@ -34,8 +34,7 @@ services:
   Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationDispatcherInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationDispatcher
 
-  # Writing the bell row is its own collaborator so the dispatcher's routing decisions can be
-  # tested without a database — Notification::save() goes through a Dao.
+  # Own collaborator so the dispatcher can be tested without a database.
   Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationWriterInterface:
     class: Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationWriter
 

--- a/src/DependencyInjection/CompilerPass/NotificationDispatchPass.php
+++ b/src/DependencyInjection/CompilerPass/NotificationDispatchPass.php
@@ -148,11 +148,8 @@ final readonly class NotificationDispatchPass implements CompilerPassInterface
      * is always available and is not a tagged channel, so it is unaffected. Installing a bundle that
      * contributes an externally-deliverable type brings the channels back automatically.
      *
-     * The gate clears the tag rather than removing the definition. Untagging is enough — the
-     * registry collects by tag, and an untagged private service nothing references is dropped by
-     * Symfony's own unused-definition pass, so no dead mailer is instantiated either way. Removing
-     * the definition would additionally break any bundle that aliases or injects its own channel,
-     * which is exactly what the documented extension path invites it to do.
+     * The gate clears the tag rather than removing the definition: removing it would break any
+     * bundle that aliases or injects its own channel.
      *
      * @param string[] $channelIds
      */
@@ -170,8 +167,7 @@ final readonly class NotificationDispatchPass implements CompilerPassInterface
                 continue;
             }
 
-            // clearTag only strips this tag, so a bundle that tagged its channel explicitly is
-            // gated the same way rather than being left half-registered.
+            // Only strips this tag, so a channel a bundle tagged itself is gated the same way.
             $definition->clearTag(ChannelInterface::TAG);
         }
     }

--- a/src/DependencyInjection/CompilerPass/NotificationDispatchPass.php
+++ b/src/DependencyInjection/CompilerPass/NotificationDispatchPass.php
@@ -144,9 +144,15 @@ final readonly class NotificationDispatchPass implements CompilerPassInterface
      * delivered externally. With just the built-in 'info' catch-all — which never allows it — a
      * core-only install would otherwise carry a dead channel: an extra column on the preferences
      * screen and an instantiated mailer no notification could ever reach. So the channels are tagged
-     * (collected) only when a consumer exists, and dropped otherwise. The in-app 'popup' substrate
+     * (collected) only when a consumer exists, and untagged otherwise. The in-app 'popup' substrate
      * is always available and is not a tagged channel, so it is unaffected. Installing a bundle that
      * contributes an externally-deliverable type brings the channels back automatically.
+     *
+     * The gate clears the tag rather than removing the definition. Untagging is enough — the
+     * registry collects by tag, and an untagged private service nothing references is dropped by
+     * Symfony's own unused-definition pass, so no dead mailer is instantiated either way. Removing
+     * the definition would additionally break any bundle that aliases or injects its own channel,
+     * which is exactly what the documented extension path invites it to do.
      *
      * @param string[] $channelIds
      */
@@ -156,11 +162,17 @@ final readonly class NotificationDispatchPass implements CompilerPassInterface
         bool $allowsExternalDelivery,
     ): void {
         foreach ($channelIds as $id) {
+            $definition = $container->getDefinition($id);
+
             if ($allowsExternalDelivery) {
-                $this->tag($container->getDefinition($id), ChannelInterface::TAG);
-            } else {
-                $container->removeDefinition($id);
+                $this->tag($definition, ChannelInterface::TAG);
+
+                continue;
             }
+
+            // clearTag only strips this tag, so a bundle that tagged its channel explicitly is
+            // gated the same way rather than being left half-registered.
+            $definition->clearTag(ChannelInterface::TAG);
         }
     }
 

--- a/src/Notification/Dispatch/NotificationDispatcher.php
+++ b/src/Notification/Dispatch/NotificationDispatcher.php
@@ -14,20 +14,17 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch;
 
 use Exception;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Descriptor\NotificationTypeDescriptorInterface;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Registry\ChannelRegistryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Registry\NotificationTypeRegistryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Subscription\SubscriptionResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\User\Repository\UserRepositoryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
 use Pimcore\Model\Notification;
-use Pimcore\Model\User;
 use Pimcore\Model\UserInterface;
 use Psr\Log\LoggerInterface;
-use function json_encode;
 use function sprintf;
-use const JSON_THROW_ON_ERROR;
 
 /**
  * @internal
@@ -38,6 +35,7 @@ final readonly class NotificationDispatcher implements NotificationDispatcherInt
         private NotificationTypeRegistryInterface $typeRegistry,
         private ChannelRegistryInterface $channelRegistry,
         private SubscriptionResolverInterface $subscriptionResolver,
+        private NotificationWriterInterface $notificationWriter,
         private UserRepositoryInterface $userRepository,
         private LoggerInterface $logger,
     ) {
@@ -53,25 +51,52 @@ final readonly class NotificationDispatcher implements NotificationDispatcherInt
 
         foreach ($notification->getRecipientIds() as $recipientId) {
             try {
-                $recipient = $this->userRepository->getUserById($recipientId);
-            } catch (NotFoundException) {
-                continue;
+                $this->dispatchToRecipient($notification, $descriptor, $recipientId, $sender);
+            } catch (Exception $e) {
+                // Recipients are independent of one another. Writing the bell row was the only
+                // step not already isolated, so a failure part-way through a fan-out used to
+                // deliver to the recipients before it, silently skip everyone after it, and
+                // surface as an exception the producer could do nothing useful with.
+                $this->logger->error(
+                    sprintf(
+                        'Notification could not be dispatched to user %d: %s',
+                        $recipientId,
+                        $e->getMessage()
+                    ),
+                    ['exception' => $e]
+                );
             }
-
-            if (!$recipient->isAllowed(UserPermissions::NOTIFICATIONS->value)) {
-                continue;
-            }
-
-            $subscription = $this->subscriptionResolver->resolve($recipientId, $descriptor);
-
-            if (!$subscription->isSubscribed()) {
-                continue;
-            }
-
-            $stored = $this->write($notification, $recipient, $sender);
-
-            $this->deliver($stored, $recipient, $subscription->getTransportChannels());
         }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function dispatchToRecipient(
+        DispatchableNotification $notification,
+        NotificationTypeDescriptorInterface $descriptor,
+        int $recipientId,
+        ?UserInterface $sender,
+    ): void {
+        try {
+            $recipient = $this->userRepository->getUserById($recipientId);
+        } catch (NotFoundException) {
+            return;
+        }
+
+        if (!$recipient->isAllowed(UserPermissions::NOTIFICATIONS->value)) {
+            return;
+        }
+
+        $subscription = $this->subscriptionResolver->resolve($recipientId, $descriptor);
+
+        if (!$subscription->isSubscribed()) {
+            return;
+        }
+
+        $stored = $this->notificationWriter->write($notification, $recipient, $sender);
+
+        $this->deliver($stored, $recipient, $subscription->getTransportChannels());
     }
 
     private function resolveSender(?int $senderId): ?UserInterface
@@ -84,37 +109,6 @@ final readonly class NotificationDispatcher implements NotificationDispatcherInt
             return $this->userRepository->getUserById($senderId);
         } catch (NotFoundException) {
             return null;
-        }
-    }
-
-    /**
-     * @throws DatabaseException
-     */
-    private function write(
-        DispatchableNotification $notification,
-        UserInterface $recipient,
-        ?UserInterface $sender,
-    ): Notification {
-        try {
-            $stored = new Notification();
-            /** @var User $recipient */
-            $stored->setRecipient($recipient);
-            /** @var User|null $sender */
-            $stored->setSender($sender);
-            $stored->setType($notification->getTypeId());
-            $stored->setTitle($notification->getTitle());
-            $stored->setMessage($notification->getMessage());
-            $stored->setLinkedElement($notification->getLinkedElement());
-            $stored->setPayload(json_encode($notification->getPayload(), JSON_THROW_ON_ERROR));
-            $stored->setIsStudio(true);
-            $stored->save();
-
-            return $stored;
-        } catch (Exception $e) {
-            throw new DatabaseException(
-                sprintf('Failed to write notification: %s', $e->getMessage()),
-                $e
-            );
         }
     }
 

--- a/src/Notification/Dispatch/NotificationDispatcher.php
+++ b/src/Notification/Dispatch/NotificationDispatcher.php
@@ -53,10 +53,7 @@ final readonly class NotificationDispatcher implements NotificationDispatcherInt
             try {
                 $this->dispatchToRecipient($notification, $descriptor, $recipientId, $sender);
             } catch (Exception $e) {
-                // Recipients are independent of one another. Writing the bell row was the only
-                // step not already isolated, so a failure part-way through a fan-out used to
-                // deliver to the recipients before it, silently skip everyone after it, and
-                // surface as an exception the producer could do nothing useful with.
+                // Recipients are independent: one failing row must not cost the others theirs.
                 $this->logger->error(
                     sprintf(
                         'Notification could not be dispatched to user %d: %s',

--- a/src/Notification/Dispatch/NotificationDispatcherInterface.php
+++ b/src/Notification/Dispatch/NotificationDispatcherInterface.php
@@ -25,8 +25,14 @@ interface NotificationDispatcherInterface
      * Recipients who are not subscribed to the type, or who lack the notifications
      * permission, are skipped silently — that is the point of a subscription.
      *
-     * Channel failures never propagate: a broken transport must not take down the action that
-     * produced the notification.
+     * Failures never propagate, and recipients are independent: a broken transport, or a bell
+     * row that cannot be written for one recipient, is logged and the fan-out continues. A
+     * broken transport must not take down the action that produced the notification, and one
+     * bad recipient must not cost the others their notification.
+     *
+     * The single exception is an unregistered type id, which is a wiring mistake in the
+     * producing bundle rather than a runtime condition, and is raised before any recipient is
+     * processed.
      *
      * @throws NotFoundException when the type id is not registered
      */

--- a/src/Notification/Dispatch/NotificationDispatcherInterface.php
+++ b/src/Notification/Dispatch/NotificationDispatcherInterface.php
@@ -25,14 +25,9 @@ interface NotificationDispatcherInterface
      * Recipients who are not subscribed to the type, or who lack the notifications
      * permission, are skipped silently — that is the point of a subscription.
      *
-     * Failures never propagate, and recipients are independent: a broken transport, or a bell
-     * row that cannot be written for one recipient, is logged and the fan-out continues. A
-     * broken transport must not take down the action that produced the notification, and one
-     * bad recipient must not cost the others their notification.
-     *
-     * The single exception is an unregistered type id, which is a wiring mistake in the
-     * producing bundle rather than a runtime condition, and is raised before any recipient is
-     * processed.
+     * Failures never propagate and recipients are independent: a broken transport, or a bell row
+     * that cannot be written for one recipient, is logged and the fan-out continues. The one
+     * exception is an unregistered type id, raised before any recipient is processed.
      *
      * @throws NotFoundException when the type id is not registered
      */

--- a/src/Notification/Dispatch/NotificationWriter.php
+++ b/src/Notification/Dispatch/NotificationWriter.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch;
+
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
+use Pimcore\Model\Notification;
+use Pimcore\Model\User;
+use Pimcore\Model\UserInterface;
+use function json_encode;
+use function sprintf;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * @internal
+ */
+final readonly class NotificationWriter implements NotificationWriterInterface
+{
+    public function write(
+        DispatchableNotification $notification,
+        UserInterface $recipient,
+        ?UserInterface $sender,
+    ): Notification {
+        try {
+            $stored = new Notification();
+            /** @var User $recipient */
+            $stored->setRecipient($recipient);
+            /** @var User|null $sender */
+            $stored->setSender($sender);
+            $stored->setType($notification->getTypeId());
+            $stored->setTitle($notification->getTitle());
+            $stored->setMessage($notification->getMessage());
+            $stored->setLinkedElement($notification->getLinkedElement());
+            $stored->setPayload(json_encode($notification->getPayload(), JSON_THROW_ON_ERROR));
+            $stored->setIsStudio(true);
+            $stored->save();
+
+            return $stored;
+        } catch (Exception $e) {
+            throw new DatabaseException(
+                sprintf('Failed to write notification: %s', $e->getMessage()),
+                $e
+            );
+        }
+    }
+}

--- a/src/Notification/Dispatch/NotificationWriterInterface.php
+++ b/src/Notification/Dispatch/NotificationWriterInterface.php
@@ -18,12 +18,9 @@ use Pimcore\Model\Notification;
 use Pimcore\Model\UserInterface;
 
 /**
- * Writes the bell entry for one recipient.
- *
- * Split out of the dispatcher so that what the dispatcher *decides* — who is skipped, what is
- * written, which channels are handed the result — can be tested without a database. Notification
- * is a Pimcore model whose save() goes through a Dao, and doubling that is worse than useless:
- * Dao-proxied calls silently no-op on a mock, so the test passes while asserting nothing.
+ * Writes the bell entry for one recipient. Split out of the dispatcher so its routing decisions
+ * can be tested without a database — Notification::save() goes through a Dao, and Dao-proxied
+ * calls silently no-op on a mock rather than failing.
  *
  * @internal
  */

--- a/src/Notification/Dispatch/NotificationWriterInterface.php
+++ b/src/Notification/Dispatch/NotificationWriterInterface.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch;
+
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
+use Pimcore\Model\Notification;
+use Pimcore\Model\UserInterface;
+
+/**
+ * Writes the bell entry for one recipient.
+ *
+ * Split out of the dispatcher so that what the dispatcher *decides* — who is skipped, what is
+ * written, which channels are handed the result — can be tested without a database. Notification
+ * is a Pimcore model whose save() goes through a Dao, and doubling that is worse than useless:
+ * Dao-proxied calls silently no-op on a mock, so the test passes while asserting nothing.
+ *
+ * @internal
+ */
+interface NotificationWriterInterface
+{
+    /**
+     * @throws DatabaseException
+     */
+    public function write(
+        DispatchableNotification $notification,
+        UserInterface $recipient,
+        ?UserInterface $sender,
+    ): Notification;
+}

--- a/tests/Unit/Notification/Dispatch/DispatchableNotificationTest.php
+++ b/tests/Unit/Notification/Dispatch/DispatchableNotificationTest.php
@@ -16,9 +16,6 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Notification\Dispatch;
 use Codeception\Test\Unit;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\DispatchableNotification;
 
-/**
- * The value object is final readonly, so it is constructed directly rather than mocked.
- */
 final class DispatchableNotificationTest extends Unit
 {
     public function testItDefaultsToNoSenderElementOrPayload(): void

--- a/tests/Unit/Notification/Dispatch/DispatchableNotificationTest.php
+++ b/tests/Unit/Notification/Dispatch/DispatchableNotificationTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Notification\Dispatch;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\DispatchableNotification;
+
+/**
+ * The value object is final readonly, so it is constructed directly rather than mocked.
+ */
+final class DispatchableNotificationTest extends Unit
+{
+    public function testItDefaultsToNoSenderElementOrPayload(): void
+    {
+        $notification = new DispatchableNotification('test.type', [1, 2], 'Title', 'Message');
+
+        $this->assertSame('test.type', $notification->getTypeId());
+        $this->assertSame([1, 2], $notification->getRecipientIds());
+        $this->assertSame('Title', $notification->getTitle());
+        $this->assertSame('Message', $notification->getMessage());
+        $this->assertNull($notification->getSenderId());
+        $this->assertNull($notification->getLinkedElement());
+        $this->assertSame([], $notification->getPayload());
+    }
+}

--- a/tests/Unit/Notification/Dispatch/EffectiveSubscriptionTest.php
+++ b/tests/Unit/Notification/Dispatch/EffectiveSubscriptionTest.php
@@ -17,9 +17,6 @@ use Codeception\Test\Unit;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Registry\ChannelRegistryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Subscription\EffectiveSubscription;
 
-/**
- * The value object is final readonly, so it is constructed directly rather than mocked.
- */
 final class EffectiveSubscriptionTest extends Unit
 {
     public function testItSeparatesThePopupPreferenceFromTransports(): void

--- a/tests/Unit/Notification/Dispatch/EffectiveSubscriptionTest.php
+++ b/tests/Unit/Notification/Dispatch/EffectiveSubscriptionTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Notification\Dispatch;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Registry\ChannelRegistryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Subscription\EffectiveSubscription;
+
+/**
+ * The value object is final readonly, so it is constructed directly rather than mocked.
+ */
+final class EffectiveSubscriptionTest extends Unit
+{
+    public function testItSeparatesThePopupPreferenceFromTransports(): void
+    {
+        $subscription = new EffectiveSubscription('test.type', true, ['popup', 'email', 'teams']);
+
+        $this->assertTrue($subscription->wantsPopup());
+        $this->assertSame(['email', 'teams'], $subscription->getTransportChannels());
+        $this->assertTrue($subscription->hasChannel('email'));
+        $this->assertFalse($subscription->hasChannel('sms'));
+    }
+
+    public function testAnUnsubscribedSubscriptionNeverWantsAPopup(): void
+    {
+        $subscription = new EffectiveSubscription('test.type', false, []);
+
+        $this->assertFalse($subscription->wantsPopup());
+        $this->assertSame([], $subscription->getTransportChannels());
+    }
+
+    public function testPopupIsTheReservedChannelName(): void
+    {
+        $this->assertSame('popup', ChannelRegistryInterface::POPUP_CHANNEL);
+    }
+}

--- a/tests/Unit/Notification/Dispatch/Fixture/TestNotificationWriter.php
+++ b/tests/Unit/Notification/Dispatch/Fixture/TestNotificationWriter.php
@@ -22,10 +22,7 @@ use function in_array;
 
 /**
  * Stands in for the bell-row write. Records who was written for, and can be told to fail for
- * specific recipients so the dispatcher's per-recipient isolation can be exercised.
- *
- * Returning a bare Notification is safe: constructing the model touches no database, only
- * save() does — which is exactly why the real writer is a separate collaborator.
+ * specific recipients. Constructing a Notification touches no database; only save() does.
  */
 final class TestNotificationWriter implements NotificationWriterInterface
 {

--- a/tests/Unit/Notification/Dispatch/Fixture/TestNotificationWriter.php
+++ b/tests/Unit/Notification/Dispatch/Fixture/TestNotificationWriter.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Notification\Dispatch\Fixture;
+
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\DatabaseException;
+use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\DispatchableNotification;
+use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationWriterInterface;
+use Pimcore\Model\Notification;
+use Pimcore\Model\UserInterface;
+use function in_array;
+
+/**
+ * Stands in for the bell-row write. Records who was written for, and can be told to fail for
+ * specific recipients so the dispatcher's per-recipient isolation can be exercised.
+ *
+ * Returning a bare Notification is safe: constructing the model touches no database, only
+ * save() does — which is exactly why the real writer is a separate collaborator.
+ */
+final class TestNotificationWriter implements NotificationWriterInterface
+{
+    /**
+     * @var array<int, array{notification: DispatchableNotification, recipient: UserInterface, sender: ?UserInterface}>
+     */
+    public array $written = [];
+
+    /**
+     * @param int[] $failForRecipientIds
+     */
+    public function __construct(private readonly array $failForRecipientIds = [])
+    {
+    }
+
+    public function write(
+        DispatchableNotification $notification,
+        UserInterface $recipient,
+        ?UserInterface $sender,
+    ): Notification {
+        if (in_array($recipient->getId(), $this->failForRecipientIds, true)) {
+            throw new DatabaseException('Simulated write failure');
+        }
+
+        $this->written[] = [
+            'notification' => $notification,
+            'recipient' => $recipient,
+            'sender' => $sender,
+        ];
+
+        return new Notification();
+    }
+
+    /**
+     * @return int[]
+     */
+    public function writtenRecipientIds(): array
+    {
+        return array_map(
+            static fn (array $entry): int => $entry['recipient']->getId(),
+            $this->written
+        );
+    }
+}

--- a/tests/Unit/Notification/Dispatch/NotificationDispatchPassTest.php
+++ b/tests/Unit/Notification/Dispatch/NotificationDispatchPassTest.php
@@ -52,9 +52,7 @@ final class NotificationDispatchPassTest extends Unit
     }
 
     /**
-     * The whole point of the gate: with only types that never allow external delivery (a core-only
-     * install has just the 'info' catch-all), a transport channel is dead weight. Untagging is what
-     * gates it — the registry collects by tag — and the definition is deliberately left in place.
+     * Untagging is what gates the channel; the definition is deliberately left in place.
      */
     public function testUntagsTransportChannelsWhenNoTypeAllowsExternalDelivery(): void
     {
@@ -73,10 +71,6 @@ final class NotificationDispatchPassTest extends Unit
         );
     }
 
-    /**
-     * A channel a bundle tagged itself is gated the same way, rather than being left registered
-     * and half-active.
-     */
     public function testUntagsAChannelThatWasTaggedExplicitly(): void
     {
         $container = new ContainerBuilder();
@@ -92,9 +86,8 @@ final class NotificationDispatchPassTest extends Unit
     }
 
     /**
-     * The reason the gate untags rather than removing. A bundle contributing a channel is expected
-     * to alias the interface to it — that is what the extending doc shows — and removing the
-     * definition leaves the alias pointing at nothing, so the container no longer compiles.
+     * Why the gate untags rather than removes: a bundle is expected to alias the interface to its
+     * channel, and removing the definition leaves the alias pointing at nothing.
      */
     public function testAGatedChannelStillLeavesTheContainerCompilable(): void
     {

--- a/tests/Unit/Notification/Dispatch/NotificationDispatchPassTest.php
+++ b/tests/Unit/Notification/Dispatch/NotificationDispatchPassTest.php
@@ -53,9 +53,10 @@ final class NotificationDispatchPassTest extends Unit
 
     /**
      * The whole point of the gate: with only types that never allow external delivery (a core-only
-     * install has just the 'info' catch-all), a transport channel is dead weight and is removed.
+     * install has just the 'info' catch-all), a transport channel is dead weight. Untagging is what
+     * gates it — the registry collects by tag — and the definition is deliberately left in place.
      */
-    public function testRemovesTransportChannelsWhenNoTypeAllowsExternalDelivery(): void
+    public function testUntagsTransportChannelsWhenNoTypeAllowsExternalDelivery(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('a.descriptor', new Definition(TestNotificationTypeDescriptor::class))
@@ -64,11 +65,49 @@ final class NotificationDispatchPassTest extends Unit
 
         (new NotificationDispatchPass())->process($container);
 
-        $this->assertFalse($container->hasDefinition('a.channel'));
+        $this->assertTrue($container->hasDefinition('a.channel'), 'The definition must survive.');
+        $this->assertFalse($container->getDefinition('a.channel')->hasTag(ChannelInterface::TAG));
         // The descriptor itself is still contributed — only the channel is gated.
         $this->assertTrue(
             $container->getDefinition('a.descriptor')->hasTag(NotificationTypeDescriptorInterface::TAG)
         );
+    }
+
+    /**
+     * A channel a bundle tagged itself is gated the same way, rather than being left registered
+     * and half-active.
+     */
+    public function testUntagsAChannelThatWasTaggedExplicitly(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('a.descriptor', new Definition(TestNotificationTypeDescriptor::class))
+            ->setArguments(['a.type', false]);
+        $definition = new Definition(TestChannel::class);
+        $definition->addTag(ChannelInterface::TAG);
+        $container->setDefinition('a.channel', $definition);
+
+        (new NotificationDispatchPass())->process($container);
+
+        $this->assertFalse($container->getDefinition('a.channel')->hasTag(ChannelInterface::TAG));
+    }
+
+    /**
+     * The reason the gate untags rather than removing. A bundle contributing a channel is expected
+     * to alias the interface to it — that is what the extending doc shows — and removing the
+     * definition leaves the alias pointing at nothing, so the container no longer compiles.
+     */
+    public function testAGatedChannelStillLeavesTheContainerCompilable(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('a.descriptor', new Definition(TestNotificationTypeDescriptor::class))
+            ->setArguments(['a.type', false]);
+        $container->setDefinition('a.channel', new Definition(TestChannel::class))->setPublic(true);
+        $container->setAlias(ChannelInterface::class, 'a.channel')->setPublic(true);
+
+        (new NotificationDispatchPass())->process($container);
+        $container->compile();
+
+        $this->assertInstanceOf(TestChannel::class, $container->get(ChannelInterface::class));
     }
 
     /**

--- a/tests/Unit/Notification/Dispatch/NotificationDispatcherTest.php
+++ b/tests/Unit/Notification/Dispatch/NotificationDispatcherTest.php
@@ -32,17 +32,14 @@ use function in_array;
 
 /**
  * What the dispatcher decides: who is skipped, who gets a bell row, and which channels are handed
- * the result. Writing the row itself goes through NotificationWriter, which is stubbed here — the
- * seam exists precisely so these decisions can be pinned without a database.
+ * the result. The write itself is stubbed, so no database is needed.
  */
 final class NotificationDispatcherTest extends Unit
 {
     private const string TYPE_ID = 'test.type';
 
     /**
-     * A producer naming a type nobody registered is a wiring mistake, and silently writing an
-     * unroutable notification would hide it. Unlike a per-recipient failure this is raised, and
-     * before anything is written.
+     * A wiring mistake, so unlike a per-recipient failure it is raised — before anything is written.
      */
     public function testUnknownTypeIsRejected(): void
     {
@@ -89,10 +86,6 @@ final class NotificationDispatcherTest extends Unit
         $this->assertSame(7, $email->sent[0]['recipient']->getId());
     }
 
-    /**
-     * The pop-up is a presentation preference resolved when the notification is published, never
-     * something to hand a transport.
-     */
     public function testAPopupOnlySubscriptionInvokesNoTransportChannel(): void
     {
         $writer = new TestNotificationWriter();
@@ -153,8 +146,7 @@ final class NotificationDispatcherTest extends Unit
     }
 
     /**
-     * A channel is contributed by another bundle and may be broken, slow or misconfigured. None of
-     * that may stop the other channels — the guarantee ChannelInterface::send() documents.
+     * The guarantee ChannelInterface::send() documents.
      */
     public function testABrokenChannelIsLoggedAndTheOtherChannelStillDelivers(): void
     {
@@ -178,10 +170,6 @@ final class NotificationDispatcherTest extends Unit
         $this->assertSame([7], $writer->writtenRecipientIds());
     }
 
-    /**
-     * Recipients are independent. A bell row that cannot be written for one of them used to abort
-     * the loop, delivering to everyone before it and silently skipping everyone after.
-     */
     public function testAFailedWriteForOneRecipientDoesNotCostTheOthersTheirNotification(): void
     {
         $writer = new TestNotificationWriter(failForRecipientIds: [8]);

--- a/tests/Unit/Notification/Dispatch/NotificationDispatcherTest.php
+++ b/tests/Unit/Notification/Dispatch/NotificationDispatcherTest.php
@@ -16,100 +16,257 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Notification\Dispatch;
 use Codeception\Test\Unit;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\DispatchableNotification;
+use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationDispatcher;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Registry\ChannelRegistry;
+use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Registry\NotificationTypeRegistryInterface;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Subscription\EffectiveSubscription;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Subscription\SubscriptionResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Notification\Dispatch\Fixture\TestChannel;
 use Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Notification\Dispatch\Fixture\TestNotificationTypeDescriptor;
+use Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Notification\Dispatch\Fixture\TestNotificationWriter;
+use Pimcore\Bundle\StudioBackendBundle\User\Repository\UserRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\UserPermissions;
+use Pimcore\Model\UserInterface;
+use Psr\Log\LoggerInterface;
+use function in_array;
 
 /**
- * Covers what the dispatcher decides. Writing the bell row itself goes through the Pimcore
- * notification model, which is exercised in the integration tests rather than mocked here.
+ * What the dispatcher decides: who is skipped, who gets a bell row, and which channels are handed
+ * the result. Writing the row itself goes through NotificationWriter, which is stubbed here — the
+ * seam exists precisely so these decisions can be pinned without a database.
  */
 final class NotificationDispatcherTest extends Unit
 {
+    private const string TYPE_ID = 'test.type';
+
     /**
      * A producer naming a type nobody registered is a wiring mistake, and silently writing an
-     * unroutable notification would hide it.
+     * unroutable notification would hide it. Unlike a per-recipient failure this is raised, and
+     * before anything is written.
      */
     public function testUnknownTypeIsRejected(): void
     {
-        $registry = $this->makeEmpty(
-            \Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\Registry\NotificationTypeRegistryInterface::class,
-            [
-                'getDescriptor' => static function (string $typeId): never {
-                    throw new NotFoundException('Notification type', $typeId, 'type id');
-                },
-            ]
-        );
+        $writer = new TestNotificationWriter();
 
-        $dispatcher = new \Pimcore\Bundle\StudioBackendBundle\Notification\Dispatch\NotificationDispatcher(
-            $registry,
-            new ChannelRegistry([], []),
-            $this->makeEmpty(SubscriptionResolverInterface::class),
-            $this->makeEmpty(\Pimcore\Bundle\StudioBackendBundle\User\Repository\UserRepositoryInterface::class),
-            $this->makeEmpty(\Psr\Log\LoggerInterface::class),
+        $dispatcher = $this->dispatcher(
+            writer: $writer,
+            typeRegistry: $this->makeEmpty(
+                NotificationTypeRegistryInterface::class,
+                [
+                    'getDescriptor' => static function (string $typeId): never {
+                        throw new NotFoundException('Notification type', $typeId, 'type id');
+                    },
+                ]
+            )
         );
 
         $this->expectException(NotFoundException::class);
 
-        $dispatcher->dispatch(
-            new DispatchableNotification('unregistered.type', [1], 'Title', 'Message')
+        try {
+            $dispatcher->dispatch(new DispatchableNotification('unregistered.type', [1], 'Title', 'Message'));
+        } finally {
+            $this->assertSame([], $writer->written);
+        }
+    }
+
+    public function testSubscribedRecipientIsWrittenAndHandedToEveryTransportChannel(): void
+    {
+        $writer = new TestNotificationWriter();
+        $email = new TestChannel('email');
+        $teams = new TestChannel('teams', sortOrder: 200);
+
+        $dispatcher = $this->dispatcher(
+            writer: $writer,
+            channels: [$email, $teams],
+            subscription: new EffectiveSubscription(self::TYPE_ID, true, ['popup', 'email', 'teams'])
+        );
+
+        $dispatcher->dispatch($this->notification([7]));
+
+        $this->assertSame([7], $writer->writtenRecipientIds());
+        $this->assertCount(1, $email->sent);
+        $this->assertCount(1, $teams->sent);
+        $this->assertSame(7, $email->sent[0]['recipient']->getId());
+    }
+
+    /**
+     * The pop-up is a presentation preference resolved when the notification is published, never
+     * something to hand a transport.
+     */
+    public function testAPopupOnlySubscriptionInvokesNoTransportChannel(): void
+    {
+        $writer = new TestNotificationWriter();
+        $email = new TestChannel('email');
+
+        $dispatcher = $this->dispatcher(
+            writer: $writer,
+            channels: [$email],
+            subscription: new EffectiveSubscription(self::TYPE_ID, true, ['popup'])
+        );
+
+        $dispatcher->dispatch($this->notification([7]));
+
+        $this->assertSame([7], $writer->writtenRecipientIds(), 'The bell row is still written.');
+        $this->assertSame([], $email->sent);
+    }
+
+    public function testRecipientWithoutTheNotificationsPermissionIsSkipped(): void
+    {
+        $writer = new TestNotificationWriter();
+        $email = new TestChannel('email');
+
+        $dispatcher = $this->dispatcher(
+            writer: $writer,
+            channels: [$email],
+            allowedUserIds: []
+        );
+
+        $dispatcher->dispatch($this->notification([7]));
+
+        $this->assertSame([], $writer->written);
+        $this->assertSame([], $email->sent);
+    }
+
+    public function testUnsubscribedRecipientIsSkipped(): void
+    {
+        $writer = new TestNotificationWriter();
+
+        $dispatcher = $this->dispatcher(
+            writer: $writer,
+            subscription: new EffectiveSubscription(self::TYPE_ID, false, [])
+        );
+
+        $dispatcher->dispatch($this->notification([7]));
+
+        $this->assertSame([], $writer->written);
+    }
+
+    public function testAnUnknownRecipientIsSkippedAndTheRestStillReceive(): void
+    {
+        $writer = new TestNotificationWriter();
+
+        $dispatcher = $this->dispatcher(writer: $writer, knownUserIds: [7, 9]);
+
+        $dispatcher->dispatch($this->notification([7, 404, 9]));
+
+        $this->assertSame([7, 9], $writer->writtenRecipientIds());
+    }
+
+    /**
+     * A channel is contributed by another bundle and may be broken, slow or misconfigured. None of
+     * that may stop the other channels — the guarantee ChannelInterface::send() documents.
+     */
+    public function testABrokenChannelIsLoggedAndTheOtherChannelStillDelivers(): void
+    {
+        $writer = new TestNotificationWriter();
+        $broken = new TestChannel('broken', sortOrder: 10, throwOnSend: true);
+        $working = new TestChannel('working', sortOrder: 20);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with($this->stringContains('broken'));
+
+        $dispatcher = $this->dispatcher(
+            writer: $writer,
+            channels: [$broken, $working],
+            subscription: new EffectiveSubscription(self::TYPE_ID, true, ['broken', 'working']),
+            logger: $logger
+        );
+
+        $dispatcher->dispatch($this->notification([7]));
+
+        $this->assertCount(1, $working->sent, 'The working channel must still have delivered.');
+        $this->assertSame([7], $writer->writtenRecipientIds());
+    }
+
+    /**
+     * Recipients are independent. A bell row that cannot be written for one of them used to abort
+     * the loop, delivering to everyone before it and silently skipping everyone after.
+     */
+    public function testAFailedWriteForOneRecipientDoesNotCostTheOthersTheirNotification(): void
+    {
+        $writer = new TestNotificationWriter(failForRecipientIds: [8]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with($this->stringContains('user 8'));
+
+        $dispatcher = $this->dispatcher(
+            writer: $writer,
+            knownUserIds: [7, 8, 9],
+            logger: $logger
+        );
+
+        $dispatcher->dispatch($this->notification([7, 8, 9]));
+
+        $this->assertSame([7, 9], $writer->writtenRecipientIds());
+    }
+
+    private function notification(array $recipientIds): DispatchableNotification
+    {
+        return new DispatchableNotification(self::TYPE_ID, $recipientIds, 'Title', 'Message');
+    }
+
+    /**
+     * @param TestChannel[] $channels
+     * @param int[] $knownUserIds
+     * @param int[]|null $allowedUserIds null means every known user is allowed
+     */
+    private function dispatcher(
+        TestNotificationWriter $writer,
+        array $channels = [],
+        ?EffectiveSubscription $subscription = null,
+        array $knownUserIds = [7],
+        ?array $allowedUserIds = null,
+        ?LoggerInterface $logger = null,
+        ?NotificationTypeRegistryInterface $typeRegistry = null,
+    ): NotificationDispatcher {
+        $descriptor = new TestNotificationTypeDescriptor(self::TYPE_ID, allowsExternalDelivery: true);
+
+        return new NotificationDispatcher(
+            $typeRegistry ?? $this->makeEmpty(
+                NotificationTypeRegistryInterface::class,
+                ['getDescriptor' => $descriptor]
+            ),
+            new ChannelRegistry($channels, []),
+            $this->makeEmpty(
+                SubscriptionResolverInterface::class,
+                [
+                    'resolve' => $subscription
+                        ?? new EffectiveSubscription(self::TYPE_ID, true, ['popup', 'email']),
+                ]
+            ),
+            $writer,
+            $this->userRepository($knownUserIds, $allowedUserIds),
+            $logger ?? $this->createMock(LoggerInterface::class),
         );
     }
 
     /**
-     * The value object is final readonly, so it is constructed directly rather than mocked.
+     * @param int[] $knownUserIds
+     * @param int[]|null $allowedUserIds
      */
-    public function testDispatchableNotificationDefaultsToNoSenderElementOrPayload(): void
+    private function userRepository(array $knownUserIds, ?array $allowedUserIds): UserRepositoryInterface
     {
-        $notification = new DispatchableNotification('test.type', [1, 2], 'Title', 'Message');
+        return $this->makeEmpty(
+            UserRepositoryInterface::class,
+            [
+                'getUserById' => function (int $userId) use ($knownUserIds, $allowedUserIds): UserInterface {
+                    if (!in_array($userId, $knownUserIds, true)) {
+                        throw new NotFoundException('User', $userId);
+                    }
 
-        $this->assertSame('test.type', $notification->getTypeId());
-        $this->assertSame([1, 2], $notification->getRecipientIds());
-        $this->assertNull($notification->getSenderId());
-        $this->assertNull($notification->getLinkedElement());
-        $this->assertSame([], $notification->getPayload());
-    }
+                    $allowed = $allowedUserIds === null || in_array($userId, $allowedUserIds, true);
 
-    public function testEffectiveSubscriptionSeparatesPopupFromTransports(): void
-    {
-        $subscription = new EffectiveSubscription('test.type', true, ['popup', 'email', 'teams']);
+                    $user = $this->createMock(UserInterface::class);
+                    $user->method('getId')->willReturn($userId);
+                    $user->method('isAllowed')
+                        ->willReturnCallback(
+                            static fn (string $key): bool => $allowed
+                                && $key === UserPermissions::NOTIFICATIONS->value
+                        );
 
-        $this->assertTrue($subscription->wantsPopup());
-        $this->assertSame(['email', 'teams'], $subscription->getTransportChannels());
-        $this->assertTrue($subscription->hasChannel('email'));
-        $this->assertFalse($subscription->hasChannel('sms'));
-    }
-
-    public function testUnsubscribedEffectiveSubscriptionNeverWantsAPopup(): void
-    {
-        $subscription = new EffectiveSubscription('test.type', false, []);
-
-        $this->assertFalse($subscription->wantsPopup());
-        $this->assertSame([], $subscription->getTransportChannels());
-    }
-
-    /**
-     * A channel is contributed by another bundle and may be broken, slow or misconfigured.
-     * None of that may reach the action that produced the notification.
-     */
-    public function testBrokenChannelDoesNotPreventOtherChannelsFromDelivering(): void
-    {
-        $broken = new TestChannel('broken', sortOrder: 10, throwOnSend: true);
-        $working = new TestChannel('working', sortOrder: 20);
-
-        $registry = new ChannelRegistry([$broken, $working], []);
-
-        $this->assertNotNull($registry->getEnabledChannel('broken'));
-        $this->assertNotNull($registry->getEnabledChannel('working'));
-
-        // Both are offered to a type that allows external delivery; the dispatcher iterates
-        // them independently and logs rather than aborting on the first failure.
-        $descriptor = new TestNotificationTypeDescriptor('test.type', allowsExternalDelivery: true);
-        $this->assertSame(
-            ['popup', 'broken', 'working'],
-            $registry->getSupportedChannelIds($descriptor)
+                    return $user;
+                },
+            ]
         );
     }
 }


### PR DESCRIPTION
Stacked on **#1959** — base is `feat/notification-subscriptions`, so this diff is only the hardening. Retarget to `2026.x` if #1959 merges first.

Addresses the three findings I would have blocked #1959 on.

## 1. The channel gate broke the extension path it documents

`NotificationDispatchPass` removed a channel's service definition when no registered type allows external delivery. `removeDefinition()` does not rewrite aliases or references, so the first bundle to alias `ChannelInterface` to its own channel — exactly what `14_Extending_Notifications.md` shows — got a `ServiceNotFoundException` at compile time the moment the gate closed. Core was safe only because `EmailChannel` has no alias.

Clearing the tag achieves the same gate without touching the graph: the registry collects by tag, and an untagged private service nothing references is dropped by Symfony's own unused-definition pass, so no dead mailer is instantiated either way.

## 2. The dispatcher had no tests, and one test claimed otherwise

`testBrokenChannelDoesNotPreventOtherChannelsFromDelivering` never called `dispatch()` — it built a `TestChannel` with `throwOnSend: true`, then asserted on `ChannelRegistry`. `TestChannel::$sent` was written by the fixture and asserted nowhere in the suite. So the guarantee `ChannelInterface::send()` documents in capitals was unverified, along with the permission skip, the unsubscribed skip and the unknown-recipient skip — on a class with no in-repo caller, which other bundles are meant to build against.

The blocker was `write()` calling `Notification::save()`, which goes through a Dao. Doubling that is worse than useless — Dao-proxied calls silently no-op on a mock, so tests pass while asserting nothing. Extracting `NotificationWriterInterface` leaves the dispatcher holding only routing decisions.

Eight tests now call `dispatch()` and assert on what the writer and the channels actually received.

## 3. One bad recipient aborted the whole fan-out

`write()` threw `DatabaseException` out of the per-recipient loop, so a failure part-way through delivered to the recipients before it, silently skipped everyone after it, and surfaced as an exception the producer could do nothing with — while `deliver()` immediately below already logged and continued. `NotificationDispatcherInterface` promised the latter. The loop body is now wrapped; an unregistered type id still raises, since that is a wiring mistake caught before any recipient is processed.

## Verification

- PHPStan level 6 clean; full Unit suite **528 tests / 1198 assertions** (was 519 / 1177).
- Both fixes mutation-checked: restoring `removeDefinition()` fails the container-compiles test, and removing the per-recipient guard fails the fan-out test. Neither test is vacuous.

## Not included

The compiler pass still scans every container definition rather than using `findTaggedServiceIds()` — a performance and robustness outlier, not a correctness bug, and a larger change than these three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)