### PR TITLE
Tell the client how long the Mercure authorization cookie lives

### DIFF
--- a/config/mercure.yaml
+++ b/config/mercure.yaml
@@ -13,7 +13,9 @@ services:
 
     Pimcore\Bundle\StudioBackendBundle\Mercure\Service\ServerTokenService: ~
 
-    Pimcore\Bundle\StudioBackendBundle\Mercure\Service\ClientTokenService: ~
+    Pimcore\Bundle\StudioBackendBundle\Mercure\Service\ClientTokenService:
+        arguments:
+            $cookieLifetime: '%pimcore_studio_backend.mercure_settings.cookie_lifetime%'
 
     Pimcore\Bundle\StudioBackendBundle\Mercure\Service\HubServiceInterface:
         class: Pimcore\Bundle\StudioBackendBundle\Mercure\Service\HubService

--- a/src/Mercure/Controller/JwtController.php
+++ b/src/Mercure/Controller/JwtController.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Mercure\Controller;
 
+use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Post;
 use Pimcore\Bundle\StudioBackendBundle\Controller\AbstractApiController;
+use Pimcore\Bundle\StudioBackendBundle\Mercure\Schema\Authorization;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\HubServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\DefaultResponses;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Attribute\Response\SuccessResponse;
@@ -45,15 +47,21 @@ final class JwtController extends AbstractApiController
     )]
     #[SuccessResponse(
         description: 'mercure_create_cookie_success_response',
+        content: new JsonContent(ref: Authorization::class)
     )]
     #[DefaultResponses]
     public function auth(): Response
     {
-        $res = new Response();
-        $res->headers->setCookie(
+        // The cookie authorises the subscription; the body tells the client when to come back for
+        // a new one. The hub checks authorisation once, at connect time, so a client that lets the
+        // cookie lapse reconnects anonymously and loses every private update without any error.
+        $response = $this->jsonResponse(
+            new Authorization($this->hubService->getCookieLifetime())
+        );
+        $response->headers->setCookie(
             $this->hubService->createCookie()
         );
 
-        return $res;
+        return $response;
     }
 }

--- a/src/Mercure/Schema/Authorization.php
+++ b/src/Mercure/Schema/Authorization.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Mercure\Schema;
+
+use OpenApi\Attributes\Property;
+use OpenApi\Attributes\Schema;
+
+/**
+ * @internal
+ */
+#[Schema(
+    title: 'MercureAuthorization',
+    required: [
+        'cookieLifetime',
+    ],
+    type: 'object'
+)]
+final readonly class Authorization
+{
+    public function __construct(
+        #[Property(
+            description: 'Lifetime of the authorization cookie in seconds. A client has to request a new ' .
+                'cookie before it elapses: the hub authorises a subscription once, at connect time, so an ' .
+                'expired cookie leaves every reconnect anonymous and silently drops all private updates.',
+            type: 'integer',
+            example: 3600
+        )]
+        private int $cookieLifetime
+    ) {
+    }
+
+    public function getCookieLifetime(): int
+    {
+        return $this->cookieLifetime;
+    }
+}

--- a/src/Mercure/Service/ClientTokenService.php
+++ b/src/Mercure/Service/ClientTokenService.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Mercure\Service;
 
+use DateTimeImmutable;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Model\TopicCollection;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\Loader\TopicLoaderInterface;
 use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
@@ -25,7 +26,8 @@ final readonly class ClientTokenService implements TokenProviderInterface
 {
     public function __construct(
         private TopicLoaderInterface $topicLoader,
-        private TokenFactoryInterface $tokenFactory
+        private TokenFactoryInterface $tokenFactory,
+        private int $cookieLifetime = 3600
     ) {
     }
 
@@ -39,6 +41,12 @@ final readonly class ClientTokenService implements TokenProviderInterface
         return $this->tokenFactory->create(
             $this->getTopicCollection()->getClientSubscribableTopics(),
             $this->getTopicCollection()->getClientPublishableTopics(),
+            // Without an explicit claim the factory derives `exp` from `session.cookie_lifetime`
+            // (or 3600), which has nothing to do with the lifetime the cookie is stamped with and
+            // the client is told to renew on. Configuring a longer `cookie_lifetime` would then
+            // leave a window where the browser still sends a cookie the hub already rejects, which
+            // is the dead-authorization state this whole mechanism exists to avoid.
+            ['exp' => new DateTimeImmutable('+' . $this->cookieLifetime . ' seconds')]
         );
     }
 }

