### PR TITLE
Do not require view permission on the element tree levels above the requested element

### DIFF
--- a/src/DataIndex/Query/TreeQuery.php
+++ b/src/DataIndex/Query/TreeQuery.php
@@ -59,8 +59,7 @@ final readonly class TreeQuery implements TreeQueryInterface
                 $type,
                 $widget->getRootFolder()->getFullPath(),
                 $widget->isShowRoot(),
-                $query,
-                $user
+                $query
             );
 
             return $query;
@@ -122,10 +121,12 @@ final readonly class TreeQuery implements TreeQueryInterface
         string $type,
         string $rootPath,
         bool $includeParent,
-        QueryInterface $query,
-        UserInterface $user
+        QueryInterface $query
     ): void {
-        $parent = $this->elementService->getAllowedElementByPath($type, $rootPath, $user);
+        // The widget root is only navigated through here, its children sorting is applied to the
+        // query - so it is resolved without a view permission check, see
+        // ElementServiceInterface::getNavigableElementByPath().
+        $parent = $this->elementService->getNavigableElementByPath($type, $rootPath);
 
         if (!$parent instanceof DataObject) {
             throw new NotFoundException(

--- a/src/DataIndex/Query/TreeQuery.php
+++ b/src/DataIndex/Query/TreeQuery.php
@@ -59,7 +59,8 @@ final readonly class TreeQuery implements TreeQueryInterface
                 $type,
                 $widget->getRootFolder()->getFullPath(),
                 $widget->isShowRoot(),
-                $query
+                $query,
+                $user
             );
 
             return $query;
@@ -121,7 +122,8 @@ final readonly class TreeQuery implements TreeQueryInterface
         string $type,
         string $rootPath,
         bool $includeParent,
-        QueryInterface $query
+        QueryInterface $query,
+        UserInterface $user
     ): void {
         // The widget root is only navigated through here, its children sorting is applied to the
         // query - so it is resolved without a view permission check, see

--- a/src/Element/Service/ElementService.php
+++ b/src/Element/Service/ElementService.php
@@ -106,11 +106,9 @@ final readonly class ElementService implements ElementServiceInterface
     ): ElementInterface {
         $element = $this->getElementByPath($this->serviceResolver, $elementType, $elementPath);
 
-        // The tree root is a traversal anchor, not an element a user gets a workspace on: element
-        // permissions are resolved from the workspaces relevant for the requested path, and no
-        // workspace below "/" is relevant for "/" itself, so the root always resolves to "no
-        // permissions" for non-admins. ElementTreeWidgetConfigHydrator::isDefaultRootFolder()
-        // already skips the lookup for the root path for the same reason.
+        // The root is used as a traversal anchor by tree operations. Descendant workspaces are not
+        // relevant to "/" itself, so users with access only to descendants cannot pass the root check.
+        // ElementTreeWidgetConfigHydrator::isDefaultRootFolder() already skips this lookup.
         if ($elementPath !== ElementFolderPaths::ROOT->value) {
             $this->securityService->hasElementPermission($element, $user, ElementPermissions::VIEW_PERMISSION);
         }

--- a/src/Element/Service/ElementService.php
+++ b/src/Element/Service/ElementService.php
@@ -23,6 +23,7 @@ use Pimcore\Bundle\StudioBackendBundle\Element\Schema\Subtype;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\ElementParameters;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementFolderPaths;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
@@ -104,7 +105,15 @@ final readonly class ElementService implements ElementServiceInterface
         UserInterface $user
     ): ElementInterface {
         $element = $this->getElementByPath($this->serviceResolver, $elementType, $elementPath);
-        $this->securityService->hasElementPermission($element, $user, ElementPermissions::VIEW_PERMISSION);
+
+        // The tree root is a traversal anchor, not an element a user gets a workspace on: element
+        // permissions are resolved from the workspaces relevant for the requested path, and no
+        // workspace below "/" is relevant for "/" itself, so the root always resolves to "no
+        // permissions" for non-admins. ElementTreeWidgetConfigHydrator::isDefaultRootFolder()
+        // already skips the lookup for the root path for the same reason.
+        if ($elementPath !== ElementFolderPaths::ROOT->value) {
+            $this->securityService->hasElementPermission($element, $user, ElementPermissions::VIEW_PERMISSION);
+        }
 
         return $element;
     }

--- a/src/Element/Service/ElementService.php
+++ b/src/Element/Service/ElementService.php
@@ -23,7 +23,6 @@ use Pimcore\Bundle\StudioBackendBundle\Element\Schema\Subtype;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\ElementParameters;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
-use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementFolderPaths;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Trait\ElementProviderTrait;
@@ -105,15 +104,19 @@ final readonly class ElementService implements ElementServiceInterface
         UserInterface $user
     ): ElementInterface {
         $element = $this->getElementByPath($this->serviceResolver, $elementType, $elementPath);
-
-        // The root is used as a traversal anchor by tree operations. Descendant workspaces are not
-        // relevant to "/" itself, so users with access only to descendants cannot pass the root check.
-        // ElementTreeWidgetConfigHydrator::isDefaultRootFolder() already skips this lookup.
-        if ($elementPath !== ElementFolderPaths::ROOT->value) {
-            $this->securityService->hasElementPermission($element, $user, ElementPermissions::VIEW_PERMISSION);
-        }
+        $this->securityService->hasElementPermission($element, $user, ElementPermissions::VIEW_PERMISSION);
 
         return $element;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNavigableElementByPath(
+        string $elementType,
+        string $elementPath
+    ): ElementInterface {
+        return $this->getElementByPath($this->serviceResolver, $elementType, $elementPath);
     }
 
     public function hasElementChildren(ElementInterface $element): bool

--- a/src/Element/Service/ElementServiceInterface.php
+++ b/src/Element/Service/ElementServiceInterface.php
@@ -75,10 +75,11 @@ interface ElementServiceInterface
      * Resolves an element that is only navigated through - the root of an element tree or one of the
      * tree levels above the element a user asked for - without checking the view permission.
      *
-     * Element permissions are resolved from the workspaces relevant for the requested path, so an
-     * ancestor of an allowed path never carries permissions itself, while the search index
-     * deliberately keeps those ancestors listable to keep the tree navigable. Use
-     * getAllowedElementByPath() for every path a user actually opens.
+     * Element permissions are resolved from the workspaces relevant for the requested path, so tree
+     * levels above the workspace granting access carry no permissions at all - the tree root most of
+     * all, as no workspace below "/" is relevant for "/" itself. The search index deliberately keeps
+     * those levels listable to keep the tree navigable. Use getAllowedElementByPath() for every path
+     * a user actually opens.
      *
      * @throws NotFoundException
      */

--- a/src/Element/Service/ElementServiceInterface.php
+++ b/src/Element/Service/ElementServiceInterface.php
@@ -71,6 +71,22 @@ interface ElementServiceInterface
         UserInterface $user
     ): ElementInterface;
 
