### PR TITLE
Fix PhpCode transformer select options missing "value" key

### DIFF
--- a/src/Grid/Column/Transformer/PhpCode.php
+++ b/src/Grid/Column/Transformer/PhpCode.php
@@ -71,7 +71,7 @@ final class PhpCode implements TransformerInterface
 
         foreach ($this->resolver->getTransformers() as $executable) {
             $options[] = [
-                'key'   => $executable->getKey(),
+                'value' => $executable->getKey(),
                 'label' => $executable->getName(),
             ];
         }

--- a/tests/Unit/Grid/Column/Transformer/PhpCodeTest.php
+++ b/tests/Unit/Grid/Column/Transformer/PhpCodeTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Column\Transformer;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\PhpCodeTransformerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\Transformer\PhpCode;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\PhpCodeTransformerLoaderInterface;
+
+/**
+ * @internal
+ */
+final class PhpCodeTest extends Unit
+{
+    public function testGetConfigOptionsExposesSelectableValueForEachTransformer(): void
+    {
+        // Regression test for https://github.com/pimcore/platform-version/issues/295:
+        // the options were built with a "key" entry instead of "value", so the
+        // frontend antd Select never received a selectable value.
+        $lowercase = $this->makeEmpty(PhpCodeTransformerInterface::class, [
+            'getKey' => 'lowercase',
+            'getName' => 'Lowercase',
+        ]);
+        $uppercase = $this->makeEmpty(PhpCodeTransformerInterface::class, [
+            'getKey' => 'uppercase',
+            'getName' => 'Uppercase',
+        ]);
+
+        $resolver = $this->makeEmpty(PhpCodeTransformerLoaderInterface::class, [
+            'getTransformers' => [$lowercase, $uppercase],
+        ]);
+
+        $transformer = new PhpCode($resolver);
+
+        $options = $transformer->getConfigOptions()['phpCodeKey']['options'];
+
+        $this->assertSame(
+            [
+                ['value' => 'lowercase', 'label' => 'Lowercase'],
+                ['value' => 'uppercase', 'label' => 'Uppercase'],
+            ],
+            $options
+        );
+    }
+
+    public function testGetConfigOptionsReturnsEmptyOptionsWhenNoTransformersAreRegistered(): void
+    {
+        $resolver = $this->makeEmpty(PhpCodeTransformerLoaderInterface::class, [
+            'getTransformers' => [],
+        ]);
+
+        $transformer = new PhpCode($resolver);
+
+        $this->assertSame([], $transformer->getConfigOptions()['phpCodeKey']['options']);
+    }
+}


### PR DESCRIPTION
## Summary

- `PhpCode::getConfigOptions()` in `src/Grid/Column/Transformer/PhpCode.php` built the `phpCodeKey` select options with a `key` entry instead of `value`.
- The Studio UI (`php-code.tsx` in `studio-ui-bundle`) hands these options straight to an antd `Select`, which expects `{value, label}`. Because the PHP side emitted `key` instead of `value`, every option's `value` was `undefined`, so clicking a transformer in the select never actually selected anything.
- The grid preview then failed with `Invalid "phpCodeKey" configuration (must be a string) for phpCode transformer.`
- Sibling transformers (e.g. `CaseChange`) already build their options correctly as `['value' => 'lowercase', 'label' => 'Lowercase']` - `PhpCode` was the outlier.

## Fix

Emit `value` instead of `key`, matching the `CaseChange` convention. Grepped the repo for any other reader of this options array's `key` element - the only other `['key']`/`->getKey()` usages in `src/Grid/**` operate on a different structure (the request-side transformer selection, e.g. `Column.php`'s `$transformer['key']`, not this select's option list), so nothing else depends on it and it is safely replaced rather than duplicated.

```diff
 $options[] = [
-    'key'   => $executable->getKey(),
+    'value' => $executable->getKey(),
     'label' => $executable->getName(),
 ];
```

## Test plan

- [x] Added `tests/Unit/Grid/Column/Transformer/PhpCodeTest.php` (regression test asserting `getConfigOptions()['phpCodeKey']['options']` contains `value` equal to each executable's key, mirroring the `CaseChange`-style options shape; also covers the empty-transformers case).
- [x] Ran the full Codeception `Unit` suite in the repo's `pimcore/pimcore:php8.4-debug-latest` Docker image: 519 tests, 1187 assertions, all green (only pre-existing unrelated twig/DBAL deprecation notices).
- [x] Ran `vendor/bin/phpstan analyse --memory-limit=-1 --no-progress`: no errors.

Fixes pimcore/platform-version#295