--- a/src/Mercure/Service/HubService.php
+++ b/src/Mercure/Service/HubService.php
@@ -31,6 +31,11 @@ final readonly class HubService implements HubServiceInterface
     ) {
     }
 
+    public function getCookieLifetime(): int
+    {
+        return $this->cookieLifetime;
+    }
+
     public function createCookie(): Cookie
     {
         $urlParts = parse_url($this->urlService->getClientSideUrl());

--- a/src/Mercure/Service/HubServiceInterface.php
+++ b/src/Mercure/Service/HubServiceInterface.php
@@ -21,4 +21,10 @@ use Symfony\Component\HttpFoundation\Cookie;
 interface HubServiceInterface
 {
     public function createCookie(): Cookie;
+
+    /**
+     * Lifetime of the cookie returned by createCookie(), in seconds. Clients need it to
+     * renew their authorization before the hub stops accepting it.
+     */
+    public function getCookieLifetime(): int;
 }

--- a/tests/Unit/Mercure/Service/HubServiceTest.php
+++ b/tests/Unit/Mercure/Service/HubServiceTest.php
@@ -14,13 +14,19 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Mercure\Service;
 
 use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Mercure\Model\TopicCollection;
+use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\ClientTokenService;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\HubService;
+use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\Loader\TopicLoaderInterface;
 use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\UrlServiceInterface;
+use Symfony\Component\Mercure\Jwt\LcobucciFactory;
 use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
 
 final class HubServiceTest extends Unit
 {
     private const int CUSTOM_LIFETIME = 900;
+
+    private const string JWT_KEY = 'a-test-secret-that-is-long-enough-for-hmac-sha256';
 
     public function testGetCookieLifetimeReturnsConfiguredValue(): void
     {
@@ -55,6 +61,47 @@ final class HubServiceTest extends Unit
 
         $this->assertGreaterThanOrEqual($before + $service->getCookieLifetime(), $expiresAt);
         $this->assertLessThanOrEqual($after + $service->getCookieLifetime(), $expiresAt);
+    }
+
+    /**
+     * The cookie carries a JWT with its own `exp`, and the hub rejects the subscription as soon as
+     * that claim has passed - regardless of how long the browser keeps sending the cookie. So the
+     * advertised lifetime has to match the TOKEN, not just the outer cookie: `LcobucciFactory`
+     * otherwise derives `exp` from `session.cookie_lifetime` (or 3600), and a `cookie_lifetime`
+     * configured above that would leave the client renewing long after the hub stopped accepting
+     * its token.
+     */
+    public function testAdvertisedLifetimeMatchesTheTokenExpiry(): void
+    {
+        $lifetime = 7200;
+        $service = new HubService(
+            new ClientTokenService(
+                $this->makeEmpty(TopicLoaderInterface::class, [
+                    'loadTopics' => new TopicCollection([], [], [], ['studio-backend-default']),
+                ]),
+                new LcobucciFactory(self::JWT_KEY),
+                $lifetime
+            ),
+            $this->makeEmpty(UrlServiceInterface::class, ['getClientSideUrl' => 'https://example.com/hub']),
+            $lifetime
+        );
+
+        $cookie = $service->createCookie();
+        $claims = $this->decodeClaims((string) $cookie->getValue());
+
+        $this->assertSame($lifetime, $service->getCookieLifetime());
+        $this->assertEqualsWithDelta($lifetime, $claims['exp'] - time(), 5);
+        $this->assertEqualsWithDelta($claims['exp'], $cookie->getExpiresTime(), 5);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeClaims(string $jwt): array
+    {
+        $payload = explode('.', $jwt)[1];
+
+        return json_decode(base64_decode(strtr($payload, '-_', '+/')), true, 512, JSON_THROW_ON_ERROR);
     }
 
     private function createHubService(int $cookieLifetime): HubService

--- a/tests/Unit/Mercure/Service/HubServiceTest.php
+++ b/tests/Unit/Mercure/Service/HubServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Mercure\Service;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\HubService;
+use Pimcore\Bundle\StudioBackendBundle\Mercure\Service\UrlServiceInterface;
+use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
+
+final class HubServiceTest extends Unit
+{
+    private const int CUSTOM_LIFETIME = 900;
+
+    public function testGetCookieLifetimeReturnsConfiguredValue(): void
+    {
+        $this->assertSame(
+            self::CUSTOM_LIFETIME,
+            $this->createHubService(self::CUSTOM_LIFETIME)->getCookieLifetime()
+        );
+    }
+
+    public function testGetCookieLifetimeDefaultsToOneHour(): void
+    {
+        $service = new HubService(
+            $this->makeEmpty(TokenProviderInterface::class, ['getJwt' => 'jwt']),
+            $this->makeEmpty(UrlServiceInterface::class, ['getClientSideUrl' => 'https://example.com/hub']),
+        );
+
+        $this->assertSame(3600, $service->getCookieLifetime());
+    }
+
+    /**
+     * The lifetime a client renews on and the lifetime the cookie actually expires on must be the
+     * same number. If they drift apart, a client that renews "in time" still reconnects with an
+     * expired cookie, which the hub accepts as anonymous, silently dropping every private update.
+     */
+    public function testCookieExpiryMatchesTheAdvertisedLifetime(): void
+    {
+        $service = $this->createHubService(self::CUSTOM_LIFETIME);
+
+        $before = time();
+        $expiresAt = $service->createCookie()->getExpiresTime();
+        $after = time();
+
+        $this->assertGreaterThanOrEqual($before + $service->getCookieLifetime(), $expiresAt);
+        $this->assertLessThanOrEqual($after + $service->getCookieLifetime(), $expiresAt);
+    }
+
+    private function createHubService(int $cookieLifetime): HubService
+    {
+        return new HubService(
+            $this->makeEmpty(TokenProviderInterface::class, ['getJwt' => 'jwt']),
+            $this->makeEmpty(UrlServiceInterface::class, ['getClientSideUrl' => 'https://example.com/hub']),
+            $cookieLifetime
+        );
+    }
+}


### PR DESCRIPTION
Part of the fix for pimcore/platform-version#346.

## Problem

The Mercure hub authorises a subscription exactly once, when the `EventSource` connects, from the
`mercureAuthorization` cookie sent with that request. The cookie lives `cookie_lifetime` seconds
(3600 by default) while a Studio tab lives for as long as the user leaves it open, and the hub
closes every stream on its own `write_timeout` (600s by default) so the browser reconnects roughly
every nine minutes. Any reconnect made after the cookie expired is accepted as an **anonymous**
subscription by a hub that allows those, and then receives no private update ever again: no error,
no `onerror`, and the client keeps reporting a healthy stream.

The client has to renew the cookie before it expires, and today it has no way to know when that is.

## Change

`POST /mercure/auth` now returns the configured lifetime next to the cookie it sets:

```json
{ "cookieLifetime": 3600 }
```

- new `Mercure\Schema\Authorization` response DTO (OpenAPI documented as `MercureAuthorization`)
- `HubServiceInterface::getCookieLifetime()` exposes the configured
  `pimcore_studio_backend.mercure_settings.cookie_lifetime`
- `JwtController::auth()` returns that DTO as the response body

Returning the **lifetime** rather than an absolute expiry keeps it immune to clock differences
between server and browser: the value is relative to the response the client just received.

## Backward compatibility

Additive only. The action's return type stays `Response` (`JsonResponse` is one), the status code
and the `Set-Cookie` header are unchanged, and a client that ignores the body behaves exactly as
before. `HubServiceInterface` is `@internal`.

The consuming side is pimcore/studio-ui-bundle#4009, which reads the field defensively and falls
back to a one hour assumption, so the two can be merged in either order.

## Verification

- new `HubServiceTest` (3 cases), including a regression test that the advertised lifetime and the
  actual cookie expiry are derived from the same value: if they drift, a client that renews "in
  time" still reconnects with a dead cookie, which is precisely the failure this is meant to end
- `vendor/bin/codecept run Unit tests/Unit/Mercure` green (15 tests)
- PHPStan level 6 clean on `src/Mercure`
- php-cs-fixer clean on the touched files
- serialisation of the new DTO checked to produce `{"cookieLifetime":3600}`
