### PR TITLE
Forward-merge 2026.2 into 2026.x

### DIFF
--- a/src/Grid/Column/Transformer/PhpCode.php
+++ b/src/Grid/Column/Transformer/PhpCode.php
@@ -71,7 +71,7 @@ final class PhpCode implements TransformerInterface
 
         foreach ($this->resolver->getTransformers() as $executable) {
             $options[] = [
-                'key'   => $executable->getKey(),
+                'value' => $executable->getKey(),
                 'label' => $executable->getName(),
             ];
         }

--- a/tests/Unit/Grid/Column/Transformer/PhpCodeTest.php
+++ b/tests/Unit/Grid/Column/Transformer/PhpCodeTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Grid\Column\Transformer;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\PhpCodeTransformerInterface;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Column\Transformer\PhpCode;
+use Pimcore\Bundle\StudioBackendBundle\Grid\Service\PhpCodeTransformerLoaderInterface;
+
+/**
+ * @internal
+ */
+final class PhpCodeTest extends Unit
+{
+    public function testGetConfigOptionsExposesSelectableValueForEachTransformer(): void
+    {
+        // Regression test for https://github.com/pimcore/platform-version/issues/295:
+        // the options were built with a "key" entry instead of "value", so the
+        // frontend antd Select never received a selectable value.
+        $lowercase = $this->makeEmpty(PhpCodeTransformerInterface::class, [
+            'getKey' => 'lowercase',
+            'getName' => 'Lowercase',
+        ]);
+        $uppercase = $this->makeEmpty(PhpCodeTransformerInterface::class, [
+            'getKey' => 'uppercase',
+            'getName' => 'Uppercase',
+        ]);
+
+        $resolver = $this->makeEmpty(PhpCodeTransformerLoaderInterface::class, [
+            'getTransformers' => [$lowercase, $uppercase],
+        ]);
+
+        $transformer = new PhpCode($resolver);
+
+        $options = $transformer->getConfigOptions()['phpCodeKey']['options'];
+
+        $this->assertSame(
+            [
+                ['value' => 'lowercase', 'label' => 'Lowercase'],
+                ['value' => 'uppercase', 'label' => 'Uppercase'],
+            ],
+            $options
+        );
+    }
+
+    public function testGetConfigOptionsReturnsEmptyOptionsWhenNoTransformersAreRegistered(): void
+    {
+        $resolver = $this->makeEmpty(PhpCodeTransformerLoaderInterface::class, [
+            'getTransformers' => [],
+        ]);
+
+        $transformer = new PhpCode($resolver);
+
+        $this->assertSame([], $transformer->getConfigOptions()['phpCodeKey']['options']);
+    }
+}


### PR DESCRIPTION
## Summary
- Forward-merges `2026.2` into `2026.x` per the standard release forward-merge policy.
- Brings in the fix from #2008: PhpCode transformer select options were missing the `value` key.

## Test plan
- [ ] CI passes on this branch
- [ ] No behavioral changes expected on `2026.x` beyond the PhpCode transformer fix already released on `2026.2`