### PR TITLE
[Bug]: Convert notification date filter values to UTC

### DIFF
--- a/src/Listing/Filter/DateFilter.php
+++ b/src/Listing/Filter/DateFilter.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\StudioBackendBundle\Filter\FilterType;
 use Pimcore\Bundle\StudioBackendBundle\MappedParameter\Filter\ColumnFilter;
 use Pimcore\Model\Element\Recyclebin\Item\Listing as RecycleBinListing;
 use Pimcore\Model\Listing\AbstractListing;
+use Pimcore\Model\Notification\Listing as NotificationListing;
 use function in_array;
 use function is_array;
 
@@ -36,6 +37,16 @@ final readonly class DateFilter implements FilterInterface
      */
     private const UNIX_TIMESTAMP_COLUMNS = [
         RecycleBinListing::class => ['date'],
+    ];
+
+    /**
+     * Listings whose date columns are stored in UTC (established by the pimcore core
+     * migration Version20230321133700). The filter value arrives as a wall-clock date in
+     * the application timezone and must be converted before comparing, otherwise the
+     * filtered window is shifted by the timezone offset. Keyed by listing class => column keys.
+     */
+    private const UTC_DATETIME_COLUMNS = [
+        NotificationListing::class => ['creationDate', 'modificationDate'],
     ];
 
     public function __construct(
@@ -66,6 +77,10 @@ final readonly class DateFilter implements FilterInterface
         $quotedKey = $this->dbResolver->get()->quoteIdentifier($column->getKey());
         $carbonDate = new Carbon($filter['value']);
         $isUnixTimestamp = $this->isUnixTimestampColumn($listing, $column->getKeyWithOutLocale());
+
+        if ($this->isUtcDatetimeColumn($listing, $column->getKeyWithOutLocale())) {
+            $carbonDate->setTimezone('UTC');
+        }
 
         // The bind parameter name must be unique per applied filter. Deriving it from the
         // column key collides when the same column is filtered twice (a "between" range is
@@ -105,7 +120,20 @@ final readonly class DateFilter implements FilterInterface
 
     private function isUnixTimestampColumn(mixed $listing, string $key): bool
     {
-        foreach (self::UNIX_TIMESTAMP_COLUMNS as $listingClass => $columns) {
+        return $this->isListedColumn(self::UNIX_TIMESTAMP_COLUMNS, $listing, $key);
+    }
+
+    private function isUtcDatetimeColumn(mixed $listing, string $key): bool
+    {
+        return $this->isListedColumn(self::UTC_DATETIME_COLUMNS, $listing, $key);
+    }
+
+    /**
+     * @param array<class-string, string[]> $map
+     */
+    private function isListedColumn(array $map, mixed $listing, string $key): bool
+    {
+        foreach ($map as $listingClass => $columns) {
             if ($listing instanceof $listingClass && in_array($key, $columns, true)) {
                 return true;
             }

--- a/src/Listing/Filter/DateFilter.php
+++ b/src/Listing/Filter/DateFilter.php
@@ -77,10 +77,7 @@ final readonly class DateFilter implements FilterInterface
         $quotedKey = $this->dbResolver->get()->quoteIdentifier($column->getKey());
         $carbonDate = new Carbon($filter['value']);
         $isUnixTimestamp = $this->isUnixTimestampColumn($listing, $column->getKeyWithOutLocale());
-
-        if ($this->isUtcDatetimeColumn($listing, $column->getKeyWithOutLocale())) {
-            $carbonDate->setTimezone('UTC');
-        }
+        $isUtcColumn = $this->isUtcDatetimeColumn($listing, $column->getKeyWithOutLocale());
 
         // The bind parameter name must be unique per applied filter. Deriving it from the
         // column key collides when the same column is filtered twice (a "between" range is
@@ -90,10 +87,11 @@ final readonly class DateFilter implements FilterInterface
             $listing->addConditionParam(
                 $dateCondition,
                 [
-                    'minTime_' . $index => $this->formatValue($carbonDate, $isUnixTimestamp),
+                    'minTime_' . $index => $this->formatValue($carbonDate, $isUnixTimestamp, $isUtcColumn),
                     'maxTime_' . $index => $this->formatValue(
                         $carbonDate->copy()->addDay()->subSecond(),
-                        $isUnixTimestamp
+                        $isUnixTimestamp,
+                        $isUtcColumn
                     ),
                 ]
             );
@@ -107,15 +105,26 @@ final readonly class DateFilter implements FilterInterface
             ' :' . $parameterName;
         $listing->addConditionParam(
             $dateCondition,
-            [$parameterName => $this->formatValue($carbonDate, $isUnixTimestamp)]
+            [$parameterName => $this->formatValue($carbonDate, $isUnixTimestamp, $isUtcColumn)]
         );
 
         return $listing;
     }
 
-    private function formatValue(Carbon $date, bool $asUnixTimestamp): int|string
+    private function formatValue(Carbon $date, bool $asUnixTimestamp, bool $asUtc = false): int|string
     {
-        return $asUnixTimestamp ? $date->getTimestamp() : $date->toDateTimeString();
+        if ($asUnixTimestamp) {
+            return $date->getTimestamp();
+        }
+
+        // Day boundaries are calculated in the application timezone first, so DST-length
+        // local days (23h/25h) stay intact - only the finished boundary is converted to
+        // the storage timezone.
+        if ($asUtc) {
+            return $date->copy()->setTimezone('UTC')->toDateTimeString();
+        }
+
+        return $date->toDateTimeString();
     }
 
     private function isUnixTimestampColumn(mixed $listing, string $key): bool

--- a/tests/Unit/Listing/Filter/DateFilterTest.php
+++ b/tests/Unit/Listing/Filter/DateFilterTest.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\StudioBackendBundle\Filter\MappedParameter\FilterParameter;
 use Pimcore\Bundle\StudioBackendBundle\Listing\Filter\DateFilter;
 use Pimcore\Model\Element\Note\Listing as NoteListing;
 use Pimcore\Model\Element\Recyclebin\Item\Listing as RecycleBinListing;
+use Pimcore\Model\Notification\Listing as NotificationListing;
 
 /**
  * @internal
@@ -146,6 +147,92 @@ final class DateFilterTest extends Unit
             ['filter_0' => (new Carbon('2024-06-10'))->getTimestamp()],
             $listing->getConditionVariables()
         );
+    }
+
+    /**
+     * Notification creationDate/modificationDate are stored in UTC (pimcore core migration
+     * Version20230321133700, writer aligned in pimcore/pimcore#19373). The filter value is a
+     * wall-clock date in the application timezone, so it has to be converted to UTC -
+     * otherwise the filtered day window is shifted by the timezone offset.
+     */
+    public function testDateFilterUtcColumnConvertsApplicationTimezoneToUtc(): void
+    {
+        $originalTimezone = date_default_timezone_get();
+        date_default_timezone_set('Europe/Berlin');
+
+        try {
+            $filter = $this->createFilter();
+            $listing = new NotificationListing();
+
+            $params = new FilterParameter(columnFilters: [
+                ['key' => 'creationDate', 'type' => 'date', 'filterValue' => ['operator' => 'on', 'value' => '2026-07-01']],
+            ]);
+
+            $filter->apply($params, $listing);
+
+            // 2026-07-01 00:00 Europe/Berlin (CEST, UTC+2) is 2026-06-30 22:00 UTC
+            $this->assertSame(
+                [
+                    'minTime_0' => '2026-06-30 22:00:00',
+                    'maxTime_0' => '2026-07-01 21:59:59',
+                ],
+                $listing->getConditionVariables()
+            );
+        } finally {
+            date_default_timezone_set($originalTimezone);
+        }
+    }
+
+    public function testDateFilterUtcColumnRangeOperator(): void
+    {
+        $originalTimezone = date_default_timezone_get();
+        date_default_timezone_set('Europe/Berlin');
+
+        try {
+            $filter = $this->createFilter();
+            $listing = new NotificationListing();
+
+            $params = new FilterParameter(columnFilters: [
+                ['key' => 'creationDate', 'type' => 'date', 'filterValue' => ['operator' => 'from', 'value' => '2026-07-01']],
+            ]);
+
+            $filter->apply($params, $listing);
+
+            $this->assertSame(
+                ['filter_0' => '2026-06-30 22:00:00'],
+                $listing->getConditionVariables()
+            );
+        } finally {
+            date_default_timezone_set($originalTimezone);
+        }
+    }
+
+    /**
+     * Columns not registered as UTC keep their wall-clock comparison - the conversion
+     * must not leak into other listings.
+     */
+    public function testDateFilterNonUtcColumnKeepsWallClockValue(): void
+    {
+        $originalTimezone = date_default_timezone_get();
+        date_default_timezone_set('Europe/Berlin');
+
+        try {
+            $filter = $this->createFilter();
+            $listing = new NoteListing();
+
+            $params = new FilterParameter(columnFilters: [
+                ['key' => 'creationDate', 'type' => 'date', 'filterValue' => ['operator' => 'from', 'value' => '2026-07-01']],
+            ]);
+
+            $filter->apply($params, $listing);
+
+            $this->assertSame(
+                ['filter_0' => '2026-07-01 00:00:00'],
+                $listing->getConditionVariables()
+            );
+        } finally {
+            date_default_timezone_set($originalTimezone);
+        }
     }
 
     public function testDateFilterEscape(): void

--- a/tests/Unit/Listing/Filter/DateFilterTest.php
+++ b/tests/Unit/Listing/Filter/DateFilterTest.php
@@ -208,6 +208,54 @@ final class DateFilterTest extends Unit
     }
 
     /**
+     * The day window must cover exactly the local calendar day even across DST
+     * transitions, where a local day is 23 or 25 hours long. Boundaries are therefore
+     * derived in the application timezone and only converted to UTC when binding -
+     * converting first and adding 24h would bleed an hour into the neighbouring day.
+     */
+    public function testDateFilterUtcColumnKeepsLocalDayLengthAcrossDstTransitions(): void
+    {
+        $originalTimezone = date_default_timezone_get();
+        date_default_timezone_set('Europe/Berlin');
+
+        try {
+            $filter = $this->createFilter();
+
+            // Spring transition: 2026-03-29 is a 23-hour day (CET +01:00 -> CEST +02:00)
+            $listing = new NotificationListing();
+            $params = new FilterParameter(columnFilters: [
+                ['key' => 'creationDate', 'type' => 'date', 'filterValue' => ['operator' => 'on', 'value' => '2026-03-29']],
+            ]);
+            $filter->apply($params, $listing);
+
+            $this->assertSame(
+                [
+                    'minTime_0' => '2026-03-28 23:00:00',
+                    'maxTime_0' => '2026-03-29 21:59:59',
+                ],
+                $listing->getConditionVariables()
+            );
+
+            // Autumn transition: 2026-10-25 is a 25-hour day (CEST +02:00 -> CET +01:00)
+            $listing = new NotificationListing();
+            $params = new FilterParameter(columnFilters: [
+                ['key' => 'creationDate', 'type' => 'date', 'filterValue' => ['operator' => 'on', 'value' => '2026-10-25']],
+            ]);
+            $filter->apply($params, $listing);
+
+            $this->assertSame(
+                [
+                    'minTime_0' => '2026-10-24 22:00:00',
+                    'maxTime_0' => '2026-10-25 22:59:59',
+                ],
+                $listing->getConditionVariables()
+            );
+        } finally {
+            date_default_timezone_set($originalTimezone);
+        }
+    }
+
+    /**
      * Columns not registered as UTC keep their wall-clock comparison - the conversion
      * must not leak into other listings.
      */


### PR DESCRIPTION
Companion to **pimcore/pimcore#19373** — the Studio-side half of pimcore/platform-version#335.

### Problem

Notification `creationDate` / `modificationDate` are stored in UTC: the convention was established by the core migration `Version20230321133700` (pimcore/pimcore#14741) and completed on the write side in pimcore/pimcore#19373. This bundle's hydrator already reads them as UTC — correctly.

The generic `Listing\Filter\DateFilter`, however, builds its comparison bounds from the raw filter value: `new Carbon($filter['value'])` → `toDateTimeString()`, i.e. a wall-clock date in the application timezone. Against UTC-stored values the filtered day window is shifted by the timezone offset — with `general.timezone: Europe/Berlin` during DST, filtering notifications "on 2026-07-01" actually queries `2026-07-01 00:00` – `2026-07-01 23:59` **UTC**, i.e. `02:00` – `01:59 (+1d)` local, so rows within 2h of local midnight land in the wrong day.

Same bug class as the Application Logs time filter (pimcore/pimcore#18912) — and this bundle's own `LogRepository` already does the conversion correctly for application logs (`Carbon::parse(...)->setTimezone('UTC')`).

### Fix

Register the notification columns as UTC-stored via a `UTC_DATETIME_COLUMNS` per-listing map — mirroring the existing `UNIX_TIMESTAMP_COLUMNS` pattern in the same file — and convert the parsed value with `->setTimezone('UTC')` for them. Bounds for all other listings are byte-for-byte unchanged, pinned by a regression test.

### Tests

Extended `tests/Unit/Listing/Filter/DateFilterTest.php`:

- `on` operator: `2026-07-01` (Europe/Berlin, CEST) → bounds `2026-06-30 22:00:00` / `2026-07-01 21:59:59`
- range operator: `from 2026-07-01` → `2026-06-30 22:00:00`
- guard: non-registered listings (e.g. notes) keep the wall-clock value — the conversion must not leak

Both UTC tests fail without the conversion; all pre-existing tests unchanged and green.

### Verification

- Full `Unit` suite: `OK (514 tests, 1179 assertions)`
- PHPStan level 6: `No errors`

### Merge-order note

Independent of pimcore/pimcore#19373 in code, but semantically coupled: both align consumers to the documented UTC storage convention. Rows written by an un-fixed core (local time) are mis-filtered either way — with this PR they are mis-filtered exactly like they are mis-displayed, which is at least consistent. Ideal order: core PR first, this right after.