### PR TITLE
Fix undefined array key error_pages in SystemSettingsProvider

### DIFF
--- a/src/Setting/Provider/SystemSettingsProvider.php
+++ b/src/Setting/Provider/SystemSettingsProvider.php
@@ -132,22 +132,26 @@ final readonly class SystemSettingsProvider implements SettingsProviderInterface
             return [];
         }
 
-        $errorPage = $this->getErrorDocument($documents['error_pages']['default']);
+        $errorPages = $documents['error_pages'] ?? [];
+
+        $errorPage = $this->getErrorDocument($errorPages['default'] ?? null);
         if ($errorPage) {
-            $documents['error_pages']['default'] = $this->elementDataService->getRelatedElementData(
+            $errorPages['default'] = $this->elementDataService->getRelatedElementData(
                 $errorPage
             );
         }
 
-        foreach ($documents['error_pages']['localized'] as $language => $errorPage) {
-            $element = $this->getErrorDocument($documents['error_pages']['localized'][$language]);
+        foreach ($errorPages['localized'] ?? [] as $language => $errorPage) {
+            $element = $this->getErrorDocument($errorPages['localized'][$language]);
             if (!$element) {
                 continue;
             }
-            $documents['error_pages']['localized'][$language] = $this->elementDataService->getRelatedElementData(
+            $errorPages['localized'][$language] = $this->elementDataService->getRelatedElementData(
                 $element
             );
         }
+
+        $documents['error_pages'] = $errorPages;
 
         return $documents;
     }

--- a/tests/Unit/Setting/Provider/SystemSettingsProviderTest.php
+++ b/tests/Unit/Setting/Provider/SystemSettingsProviderTest.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Setting\Provider;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StaticResolverBundle\Lib\ConfigResolver;
+use Pimcore\Bundle\StaticResolverBundle\Lib\ToolResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Lib\VersionResolverInterface;
+use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementDataServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Setting\Provider\SystemSettingsProvider;
+use Pimcore\Bundle\StudioBackendBundle\Translation\Service\AdminLanguageServiceInterface;
+use Pimcore\SystemSettingsConfig;
+use ReflectionMethod;
+
+/**
+ * Regression tests for pimcore/platform-version#206: the Studio "Appearance & Branding"
+ * settings could not be loaded (ErrorException: Undefined array key "error_pages") whenever
+ * the `documents` system settings did not already contain a fully populated `error_pages`
+ * structure, e.g. right after switching config_location to `settings-store`.
+ *
+ * @internal
+ */
+final class SystemSettingsProviderTest extends Unit
+{
+    public function testGetDocumentSettingsHandlesMissingErrorPagesKey(): void
+    {
+        $provider = $this->buildProvider([
+            'documents' => [
+                'versions' => ['days' => 10, 'steps' => 5],
+            ],
+        ]);
+
+        $result = $this->invokeGetDocumentSettings($provider);
+
+        $this->assertSame([], $result['error_pages']);
+    }
+
+    public function testGetDocumentSettingsHandlesMissingLocalizedErrorPagesKey(): void
+    {
+        $provider = $this->buildProvider([
+            'documents' => [
+                'versions' => ['days' => 10, 'steps' => 5],
+                'error_pages' => ['default' => null],
+            ],
+        ]);
+
+        $result = $this->invokeGetDocumentSettings($provider);
+
+        $this->assertSame(['default' => null], $result['error_pages']);
+    }
+
+    private function buildProvider(array $systemSettings): SystemSettingsProvider
+    {
+        return new SystemSettingsProvider(
+            $this->makeEmpty(SystemSettingsConfig::class, [
+                'getSystemSettingsConfig' => $systemSettings,
+            ]),
+            $this->makeEmpty(ToolResolverInterface::class),
+            $this->makeEmpty(VersionResolverInterface::class),
+            new ConfigResolver(),
+            $this->makeEmpty(ServiceResolverInterface::class),
+            $this->makeEmpty(ElementDataServiceInterface::class),
+            $this->makeEmpty(AdminLanguageServiceInterface::class),
+        );
+    }
+
+    private function invokeGetDocumentSettings(SystemSettingsProvider $provider): array
+    {
+        $method = new ReflectionMethod($provider, 'getDocumentSettings');
+
+        return $method->invoke($provider);
+    }
+}


### PR DESCRIPTION
## Summary

`SystemSettingsProvider::getDocumentSettings()` accessed `documents['error_pages']['default']` and `documents['error_pages']['localized']` directly, without checking whether those keys exist. When the system settings config does not (yet) contain a fully populated `error_pages` structure — e.g. right after switching `config_location.system_settings` to `settings-store` before it has ever been saved — this raises `Undefined array key "error_pages"` / `"localized"` warnings. Under Symfony's debug error handler these warnings are promoted to fatal `ErrorException`s, so the Studio "Appearance & Branding" settings screen (and any other caller of `getSettings()`) crashes with a 500.

Fixes #206.

## Changes

- `getDocumentSettings()` now safely defaults a missing `error_pages` (and `error_pages.localized`) to an empty array instead of relying on the keys always being present.
- Added `SystemSettingsProviderTest` with two regression tests that reproduce the exact warnings from the issue (verified they fail against the pre-fix code at the exact reported lines) and pass after the fix.

## Test plan

- [x] `vendor/bin/codecept run Unit` — 459 tests, all green
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — no style violations
- [x] New regression tests fail on the unmodified code with the same `Undefined array key` warnings reported in the issue, and pass after the fix