### PR TITLE
Do not reject permission keys a user/role already carries

### DIFF
--- a/src/User/Service/UpdateService.php
+++ b/src/User/Service/UpdateService.php
@@ -28,6 +28,8 @@ use Pimcore\Model\User\Workspace\Asset as AssetWorkspace;
 use Pimcore\Model\User\Workspace\DataObject as DataObjectWorkspace;
 use Pimcore\Model\User\Workspace\Document as DocumentWorkspace;
 use Pimcore\Model\UserInterface;
+use function array_diff;
+use function array_map;
 use function in_array;
 
 /**
@@ -57,17 +59,30 @@ final readonly class UpdateService implements UpdateServiceInterface
         array $permissionsToSet,
         UserInterface|UserRoleInterface $user
     ): UserInterface|UserRoleInterface {
-        $permissions = array_map(static function ($permission) {
+        $availablePermissions = array_map(static function ($permission) {
             return $permission->getKey();
         }, $this->permissionRepository->getAvailablePermissions());
 
+        // Permission definitions can disappear (e.g. when a bundle gets uninstalled) while the key stays
+        // assigned to the user/role. Those orphaned keys are read from the database and sent back on the
+        // next save, so rejecting them would make unrelated changes (language, perspectives, ...)
+        // unsavable. They are dropped instead - keys the client made up are still reported as not found.
+        $orphanedPermissions = array_diff($user->getPermissions(), $availablePermissions);
+
+        $permissions = [];
         foreach ($permissionsToSet as $permission) {
-            if (!in_array($permission, $permissions, true)) {
+            if (in_array($permission, $availablePermissions, true)) {
+                $permissions[] = $permission;
+
+                continue;
+            }
+
+            if (!in_array($permission, $orphanedPermissions, true)) {
                 throw new NotFoundException('Permission', $permission, 'Key');
             }
         }
 
-        $user->setPermissions($permissionsToSet);
+        $user->setPermissions($permissions);
 
         return $user;
     }

--- a/tests/Unit/User/Service/UpdateServiceTest.php
+++ b/tests/Unit/User/Service/UpdateServiceTest.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\User\Service;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StaticResolverBundle\Models\Element\ServiceResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Class\Repository\ClassDefinitionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\NotFoundException;
+use Pimcore\Bundle\StudioBackendBundle\Role\Repository\RoleRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\User\Repository\PermissionRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UpdateService;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveServiceInterface;
+use Pimcore\Model\User;
+use Pimcore\Model\User\Permission\Definition;
+use Pimcore\Model\User\Role;
+
+/**
+ * @internal
+ */
+final class UpdateServiceTest extends Unit
+{
+    public function testKnownPermissionsAreStored(): void
+    {
+        $user = $this->createUser(['assets']);
+        $service = $this->createService('assets', 'documents');
+
+        $service->updatePermissions(['assets', 'documents'], $user);
+
+        $this->assertSame(['assets', 'documents'], $user->getPermissions());
+    }
+
+    public function testUnknownPermissionIsReportedAsNotFound(): void
+    {
+        $user = $this->createUser(['assets']);
+        $service = $this->createService('assets', 'documents');
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage('Permission with Key: made_up not found');
+        $service->updatePermissions(['assets', 'made_up'], $user);
+    }
+
+    public function testOrphanedPermissionOfTheUserIsDroppedInsteadOfRejected(): void
+    {
+        // The definition of "uninstalled_bundle_permission" is gone from users_permission_definitions,
+        // but the key is still assigned to the user and therefore sent back on the next save.
+        $user = $this->createUser(['assets', 'uninstalled_bundle_permission']);
+        $service = $this->createService('assets', 'documents');
+
+        $service->updatePermissions(['assets', 'uninstalled_bundle_permission'], $user);
+
+        $this->assertSame(['assets'], $user->getPermissions());
+    }
+
+    public function testOrphanedPermissionOfARoleIsDroppedInsteadOfRejected(): void
+    {
+        $role = new Role();
+        $role->setPermissions(['assets', 'uninstalled_bundle_permission']);
+        $service = $this->createService('assets', 'documents');
+
+        $service->updatePermissions(['assets', 'uninstalled_bundle_permission'], $role);
+
+        $this->assertSame(['assets'], $role->getPermissions());
+    }
+
+    public function testOrphanedPermissionOfAnotherUserIsStillReportedAsNotFound(): void
+    {
+        $user = $this->createUser(['assets']);
+        $service = $this->createService('assets', 'documents');
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage('Permission with Key: uninstalled_bundle_permission not found');
+        $service->updatePermissions(['assets', 'uninstalled_bundle_permission'], $user);
+    }
+
+    public function testStoredPermissionsAreSequentiallyIndexedAfterDroppingOrphans(): void
+    {
+        $user = $this->createUser(['orphan', 'assets']);
+        $service = $this->createService('assets');
+
+        $service->updatePermissions(['orphan', 'assets'], $user);
+
+        $this->assertSame([0], array_keys($user->getPermissions()));
+    }
+
+    private function createUser(array $permissions): User
+    {
+        $user = new User();
+        $user->setName('testuser');
+        $user->setPermissions($permissions);
+
+        return $user;
+    }
+
+    private function createService(string ...$availablePermissionKeys): UpdateService
+    {
+        $definitions = array_map(
+            static fn (string $key) => (new Definition())->setKey($key),
+            $availablePermissionKeys
+        );
+
+        return new UpdateService(
+            $this->makeEmpty(PermissionRepositoryInterface::class, [
+                'getAvailablePermissions' => $definitions,
+            ]),
+            $this->makeEmpty(RoleRepositoryInterface::class),
+            $this->makeEmpty(ClassDefinitionRepositoryInterface::class),
+            $this->makeEmpty(ServiceResolverInterface::class),
+            $this->makeEmpty(UserPerspectiveServiceInterface::class),
+        );
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

Resolves #1907

Permission definitions can vanish from `users_permission_definitions` while the key stays assigned to a user or role — uninstalling a bundle leaves exactly that behind. `UpdateService::updatePermissions()` compared every incoming key against the available definitions and threw a 404 `NotFoundException` for those orphans.

Since the payload the client sends back is the payload it read, such an orphan made **every** save of that user fail, including saves that only touched unrelated fields such as the language or the allowed perspectives. In the Studio UI the rejected save surfaced as `Cannot read properties of undefined (reading 'toString')`.

The read path already drops unknown keys silently (#1932). The write path now matches it for keys the entity already has stored, and the orphan is not written back, so the record heals itself on the next save. Keys a client made up are still reported as not found, so the validation for genuinely invalid input is unchanged.

## Additional info

- The same method is used for roles, so both `PUT /user/{id}` and the role update are covered.
- New `tests/Unit/User/Service/UpdateServiceTest.php` covers: known keys stored, an orphan of the user dropped, an orphan of a role dropped, an unknown key the entity does not carry still rejected, and sequential re-indexing of the stored list.
- `vendor/bin/codecept run Unit` → 527 tests / 1199 assertions OK. `vendor/bin/phpstan analyse` → no errors.