### PR TITLE
[Bug]: Fix SystemSettingsProvider crash when error_pages is missing

### DIFF
--- a/src/Setting/Provider/SystemSettingsProvider.php
+++ b/src/Setting/Provider/SystemSettingsProvider.php
@@ -132,22 +132,26 @@ final readonly class SystemSettingsProvider implements SettingsProviderInterface
             return [];
         }
 
-        $errorPage = $this->getErrorDocument($documents['error_pages']['default']);
+        $errorPages = $documents['error_pages'] ?? [];
+
+        $errorPage = $this->getErrorDocument($errorPages['default'] ?? null);
         if ($errorPage) {
-            $documents['error_pages']['default'] = $this->elementDataService->getRelatedElementData(
+            $errorPages['default'] = $this->elementDataService->getRelatedElementData(
                 $errorPage
             );
         }
 
-        foreach ($documents['error_pages']['localized'] as $language => $errorPage) {
-            $element = $this->getErrorDocument($documents['error_pages']['localized'][$language]);
+        foreach ($errorPages['localized'] ?? [] as $language => $localizedErrorPage) {
+            $element = $this->getErrorDocument($localizedErrorPage);
             if (!$element) {
                 continue;
             }
-            $documents['error_pages']['localized'][$language] = $this->elementDataService->getRelatedElementData(
+            $errorPages['localized'][$language] = $this->elementDataService->getRelatedElementData(
                 $element
             );
         }
+
+        $documents['error_pages'] = $errorPages;
 
         return $documents;
     }

--- a/tests/Unit/Setting/Provider/SystemSettingsProviderTest.php
+++ b/tests/Unit/Setting/Provider/SystemSettingsProviderTest.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Setting\Provider;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StaticResolverBundle\Lib\ConfigResolver;
+use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Element\Schema\RelatedElementData;
+use Pimcore\Bundle\StudioBackendBundle\Element\Service\ElementDataServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Setting\Provider\SystemSettingsProvider;
+use Pimcore\Model\Document;
+use ReflectionClass;
+
+final class SystemSettingsProviderTest extends Unit
+{
+    public function testGetDocumentSettingsWhenErrorPagesHaveNeverBeenSaved(): void
+    {
+        $provider = $this->createProvider(
+            documents: [
+                'versions' => ['days' => 10, 'steps' => 5],
+            ],
+            serviceResolver: $this->makeEmpty(ServiceResolverInterface::class),
+            elementDataService: $this->makeEmpty(ElementDataServiceInterface::class)
+        );
+
+        $documents = $this->invokeGetDocumentSettings($provider);
+
+        $this->assertSame(
+            [
+                'versions' => ['days' => 10, 'steps' => 5],
+                'error_pages' => [],
+            ],
+            $documents
+        );
+    }
+
+    public function testGetDocumentSettingsResolvesExistingErrorPages(): void
+    {
+        $resolvedElementData = new RelatedElementData(1, 'document', 'page', '/en/error', true);
+        $documentMock = $this->makeEmpty(Document::class);
+
+        $serviceResolver = $this->makeEmpty(ServiceResolverInterface::class, [
+            'getElementByPath' => function (string $type, string $path) use ($documentMock) {
+                return $path === '/en/error' ? $documentMock : null;
+            },
+        ]);
+
+        $elementDataService = $this->makeEmpty(ElementDataServiceInterface::class, [
+            'getRelatedElementData' => $resolvedElementData,
+        ]);
+
+        $provider = $this->createProvider(
+            documents: [
+                'error_pages' => [
+                    'default' => '/en/error',
+                    'localized' => [
+                        'en' => '/en/error',
+                        'de' => '',
+                    ],
+                ],
+            ],
+            serviceResolver: $serviceResolver,
+            elementDataService: $elementDataService
+        );
+
+        $documents = $this->invokeGetDocumentSettings($provider);
+
+        $this->assertSame($resolvedElementData, $documents['error_pages']['default']);
+        $this->assertSame($resolvedElementData, $documents['error_pages']['localized']['en']);
+        $this->assertSame('', $documents['error_pages']['localized']['de']);
+    }
+
+    private function createProvider(
+        array $documents,
+        ServiceResolverInterface $serviceResolver,
+        ElementDataServiceInterface $elementDataService
+    ): SystemSettingsProvider {
+        $reflection = new ReflectionClass(SystemSettingsProvider::class);
+        $provider = $reflection->newInstanceWithoutConstructor();
+
+        $this->setPrivateProperty($reflection, $provider, 'systemSettings', [
+            'documents' => $documents,
+        ]);
+        $this->setPrivateProperty($reflection, $provider, 'configResolver', new ConfigResolver());
+        $this->setPrivateProperty($reflection, $provider, 'serviceResolver', $serviceResolver);
+        $this->setPrivateProperty($reflection, $provider, 'elementDataService', $elementDataService);
+
+        return $provider;
+    }
+
+    private function setPrivateProperty(
+        ReflectionClass $reflection,
+        SystemSettingsProvider $provider,
+        string $name,
+        mixed $value
+    ): void {
+        $property = $reflection->getProperty($name);
+        $property->setAccessible(true);
+        $property->setValue($provider, $value);
+    }
+
+    private function invokeGetDocumentSettings(SystemSettingsProvider $provider): array
+    {
+        $method = (new ReflectionClass($provider))->getMethod('getDocumentSettings');
+        $method->setAccessible(true);
+
+        return $method->invoke($provider);
+    }
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/pimcore/service-operations/issues/954 (PEES-1288).
Fixes https://github.com/pimcore/platform-version/issues/206.

`SystemSettingsProvider::getDocumentSettings()` accessed `$documents['error_pages']['default']` and `$documents['error_pages']['localized']` unconditionally. When the system settings' `documents` config has never been saved (e.g. right after a fresh install, or right after switching `config_location` for `system_settings` to `settings-store` before it has ever been saved), the `documents` array can be non-empty (containing e.g. `versions`) while `error_pages` itself is entirely absent, which raised:

```
Warning: Undefined array key "error_pages"
```

and crashed the Studio system settings / "Appearance & Branding" page with a 500.

Supersedes #2006, which reported and fixed the same crash (via #206) against the `2025.4` branch — closed in favor of this PR; folding both linked issues in here.

## Fix

`getDocumentSettings()` now defaults `error_pages` (and its `default`/`localized` sub-keys) to an empty value with null-coalescing before use, so a missing key resolves to an empty error-pages config instead of crashing. Behavior is unchanged when `error_pages` is present.

## Testing

Added `tests/Unit/Setting/Provider/SystemSettingsProviderTest.php`:
- Reproduces the crash: `documents` present without an `error_pages` key no longer throws, and returns `error_pages => []`.
- Regression guard: existing `error_pages.default` / `error_pages.localized` entries still resolve to the related element data as before.

Verified locally (php8.4 Docker image):
- `vendor/bin/codecept run Unit` — 517 tests, all green
- `vendor/bin/phpstan analyse` — no errors
- Confirmed the new test fails with the exact reported warning against the pre-fix code, and passes with the fix.