+    /**
+     * Resolves an element that is only navigated through - the root of an element tree or one of the
+     * tree levels above the element a user asked for - without checking the view permission.
+     *
+     * Element permissions are resolved from the workspaces relevant for the requested path, so an
+     * ancestor of an allowed path never carries permissions itself, while the search index
+     * deliberately keeps those ancestors listable to keep the tree navigable. Use
+     * getAllowedElementByPath() for every path a user actually opens.
+     *
+     * @throws NotFoundException
+     */
+    public function getNavigableElementByPath(
+        string $elementType,
+        string $elementPath
+    ): ElementInterface;
+
     public function hasElementChildren(ElementInterface $element): bool;
 
     public function hasElementDependencies(

--- a/src/Perspective/Repository/ElementTreeWidgetRepository.php
+++ b/src/Perspective/Repository/ElementTreeWidgetRepository.php
@@ -22,7 +22,6 @@ use Pimcore\Bundle\StudioBackendBundle\DataIndex\SearchIndexFilterInterface;
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\ElementSearchServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Schema\TreeLevelData;
 use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementServiceInterface;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Model\WidgetElementData;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\ElementTreeWidgetConfig;
@@ -88,7 +87,7 @@ final readonly class ElementTreeWidgetRepository implements ElementTreeWidgetRep
         $widget = $widgetElementData->getWidgetConfig();
         $element = $widgetElementData->getResultItem();
         $treeLevelData = [];
-        $parents = $this->getParentElements($widget, $element, $user);
+        $parents = $this->getParentElements($widget, $element);
         if (empty($parents)) {
             return [new TreeLevelData(parentId: 1, elementId: $element->getId(), pageNumber: 1)];
         }
@@ -107,23 +106,25 @@ final readonly class ElementTreeWidgetRepository implements ElementTreeWidgetRep
     }
 
     /**
-     * @throws ForbiddenException|NotFoundException
+     * @throws NotFoundException
      *
      */
     private function getParentElements(
         ElementTreeWidgetConfig $widget,
-        ElementSearchResultItemInterface $element,
-        UserInterface $user
+        ElementSearchResultItemInterface $element
     ): array {
         $levels = $this->pathService->getAllParentPaths([$element->getFullPath()]);
         $levels = $this->filterParentPaths($levels, $widget->getRootFolder()->getFullPath());
 
         $parents = [];
         foreach ($levels as $level) {
-            $parents[] = $this->elementService->getAllowedElementByPath(
+            // The tree levels above the requested element are only navigated through, they are not
+            // opened - so they are resolved without a view permission check, see
+            // ElementServiceInterface::getNavigableElementByPath(). The element itself is checked in
+            // ElementLocationService::getElementLocation().
+            $parents[] = $this->elementService->getNavigableElementByPath(
                 $widget->getElementType(),
-                $level,
-                $user
+                $level
             )->getId();
         }
 

--- a/src/Perspective/Repository/ElementTreeWidgetRepository.php
+++ b/src/Perspective/Repository/ElementTreeWidgetRepository.php
@@ -87,7 +87,7 @@ final readonly class ElementTreeWidgetRepository implements ElementTreeWidgetRep
         $widget = $widgetElementData->getWidgetConfig();
         $element = $widgetElementData->getResultItem();
         $treeLevelData = [];
-        $parents = $this->getParentElements($widget, $element);
+        $parents = $this->getParentElements($widget, $element, $user);
         if (empty($parents)) {
             return [new TreeLevelData(parentId: 1, elementId: $element->getId(), pageNumber: 1)];
         }
@@ -111,7 +111,8 @@ final readonly class ElementTreeWidgetRepository implements ElementTreeWidgetRep
      */
     private function getParentElements(
         ElementTreeWidgetConfig $widget,
-        ElementSearchResultItemInterface $element
+        ElementSearchResultItemInterface $element,
+        UserInterface $user
     ): array {
         $levels = $this->pathService->getAllParentPaths([$element->getFullPath()]);
         $levels = $this->filterParentPaths($levels, $widget->getRootFolder()->getFullPath());

--- a/src/Perspective/Repository/ElementTreeWidgetRepositoryInterface.php
+++ b/src/Perspective/Repository/ElementTreeWidgetRepositoryInterface.php
@@ -15,7 +15,6 @@ namespace Pimcore\Bundle\StudioBackendBundle\Perspective\Repository;
 
 use Pimcore\Bundle\StudioBackendBundle\DataIndex\SearchIndexFilterInterface;
 use Pimcore\Bundle\StudioBackendBundle\Element\Schema\TreeLevelData;
-use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidFilterTypeException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidQueryTypeException;
@@ -41,7 +40,7 @@ interface ElementTreeWidgetRepositoryInterface
     ): ?WidgetElementData;
 
     /**
-     * @throws ForbiddenException|InvalidArgumentException|InvalidFilterTypeException|InvalidQueryTypeException
+     * @throws InvalidArgumentException|InvalidFilterTypeException|InvalidQueryTypeException
      * @throws NotFoundException
      *
      * @return TreeLevelData[]

--- a/tests/Unit/Element/Service/ElementServiceTest.php
+++ b/tests/Unit/Element/Service/ElementServiceTest.php
@@ -1,0 +1,155 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Element\Service;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\ElementSearchServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementService;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementFolderPaths;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\UserInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use function end;
+use function sprintf;
+
+/**
+ * @internal
+ */
+final class ElementServiceTest extends Unit
+{
+    /**
+     * @throws Exception
+     */
+    public function testGetAllowedElementByPathChecksViewPermission(): void
+    {
+        $service = $this->createService($checkedPaths);
+
+        $element = $service->getAllowedElementByPath(
+            ElementTypes::TYPE_DATA_OBJECT,
+            '/some-folder',
+            $this->makeUser()
+        );
+
+        $this->assertSame(7221, $element->getId());
+        $this->assertSame(['/some-folder'], $checkedPaths);
+    }
+
+    /**
+     * The root path must not be exempted from the check here: this method resolves elements a user
+     * opens, so it has to stay unconditional. Tree traversal uses getNavigableElementByPath().
+     *
+     * @throws Exception
+     */
+    public function testGetAllowedElementByPathChecksViewPermissionForRootPath(): void
+    {
+        $service = $this->createService($checkedPaths, forbidden: true);
+
+        $this->expectException(ForbiddenException::class);
+
+        $service->getAllowedElementByPath(
+            ElementTypes::TYPE_DATA_OBJECT,
+            ElementFolderPaths::ROOT->value,
+            $this->makeUser()
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetNavigableElementByPathDoesNotCheckPermissions(): void
+    {
+        // A user only ever navigates through these paths, and an ancestor of an allowed path never
+        // carries permissions itself - so no permission check must happen, not even for the root.
+        $service = $this->createService($checkedPaths, forbidden: true);
+
+        foreach ([ElementFolderPaths::ROOT->value, '/some-folder'] as $path) {
+            $element = $service->getNavigableElementByPath(ElementTypes::TYPE_DATA_OBJECT, $path);
+
+            $this->assertSame(7221, $element->getId());
+        }
+
+        $this->assertSame([], $checkedPaths);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetNavigableElementByPathThrowsForUnknownPath(): void
+    {
+        $service = $this->createService($checkedPaths, elementFound: false);
+
+        $this->expectException(NotFoundException::class);
+
+        $service->getNavigableElementByPath(ElementTypes::TYPE_DATA_OBJECT, '/does-not-exist');
+    }
+
+    /**
+     * @param array<int, string>|null $checkedPaths paths the security service was asked about
+     *
+     * @throws Exception
+     */
+    private function createService(
+        ?array &$checkedPaths = null,
+        bool $forbidden = false,
+        bool $elementFound = true
+    ): ElementService {
+        $checkedPaths = [];
+        $resolvedPaths = [];
+
+        $element = $elementFound ? $this->makeEmpty(ElementInterface::class, ['getId' => 7221]) : null;
+
+        $serviceResolver = $this->makeEmpty(ServiceResolverInterface::class, [
+            'getElementByPath' => function (string $type, string $path) use (&$resolvedPaths, $element) {
+                $resolvedPaths[] = $path;
+
+                return $element;
+            },
+        ]);
+
+        $securityService = $this->makeEmpty(SecurityServiceInterface::class, [
+            'hasElementPermission' => function (
+                ElementInterface $element,
+                UserInterface $user,
+                string $permission
+            ) use (&$checkedPaths, &$resolvedPaths, $forbidden): void {
+                $checkedPaths[] = end($resolvedPaths);
+
+                if ($forbidden) {
+                    throw new ForbiddenException(sprintf('You dont have %s permission', $permission));
+                }
+            },
+        ]);
+
+        return new ElementService(
+            $this->makeEmpty(ElementSearchServiceInterface::class),
+            $this->makeEmpty(EventDispatcherInterface::class),
+            $serviceResolver,
+            $securityService
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function makeUser(): UserInterface
+    {
+        return $this->makeEmpty(UserInterface::class, ['getId' => 42]);
+    }
+}

--- a/tests/Unit/Perspective/Repository/ElementTreeWidgetRepositoryTest.php
+++ b/tests/Unit/Perspective/Repository/ElementTreeWidgetRepositoryTest.php
@@ -1,0 +1,191 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Perspective\Repository;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\ElementSearchResultItemInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Model\Search\Interfaces\SearchInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\SearchIndexAdapter\Search\LocateInTreeServiceInterface;
+use Pimcore\Bundle\GenericDataIndexBundle\Service\PathServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\QueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Query\TreeQueryInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\SearchIndexFilterInterface;
+use Pimcore\Bundle\StudioBackendBundle\DataIndex\Service\ElementSearchServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Schema\RelatedElementData;
+use Pimcore\Bundle\StudioBackendBundle\Element\Schema\TreeLevelData;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Model\WidgetElementData;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Repository\ElementTreeWidgetRepository;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\ElementTreeWidgetConfig;
+use Pimcore\Bundle\StudioBackendBundle\Response\ElementIcon;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementIconTypes;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\UserInterface;
+use function array_keys;
+use function array_map;
+
+/**
+ * @internal
+ */
+final class ElementTreeWidgetRepositoryTest extends Unit
+{
+    private const ELEMENT_ID = 7221;
+
+    private const IDS_BY_PATH = [
+        '/' => 1,
+        '/some-folder' => 4758,
+        '/some-folder/child' => 7219,
+        '/some-folder/child/leaf' => 7220,
+    ];
+
+    /**
+     * The tree levels between the widget root and the requested element are only navigated through,
+     * so they must be resolved without a view permission check - a user with a workspace on a
+     * descendant has no permissions on its ancestors, not even on the root.
+     *
+     * @throws Exception
+     */
+    public function testTreeLevelsAreResolvedWithoutPermissionCheck(): void
+    {
+        $repository = $this->createRepository($navigatedPaths);
+
+        $treeLevelData = $repository->getTreeLevelData(
+            $this->createWidgetElementData(),
+            $this->makeEmpty(SearchIndexFilterInterface::class),
+            $this->makeUser()
+        );
+
+        $this->assertSame(
+            ['/', '/some-folder', '/some-folder/child', '/some-folder/child/leaf'],
+            $navigatedPaths
+        );
+        $this->assertSame(
+            [[1, 4758], [4758, 7219], [7219, 7220], [7220, self::ELEMENT_ID]],
+            $this->flatten($treeLevelData)
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testTreeLevelsStartAtTheWidgetRootFolder(): void
+    {
+        $repository = $this->createRepository($navigatedPaths);
+
+        $treeLevelData = $repository->getTreeLevelData(
+            $this->createWidgetElementData('/some-folder/child'),
+            $this->makeEmpty(SearchIndexFilterInterface::class),
+            $this->makeUser()
+        );
+
+        $this->assertSame(['/some-folder/child', '/some-folder/child/leaf'], $navigatedPaths);
+        $this->assertSame([[7219, 7220], [7220, self::ELEMENT_ID]], $this->flatten($treeLevelData));
+    }
+
+    /**
+     * @param array<int, string>|null $navigatedPaths paths resolved as a tree level
+     *
+     * @throws Exception
+     */
+    private function createRepository(?array &$navigatedPaths = null): ElementTreeWidgetRepository
+    {
+        $navigatedPaths = [];
+
+        $elementService = $this->makeEmpty(ElementServiceInterface::class, [
+            'getNavigableElementByPath' => function (
+                string $elementType,
+                string $elementPath
+            ) use (&$navigatedPaths): ElementInterface {
+                $navigatedPaths[] = $elementPath;
+
+                return $this->makeEmpty(ElementInterface::class, [
+                    'getId' => self::IDS_BY_PATH[$elementPath],
+                ]);
+            },
+            'getAllowedElementByPath' => function (): ElementInterface {
+                $this->fail('Tree levels must not be resolved with a permission check.');
+            },
+        ]);
+
+        $pathService = $this->makeEmpty(PathServiceInterface::class, [
+            'getAllParentPaths' => array_keys(self::IDS_BY_PATH),
+        ]);
+
+        $treeQuery = $this->makeEmpty(TreeQueryInterface::class, [
+            'get' => $this->makeEmpty(QueryInterface::class, [
+                'getSearch' => $this->makeEmpty(SearchInterface::class),
+            ]),
+        ]);
+
+        return new ElementTreeWidgetRepository(
+            $elementService,
+            $this->makeEmpty(ElementSearchServiceInterface::class),
+            $this->makeEmpty(LocateInTreeServiceInterface::class, ['getPageNumber' => 1]),
+            $pathService,
+            $treeQuery
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createWidgetElementData(string $rootPath = '/'): WidgetElementData
+    {
+        $widget = new ElementTreeWidgetConfig(
+            'studio_data_object_tree_widget',
+            'Objects',
+            [],
+            new ElementIcon(ElementIconTypes::NAME->value, 'folder'),
+            ElementTypes::TYPE_DATA_OBJECT,
+            new RelatedElementData(
+                self::IDS_BY_PATH[$rootPath],
+                ElementTypes::TYPE_OBJECT,
+                ElementTypes::TYPE_FOLDER,
+                $rootPath,
+                null
+            )
+        );
+
+        return new WidgetElementData(
+            $widget,
+            $this->makeEmpty(ElementSearchResultItemInterface::class, [
+                'getId' => self::ELEMENT_ID,
+                'getFullPath' => '/some-folder/child/leaf/element',
+            ])
+        );
+    }
+
+    /**
+     * @param TreeLevelData[] $treeLevelData
+     *
+     * @return array<int, array<int, int>>
+     */
+    private function flatten(array $treeLevelData): array
+    {
+        return array_map(
+            static fn (TreeLevelData $data) => [$data->getParentId(), $data->getElementId()],
+            $treeLevelData
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function makeUser(): UserInterface
+    {
+        return $this->makeEmpty(UserInterface::class, ['getId' => 42]);
+    }
+}


### PR DESCRIPTION
Fixes pimcore/platform-version#313
Supersedes #1986 by @timwiechers — his two commits are kept as-is, this branch adds the rework discussed below (his analysis in the issue is what made the root cause obvious, thanks!).

## Problem

`GET /studio/api/element/tree-location` answers **403** for a non-admin user, so "show in tree" silently does nothing.

`ElementTreeWidgetRepository::getParentElements()` resolves *every* tree level between the widget root and the requested element through `ElementService::getAllowedElementByPath()`, which enforces `view`, and `TreeQuery::handleTreeSorting()` does the same for the widget root. But element permissions are resolved from the workspaces *relevant for the requested path* (`WorkspaceService::getRelevantWorkspaces()` in generic-data-index-bundle matches with `str_contains($path, $workspace->getPath())`), so an **ancestor of an allowed path never carries permissions itself**:

| requested path | workspace `/some-folder` relevant? | view |
|----|----|----|
| `/` | no | 0 |
| `/some-folder` | yes | 1 |
| `/some-folder/child/leaf` | yes | 1 |

`PermissionService::addRootNodePermissions()` only *removes* delete/rename/unpublish for the root, it never grants list/view, and `BasePermissions` defaults everything to `false` — so no workspace configuration satisfies the check short of granting an explicit workspace on `/`. Downgrading to `list` would not help either.

The index side takes the opposite, deliberate stance — `QueryService::createWorkspacesGroupQuery()`:

> we need to include all parent paths of the allowed paths as otherwise it will not be possible to navigate to the allowed paths in the tree

That is the actual bug: tree levels are *navigable* by design (and listed with `list`, ancestors explicitly included), but locating an element demanded `view` on each of them.

## Fix

Tree levels are resolved through a new `ElementServiceInterface::getNavigableElementByPath()` that performs no permission check, while `getAllowedElementByPath()` keeps its unconditional check for every path a user actually opens.

The element the user asked for is unaffected — `ElementLocationService::getElementLocation()` still resolves it via `getAllowedElementById()` before any tree work happens.

### Why not the original patch in #1986

That one skipped the check for the root path *inside* `getAllowedElementByPath()`, which

- also loosened the callers that resolve a path a user opens — `GetIdByPathController` would answer `/` with the root id instead of 403, plus `SiteHydrator` and widget validation, and
- fixed only the root level: a user holding a workspace on `/some-folder/child/leaf` still got a 403 on `/some-folder` and `/some-folder/child`, i.e. whenever the workspace sits more than one level below the widget root.

## Tests

- `tests/Unit/Element/Service/ElementServiceTest.php` — pins that `getAllowedElementByPath()` checks `view` **including for the root path**, and that `getNavigableElementByPath()` never checks permissions.
- `tests/Unit/Perspective/Repository/ElementTreeWidgetRepositoryTest.php` — the regression test: all tree levels of a nested element are resolved without a permission check, and level resolution starts at the widget root folder.

Both fail on `2026.2` (4 failures / 1 error) and pass with the fix. Full Unit suite green (487 tests), PHPStan level 6 clean.

## Notes

- No API shape change; the stale `@throws ForbiddenException` on `ElementTreeWidgetRepositoryInterface::getTreeLevelData()` is dropped since that path can no longer throw it.
- `TreeQueryInterface::get()` keeps its `UserInterface $user` parameter (interface contract) although the implementation no longer needs it.
- Separate observation while tracing this, **not** addressed here: the tree-location query never gets a user set on it (`TreeQuery` builds its parameters without one), so `AbstractSearchHelper::addSearchRestrictions()` returns early and that index search runs unrestricted. Worth a follow-up ticket.
