### PR TITLE
[Bug]: Parse notification creationDate in the application timezone

### DIFF
--- a/src/Notification/Hydrator/NotificationHydrator.php
+++ b/src/Notification/Hydrator/NotificationHydrator.php
@@ -19,6 +19,7 @@ use Pimcore\Bundle\StudioBackendBundle\Notification\Schema\NotificationListItem;
 use Pimcore\Bundle\StudioBackendBundle\Notification\Schema\NotificationMinimal;
 use Pimcore\Model\Notification as NotificationModel;
 use Pimcore\Model\User;
+use function date_default_timezone_get;
 
 /**
  * @internal
@@ -33,7 +34,7 @@ final readonly class NotificationHydrator implements NotificationHydratorInterfa
             $notification->getTitle(),
             $notification->isRead(),
             (bool)$notification->getLinkedElementType(),
-            (new Carbon($notification->getCreationDate(), 'UTC'))->getTimeStamp(),
+            $this->getCreationTimestamp($notification),
             $this->getRecipientName($notification->getSender()),
         );
     }
@@ -45,7 +46,7 @@ final readonly class NotificationHydrator implements NotificationHydratorInterfa
             $notification->getType() ?? 'info',
             $notification->getTitle(),
             $notification->isRead(),
-            (new Carbon($notification->getCreationDate(), 'UTC'))->getTimeStamp(),
+            $this->getCreationTimestamp($notification),
             $notification->getRecipient()?->getId() ?? 0,
             $this->getRecipientName($notification->getSender()),
         );
@@ -59,7 +60,7 @@ final readonly class NotificationHydrator implements NotificationHydratorInterfa
             $notification->getTitle(),
             $notification->isRead(),
             (bool)$notification->getLinkedElementType(),
-            (new Carbon($notification->getCreationDate(), 'UTC'))->getTimeStamp(),
+            $this->getCreationTimestamp($notification),
             $this->getRecipientName($notification->getSender()),
             $notification->getMessage(),
             $notification->getPayload(),
@@ -67,6 +68,16 @@ final readonly class NotificationHydrator implements NotificationHydratorInterfa
             $notification->getLinkedElement()?->getId(),
             $notification->getLinkedElement()?->getRealFullPath()
         );
+    }
+
+    /**
+     * Notification\Dao::save() stores creationDate as a naive wall-clock string in the
+     * application's default timezone (general.timezone), so it has to be parsed in that
+     * same timezone instead of UTC to end up with the correct epoch.
+     */
+    private function getCreationTimestamp(NotificationModel $notification): int
+    {
+        return (new Carbon($notification->getCreationDate(), date_default_timezone_get()))->getTimestamp();
     }
 
     private function getRecipientName(?User $recipient): ?string

