### PR TITLE
Turn a missing advanced-column field config into a 422 instead of an uncaught error

### DIFF
--- a/src/Grid/Schema/Column.php
+++ b/src/Grid/Schema/Column.php
@@ -23,6 +23,8 @@ use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\AdvancedColumnConfig\SimpleFi
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\AdvancedColumnConfig\StaticTextConfig;
 use Pimcore\Bundle\StudioBackendBundle\Grid\Schema\AdvancedColumnConfig\Transformer;
 
+use function sprintf;
+
 /**
  * Contains all data that is needed to get all the data for the column.
  *
@@ -96,7 +98,7 @@ final readonly class Column
             throw new InvalidArgumentException('Advanced column config is not set');
         }
 
-        foreach ($this->config['advancedColumns'] as $advancedColumn) {
+        foreach ($this->config['advancedColumns'] as $index => $advancedColumn) {
             if ($advancedColumn['key'] === 'relationField') {
                 $configs[] = new RelationFieldConfig(
                     relation: $advancedColumn['config']['relation'],
@@ -109,6 +111,14 @@ final readonly class Column
             }
 
             if ($advancedColumn['key'] === 'simpleField') {
+                if (!isset($advancedColumn['config']['field'])) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Advanced column "%s" (source field at index %d) is missing the required "field" config',
+                        $this->getKey(),
+                        $index
+                    ));
+                }
+
                 $configs[] = new SimpleFieldConfig(
                     field: $advancedColumn['config']['field'],
                     groupId: $advancedColumn['config']['groupId'] ?? null,

--- a/tests/Unit/Grid/Schema/ColumnTest.php
+++ b/tests/Unit/Grid/Schema/ColumnTest.php
@@ -68,6 +68,63 @@ final class ColumnTest extends Unit
         $this->assertNull($configs->getColumns()[0]->getKeyId());
     }
 
+    /**
+     * Regression pimcore/platform-version#296: a saved advanced-column config whose
+     * simple field is missing `config.field` (e.g. the studio-ui-bundle bug where the
+     * pre-selected first source field option was dropped on save) must not reach
+     * `SimpleFieldConfig`'s constructor with an undefined array key — it should be
+     * rejected as a 422 `InvalidArgumentException` naming the broken column instead of
+     * causing an uncaught error that blanks the whole grid response.
+     */
+    public function testGetAdvancedColumnConfigSimpleFieldMissingFieldThrows(): void
+    {
+        $column = new Column(
+            key: 'name',
+            locale: 'de',
+            type: 'ttest',
+            group: ['test'],
+            config: [
+                'advancedColumns' => [
+                    [
+                        'key' => 'simpleField',
+                        'config' => [],
+                    ],
+                ],
+            ],
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Advanced column "name" (source field at index 0) is missing the required "field" config');
+
+        $column->getAdvancedColumnConfig();
+    }
+
+    /**
+     * The reported bug actually saves the advanced column without a `config` key at all
+     * (`{"key": "simpleField"}`), not merely without `field` inside an empty `config`.
+     */
+    public function testGetAdvancedColumnConfigSimpleFieldMissingConfigThrows(): void
+    {
+        $column = new Column(
+            key: 'name',
+            locale: 'de',
+            type: 'ttest',
+            group: ['test'],
+            config: [
+                'advancedColumns' => [
+                    [
+                        'key' => 'simpleField',
+                    ],
+                ],
+            ],
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Advanced column "name" (source field at index 0) is missing the required "field" config');
+
+        $column->getAdvancedColumnConfig();
+    }
+
     public function testGetAdvancedColumnConfigRelationField(): void
     {
         $column = new Column(


### PR DESCRIPTION
## Summary

Hardens `Column::getAdvancedColumnConfig()` against malformed advanced-column configs, as identified in [pimcore/platform-version#296](https://github.com/pimcore/platform-version/issues/296).

### Root cause

`getAdvancedColumnConfig()` built `new SimpleFieldConfig(field: $advancedColumn['config']['field'], ...)` directly off the saved config array, with no check that `config.field` (or even `config` itself) was present. When it wasn't — for example because of the studio-ui-bundle bug where the pre-selected first "Simple Field" source-field option was silently dropped from the saved template (see the companion frontend PR) — this hit an undefined array key while building that one column, which surfaced as an unhandled error on the `grid/{class}` request. That blanked the *entire* grid listing, not just the one broken column, with nothing in the response pointing at which column was actually at fault.

### Fix

Validate `isset($advancedColumn['config']['field'])` before constructing `SimpleFieldConfig`, and reuse the `InvalidArgumentException` this same method already throws for a missing `advancedColumns` key — no new exception type or error-handling path. `InvalidArgumentException` extends `AbstractApiException` with `HttpResponseCodes::UNPROCESSABLE_CONTENT` (422), and `ApiExceptionSubscriber::onKernelException` already turns any `AbstractApiException` on a studio backend path into a proper JSON `{message, errorKey}` response. The message names both the column key and the index of the broken source field within `advancedColumns`, so a malformed saved config is diagnosable from the response instead of only from a stack trace.

This is defense-in-depth: it turns *any* malformed `config.field` (regardless of cause) into an actionable 422 instead of letting the whole listing 500.

### Test

Added two cases to the existing `ColumnTest`:
- `testGetAdvancedColumnConfigSimpleFieldMissingFieldThrows` — `config: []` (present but empty) throws `InvalidArgumentException` naming the column and index
- `testGetAdvancedColumnConfigSimpleFieldMissingConfigThrows` — `config` key absent entirely (the actual shape reported in the issue) throws the same way
- Existing passing cases (`simpleField`, `relationField`, classification-store variants) are unaffected

## Related

Related to pimcore/platform-version#296 (the frontend PR carries the `Fixes` keyword, since fixing the pre-selected-field commit is what stops new saves from producing the malformed config in the first place; this PR is hardening for that and any other cause of the same shape).

## Test plan

- [x] `vendor/bin/codecept run Unit tests/Unit/Grid/Schema/ColumnTest.php` — 11/11 pass (2 new)
- [x] `vendor/bin/codecept run Unit` (full suite) — 521/521 pass
- [x] `vendor/bin/phpstan analyse --memory-limit=-1 --no-progress` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)