--- a/tests/Unit/Notification/Hydrator/NotificationHydratorTest.php
+++ b/tests/Unit/Notification/Hydrator/NotificationHydratorTest.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Notification\Hydrator;
+
+use Codeception\Test\Unit;
+use DateTimeImmutable;
+use DateTimeZone;
+use Pimcore\Bundle\StudioBackendBundle\Notification\Hydrator\NotificationHydrator;
+use Pimcore\Model\Notification as NotificationModel;
+use function date_default_timezone_get;
+use function date_default_timezone_set;
+
+/**
+ * @internal
+ */
+final class NotificationHydratorTest extends Unit
+{
+    private const CREATION_DATE = '2026-07-29 09:57:48';
+
+    private string $originalTimezone;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalTimezone = date_default_timezone_get();
+    }
+
+    protected function tearDown(): void
+    {
+        date_default_timezone_set($this->originalTimezone);
+        parent::tearDown();
+    }
+
+    /**
+     * Notification\Dao::save() writes creationDate as a naive wall-clock string in the
+     * application timezone, so hydrating it must not assume the string is UTC.
+     */
+    public function testCreationDateIsParsedInApplicationTimezoneDuringDst(): void
+    {
+        date_default_timezone_set('Europe/Berlin');
+
+        $hydrator = new NotificationHydrator();
+        $model = $this->createNotificationModel();
+
+        $expected = $this->expectedTimestamp('Europe/Berlin');
+
+        $this->assertSame($expected, $hydrator->hydrate($model)->getCreationDate());
+        $this->assertSame($expected, $hydrator->hydrateMinimal($model)->getCreationDate());
+        $this->assertSame($expected, $hydrator->hydrateDetail($model)->getCreationDate());
+
+        // Guard against the regression: reading the local string as UTC shifted it by +2h.
+        $this->assertNotSame($this->expectedTimestamp('UTC'), $expected);
+    }
+
+    public function testCreationDateIsParsedInApplicationTimezoneOutsideDst(): void
+    {
+        date_default_timezone_set('Europe/Berlin');
+
+        $hydrator = new NotificationHydrator();
+        $model = $this->createNotificationModel('2026-01-15 09:57:48');
+
+        $expected = (new DateTimeImmutable('2026-01-15 09:57:48', new DateTimeZone('Europe/Berlin')))
+            ->getTimestamp();
+
+        $this->assertSame($expected, $hydrator->hydrate($model)->getCreationDate());
+    }
+
+    public function testCreationDateIsUnchangedForUtcApplicationTimezone(): void
+    {
+        date_default_timezone_set('UTC');
+
+        $hydrator = new NotificationHydrator();
+        $model = $this->createNotificationModel();
+
+        $this->assertSame(
+            $this->expectedTimestamp('UTC'),
+            $hydrator->hydrate($model)->getCreationDate()
+        );
+    }
+
+    private function expectedTimestamp(string $timezone): int
+    {
+        return (new DateTimeImmutable(self::CREATION_DATE, new DateTimeZone($timezone)))->getTimestamp();
+    }
+
+    private function createNotificationModel(string $creationDate = self::CREATION_DATE): NotificationModel
+    {
+        $model = new NotificationModel();
+        $model->setId(221189);
+        $model->setType('info');
+        $model->setTitle('Notification title');
+        $model->setMessage('Notification message');
+        $model->setCreationDate($creationDate);
+
+        return $model;
+    }
+}


### PR DESCRIPTION
Fixes pimcore/platform-version#335

### Problem

`Pimcore\Model\Notification\Dao::save()` writes `creationDate` / `modificationDate` as a naive wall-clock string via `date('Y-m-d H:i:s')`, i.e. in PHP's default timezone (set at boot from `general.timezone` in `Pimcore\Bootstrap`). No offset is stored alongside it.

`NotificationHydrator` read that same string back with `new Carbon($notification->getCreationDate(), 'UTC')` — assuming it was already UTC. It isn't; it's local time. With a non-UTC `general.timezone` the resulting epoch is shifted by the zone offset, so Studio's notification panel disagrees with the Application Logger and with the raw DB value for the same event:

```
notifications table: id=221189, creationDate = 2026-07-29 09:57:48   (correct local wall-clock time)
Application Logger (same event):               29.07.26, 09:57:48    (correct)
Studio notification panel (same event):        29.07.26, 11:57:48    (wrong, +2h)
```

All three hydrate methods were affected, so the list, the Mercure-published minimal payload and the detail view were all shifted.

For contrast, `ApplicationLoggerDb` converts to UTC explicitly on write and `LogHydrator` re-parses as UTC on read — a consistent round-trip. `Notification\Dao` never does the write-side conversion, only the hydrator made the (wrong) read-side UTC assumption.

### Fix

Parse the stored string with `date_default_timezone_get()` — the timezone it was actually written in — and collapse the three duplicated inline `Carbon` calls into a single private helper.

Read-side fix, as suggested in the issue: non-breaking and no migration needed, since existing rows are already naive local-time strings.

### Regression test

`tests/Unit/Notification/Hydrator/NotificationHydratorTest.php` covers:

- DST (`Europe/Berlin`, July) — all three hydrate methods
- outside DST (`Europe/Berlin`, January)
- UTC-configured instance — asserts the epoch is unchanged, so UTC installs see no behaviour change

Reverting just the timezone argument makes the test fail with exactly the deltas from the report: `1785319068` vs `1785311868` (+7200s, DST) and `1768471068` vs `1768467468` (+3600s, non-DST).

### Verification

- Full `Unit` suite: `OK (514 tests, 1182 assertions)`
- PHPStan level 6: `No errors`