### PR TITLE
[Permissions] Honor the language independent Classification Store column for non-admins

### DIFF
--- a/src/DataObject/Data/Adapter/ClassificationStoreAdapter.php
+++ b/src/DataObject/Data/Adapter/ClassificationStoreAdapter.php
@@ -307,18 +307,16 @@ final readonly class ClassificationStoreAdapter implements
         bool $isPatch
     ): void {
 
+        $editableLanguages = $this->getValidLanguages(
+            $element,
+            $definition->isLocalized(),
+            ElementPermissions::LANGUAGE_EDIT_PERMISSIONS,
+            $user
+        );
+
         foreach ($store as $groupId => $groupData) {
             foreach ($groupData as $language => $keys) {
-                if (!in_array(
-                    $language,
-                    $this->getValidLanguages(
-                        $element,
-                        $definition->isLocalized(),
-                        ElementPermissions::LANGUAGE_EDIT_PERMISSIONS,
-                        $user
-                    ),
-                    true
-                )) {
+                if (!in_array($language, $editableLanguages, true)) {
                     continue;
                 }
                 $this->processGroupKeys($element, $user, $definition, $container, $language, $groupId, $keys, $isPatch);

--- a/src/DataObject/Data/Adapter/ClassificationStoreAdapter.php
+++ b/src/DataObject/Data/Adapter/ClassificationStoreAdapter.php
@@ -449,18 +449,11 @@ final readonly class ClassificationStoreAdapter implements
             return array_merge($languages, $this->toolResolver->getValidLanguages());
         }
 
-        $allowedLanguages = array_values(
-            array_filter(
-                $this->languageService->getUserAllowedLanguages($object, $user, $permissionType),
-                static fn (string $language): bool => $language !== MappingProperty::NOT_LOCALIZED_KEY
-            )
+        return $this->languageService->getUserAllowedLanguagesWithLanguageIndependentValue(
+            $object,
+            $user,
+            $permissionType
         );
-
-        if (!$this->languageService->isLanguageIndependentValueAllowed($object, $user, $permissionType)) {
-            return $allowedLanguages;
-        }
-
-        return array_merge($languages, $allowedLanguages);
     }
 
     /**

--- a/src/DataObject/Data/Adapter/ClassificationStoreAdapter.php
+++ b/src/DataObject/Data/Adapter/ClassificationStoreAdapter.php
@@ -449,11 +449,18 @@ final readonly class ClassificationStoreAdapter implements
             return array_merge($languages, $this->toolResolver->getValidLanguages());
         }
 
-        return $this->languageService->getUserAllowedLanguages(
-            $object,
-            $user,
-            $permissionType
+        $allowedLanguages = array_values(
+            array_filter(
+                $this->languageService->getUserAllowedLanguages($object, $user, $permissionType),
+                static fn (string $language): bool => $language !== MappingProperty::NOT_LOCALIZED_KEY
+            )
         );
+
+        if (!$this->languageService->isLanguageIndependentValueAllowed($object, $user, $permissionType)) {
+            return $allowedLanguages;
+        }
+
+        return array_merge($languages, $allowedLanguages);
     }
 
     /**

--- a/src/Security/Service/LanguageService.php
+++ b/src/Security/Service/LanguageService.php
@@ -69,14 +69,24 @@ final readonly class LanguageService implements LanguageServiceInterface
 
         $languagePermissions = $this->getLanguagePermissions($dataObject, $user, $permission);
 
+        // Only an unset or empty permission means no restriction. Unlike for localized fields, the
+        // language independent value is a real column here, so granting just that column must not
+        // hand out any language on top of it - which is what the classic UI does as well.
+        if ($this->isUnrestrictedLanguagePermission($languagePermissions)) {
+            return array_merge(
+                [MappingProperty::NOT_LOCALIZED_KEY],
+                $this->toolResolver->getValidLanguages()
+            );
+        }
+
         $languages = array_values(
             array_filter(
-                $this->resolveAllowedLanguages($languagePermissions),
+                $languagePermissions,
                 static fn (string $language): bool => $language !== MappingProperty::NOT_LOCALIZED_KEY
             )
         );
 
-        if (!$this->isLanguageIndependentValueGranted($languagePermissions)) {
+        if (!in_array(MappingProperty::NOT_LOCALIZED_KEY, $languagePermissions, true)) {
             return $languages;
         }
 
@@ -149,19 +159,11 @@ final readonly class LanguageService implements LanguageServiceInterface
     }
 
     /**
-     * Without an explicit language restriction every language is allowed, the language independent
-     * value included. This mirrors the behavior of the classic UI, where the language independent
-     * column stays available unless it is left out of the configured language list.
-     *
      * @param array<int, string> $languagePermissions
      */
-    private function isLanguageIndependentValueGranted(array $languagePermissions): bool
+    private function isUnrestrictedLanguagePermission(array $languagePermissions): bool
     {
-        if ($languagePermissions === [] || $this->isDefaultLanguagePermission($languagePermissions)) {
-            return true;
-        }
-
-        return in_array(MappingProperty::NOT_LOCALIZED_KEY, $languagePermissions, true);
+        return $languagePermissions === [] || $languagePermissions === [''];
     }
 
     private function isDefaultLanguagePermission(array $permissions): bool

--- a/src/Security/Service/LanguageService.php
+++ b/src/Security/Service/LanguageService.php
@@ -45,39 +45,44 @@ final readonly class LanguageService implements LanguageServiceInterface
     ): array {
         $this->validateLanguagePermission($permission);
 
-        $languagePermissions = $this->getLanguagePermissions($dataObject, $user, $permission);
-
-        if ($languagePermissions === [] || $this->isDefaultLanguagePermission($languagePermissions)) {
-            return $this->toolResolver->getValidLanguages();
-        }
-
-        return $languagePermissions;
+        return $this->resolveAllowedLanguages(
+            $this->getLanguagePermissions($dataObject, $user, $permission)
+        );
     }
 
     /**
      * {@inheritdoc}
      */
-    public function isLanguageIndependentValueAllowed(
+    public function getUserAllowedLanguagesWithLanguageIndependentValue(
         DataObject $dataObject,
         UserInterface $user,
         string $permission
-    ): bool {
+    ): array {
         $this->validateLanguagePermission($permission);
 
         if ($user->isAdmin()) {
-            return true;
+            return array_merge(
+                [MappingProperty::NOT_LOCALIZED_KEY],
+                $this->toolResolver->getValidLanguages()
+            );
         }
 
         $languagePermissions = $this->getLanguagePermissions($dataObject, $user, $permission);
 
-        // Without an explicit language restriction every language is allowed, the language
-        // independent value included. This mirrors the behavior of the classic UI, where the
-        // language independent column stays available unless it is left out of the language list.
-        if ($languagePermissions === [] || $this->isDefaultLanguagePermission($languagePermissions)) {
-            return true;
+        $languages = array_values(
+            array_filter(
+                $this->resolveAllowedLanguages($languagePermissions),
+                static fn (string $language): bool => $language !== MappingProperty::NOT_LOCALIZED_KEY
+            )
+        );
+
+        if (!$this->isLanguageIndependentValueGranted($languagePermissions)) {
+            return $languages;
         }
 
-        return in_array(MappingProperty::NOT_LOCALIZED_KEY, $languagePermissions, true);
+        array_unshift($languages, MappingProperty::NOT_LOCALIZED_KEY);
+
+        return $languages;
     }
 
     /**
@@ -127,6 +132,36 @@ final readonly class LanguageService implements LanguageServiceInterface
             $user,
             $permission
         );
+    }
+
+    /**
+     * @param array<int, string> $languagePermissions
+     *
+     * @return array<int, string>
+     */
+    private function resolveAllowedLanguages(array $languagePermissions): array
+    {
+        if ($languagePermissions === [] || $this->isDefaultLanguagePermission($languagePermissions)) {
+            return $this->toolResolver->getValidLanguages();
+        }
+
+        return $languagePermissions;
+    }
+
+    /**
+     * Without an explicit language restriction every language is allowed, the language independent
+     * value included. This mirrors the behavior of the classic UI, where the language independent
+     * column stays available unless it is left out of the configured language list.
+     *
+     * @param array<int, string> $languagePermissions
+     */
+    private function isLanguageIndependentValueGranted(array $languagePermissions): bool
+    {
+        if ($languagePermissions === [] || $this->isDefaultLanguagePermission($languagePermissions)) {
+            return true;
+        }
+
+        return in_array(MappingProperty::NOT_LOCALIZED_KEY, $languagePermissions, true);
     }
 
     private function isDefaultLanguagePermission(array $permissions): bool

--- a/src/Security/Service/LanguageService.php
+++ b/src/Security/Service/LanguageService.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Security\Service;
 
+use Pimcore\Bundle\GenericDataIndexBundle\Model\SearchIndexAdapter\MappingProperty;
 use Pimcore\Bundle\StaticResolverBundle\Lib\ToolResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
@@ -42,21 +43,41 @@ final readonly class LanguageService implements LanguageServiceInterface
         UserInterface $user,
         string $permission
     ): array {
-        if (!in_array($permission, ElementPermissions::LANGUAGE_PERMISSIONS)) {
-            throw new InvalidArgumentException(sprintf('Invalid permission "%s"', $permission));
-        }
+        $this->validateLanguagePermission($permission);
 
-        $languagePermissions =  $this->securityService->getSpecialDataObjectPermissions(
-            $dataObject,
-            $user,
-            $permission
-        );
+        $languagePermissions = $this->getLanguagePermissions($dataObject, $user, $permission);
 
-        if (empty($languagePermissions) || $this->isDefaultLanguagePermission($languagePermissions)) {
+        if ($languagePermissions === [] || $this->isDefaultLanguagePermission($languagePermissions)) {
             return $this->toolResolver->getValidLanguages();
         }
 
         return $languagePermissions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isLanguageIndependentValueAllowed(
+        DataObject $dataObject,
+        UserInterface $user,
+        string $permission
+    ): bool {
+        $this->validateLanguagePermission($permission);
+
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        $languagePermissions = $this->getLanguagePermissions($dataObject, $user, $permission);
+
+        // Without an explicit language restriction every language is allowed, the language
+        // independent value included. This mirrors the behavior of the classic UI, where the
+        // language independent column stays available unless it is left out of the language list.
+        if ($languagePermissions === [] || $this->isDefaultLanguagePermission($languagePermissions)) {
+            return true;
+        }
+
+        return in_array(MappingProperty::NOT_LOCALIZED_KEY, $languagePermissions, true);
     }
 
     /**
@@ -81,6 +102,31 @@ final readonly class LanguageService implements LanguageServiceInterface
         }
 
         return $allowedLanguages;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function validateLanguagePermission(string $permission): void
+    {
+        if (!in_array($permission, ElementPermissions::LANGUAGE_PERMISSIONS, true)) {
+            throw new InvalidArgumentException(sprintf('Invalid permission "%s"', $permission));
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function getLanguagePermissions(
+        DataObject $dataObject,
+        UserInterface $user,
+        string $permission
+    ): array {
+        return $this->securityService->getSpecialDataObjectPermissions(
+            $dataObject,
+            $user,
+            $permission
+        );
     }
 
     private function isDefaultLanguagePermission(array $permissions): bool

--- a/src/Security/Service/LanguageServiceInterface.php
+++ b/src/Security/Service/LanguageServiceInterface.php
@@ -35,17 +35,19 @@ interface LanguageServiceInterface
     ): array;
 
     /**
-     * Tells whether the user may use the language independent ("default") value of a localized
-     * field for the given language permission. It is granted unless the configured language list
-     * explicitly leaves it out.
+     * Same as getUserAllowedLanguages(), but for fields that also have a language independent
+     * ("default") value - a localized Classification Store. That value is prepended unless the
+     * configured language list explicitly leaves it out.
+     *
+     * @return array<int, string>
      *
      * @throws InvalidArgumentException
      */
-    public function isLanguageIndependentValueAllowed(
+    public function getUserAllowedLanguagesWithLanguageIndependentValue(
         DataObject $dataObject,
         UserInterface $user,
         string $permission
-    ): bool;
+    ): array;
 
     /**
      * @throws ForbiddenException

--- a/src/Security/Service/LanguageServiceInterface.php
+++ b/src/Security/Service/LanguageServiceInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Security\Service;
 
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\UserInterface;
 
@@ -22,11 +23,29 @@ use Pimcore\Model\UserInterface;
  */
 interface LanguageServiceInterface
 {
+    /**
+     * @return array<int, string>
+     *
+     * @throws InvalidArgumentException
+     */
     public function getUserAllowedLanguages(
         DataObject $dataObject,
         UserInterface $user,
         string $permission
     ): array;
+
+    /**
+     * Tells whether the user may use the language independent ("default") value of a localized
+     * field for the given language permission. It is granted unless the configured language list
+     * explicitly leaves it out.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function isLanguageIndependentValueAllowed(
+        DataObject $dataObject,
+        UserInterface $user,
+        string $permission
+    ): bool;
 
     /**
      * @throws ForbiddenException

--- a/tests/Unit/DataObject/Data/Adapter/ClassificationStoreAdapterTest.php
+++ b/tests/Unit/DataObject/Data/Adapter/ClassificationStoreAdapterTest.php
@@ -393,7 +393,7 @@ final class ClassificationStoreAdapterTest extends Unit
      */
     public function testGetDataForSetterStoresLanguageIndependentValuesForAllowedNonAdmin(): void
     {
-        $storedLanguages = $this->getStoredLanguagesForNonAdmin(isLanguageIndependentValueAllowed: true);
+        $storedLanguages = $this->getStoredLanguagesForNonAdmin(['default', 'de', 'en']);
 
         $this->assertContains('default', $storedLanguages);
     }
@@ -406,18 +406,20 @@ final class ClassificationStoreAdapterTest extends Unit
      */
     public function testGetDataForSetterSkipsLanguageIndependentValuesForDeniedNonAdmin(): void
     {
-        $storedLanguages = $this->getStoredLanguagesForNonAdmin(isLanguageIndependentValueAllowed: false);
+        $storedLanguages = $this->getStoredLanguagesForNonAdmin(['de', 'en']);
 
         $this->assertNotContains('default', $storedLanguages);
         $this->assertContains('de', $storedLanguages);
     }
 
     /**
+     * @param array<int, string> $allowedLanguages
+     *
      * @return array<int, string|null>
      *
      * @throws Exception
      */
-    private function getStoredLanguagesForNonAdmin(bool $isLanguageIndependentValueAllowed): array
+    private function getStoredLanguagesForNonAdmin(array $allowedLanguages): array
     {
         $storedLanguages = [];
         $existingContainer = $this->make(Classificationstore::class, [
@@ -449,8 +451,7 @@ final class ClassificationStoreAdapterTest extends Unit
                 ]),
             ]),
             languageService: $this->makeEmpty(LanguageServiceInterface::class, [
-                'getUserAllowedLanguages' => ['de', 'en'],
-                'isLanguageIndependentValueAllowed' => $isLanguageIndependentValueAllowed,
+                'getUserAllowedLanguagesWithLanguageIndependentValue' => $allowedLanguages,
             ]),
             serviceResolver: $this->makeEmpty(ServiceResolverInterface::class, [
                 'getFieldDefinitionFromKeyConfig' => $this->makeEmpty(Data::class, [

--- a/tests/Unit/DataObject/Data/Adapter/ClassificationStoreAdapterTest.php
+++ b/tests/Unit/DataObject/Data/Adapter/ClassificationStoreAdapterTest.php
@@ -385,6 +385,99 @@ final class ClassificationStoreAdapterTest extends Unit
         $this->assertArrayHasKey(30, $mappings);
     }
 
+    /**
+     * A non admin user whose language permissions grant the language independent column must be
+     * able to store values in it, exactly like in the classic UI.
+     *
+     * @throws Exception
+     */
+    public function testGetDataForSetterStoresLanguageIndependentValuesForAllowedNonAdmin(): void
+    {
+        $storedLanguages = $this->getStoredLanguagesForNonAdmin(isLanguageIndependentValueAllowed: true);
+
+        $this->assertContains('default', $storedLanguages);
+    }
+
+    /**
+     * A non admin user whose language permissions exclude the language independent column must not
+     * be able to store values in it.
+     *
+     * @throws Exception
+     */
+    public function testGetDataForSetterSkipsLanguageIndependentValuesForDeniedNonAdmin(): void
+    {
+        $storedLanguages = $this->getStoredLanguagesForNonAdmin(isLanguageIndependentValueAllowed: false);
+
+        $this->assertNotContains('default', $storedLanguages);
+        $this->assertContains('de', $storedLanguages);
+    }
+
+    /**
+     * @return array<int, string|null>
+     *
+     * @throws Exception
+     */
+    private function getStoredLanguagesForNonAdmin(bool $isLanguageIndependentValueAllowed): array
+    {
+        $storedLanguages = [];
+        $existingContainer = $this->make(Classificationstore::class, [
+            'setLocalizedKeyValue' => function (
+                int $groupId,
+                int $keyId,
+                mixed $value,
+                ?string $language = null
+            ) use (&$storedLanguages, &$existingContainer) {
+                $storedLanguages[] = $language;
+
+                return $existingContainer;
+            },
+        ]);
+
+        $element = $this->makeEmpty(Concrete::class, [
+            'get' => $existingContainer,
+        ]);
+
+        $fieldDefinition = $this->make(ClassificationstoreDefinition::class, [
+            'isLocalized' => true,
+            'getKeyConfiguration' => new KeyConfig(),
+        ]);
+
+        $adapter = $this->createAdapter(
+            dataAdapterService: $this->makeEmpty(DataAdapterServiceInterface::class, [
+                'tryDataAdapter' => $this->makeEmpty(SetterDataInterface::class, [
+                    'getDataForSetter' => 'new-value',
+                ]),
+            ]),
+            languageService: $this->makeEmpty(LanguageServiceInterface::class, [
+                'getUserAllowedLanguages' => ['de', 'en'],
+                'isLanguageIndependentValueAllowed' => $isLanguageIndependentValueAllowed,
+            ]),
+            serviceResolver: $this->makeEmpty(ServiceResolverInterface::class, [
+                'getFieldDefinitionFromKeyConfig' => $this->makeEmpty(Data::class, [
+                    'getName' => 'inputField',
+                ]),
+            ]),
+        );
+
+        $adapter->getDataForSetter(
+            $element,
+            $fieldDefinition,
+            'myStore',
+            [
+                'myStore' => [
+                    22 => [
+                        'default' => [2 => 'language-independent-value'],
+                        'de' => [2 => 'german-value'],
+                    ],
+                    'activeGroups' => [22 => true],
+                ],
+            ],
+            $this->makeEmpty(UserInterface::class, ['isAdmin' => false])
+        );
+
+        return $storedLanguages;
+    }
+
     private function createAdapter(
         ?DataObjectServiceResolverInterface $dataObjectServiceResolver = null,
         ?DefinitionCacheResolverInterface $definitionCacheResolver = null,

--- a/tests/Unit/DataObject/Data/Adapter/ClassificationStoreAdapterTest.php
+++ b/tests/Unit/DataObject/Data/Adapter/ClassificationStoreAdapterTest.php
@@ -413,6 +413,20 @@ final class ClassificationStoreAdapterTest extends Unit
     }
 
     /**
+     * A non admin user whose language permissions grant only the language independent column must
+     * not be able to store values in concrete localized columns.
+     *
+     * @throws Exception
+     */
+    public function testGetDataForSetterSkipsConcreteLanguagesWhenOnlyDefaultIsGranted(): void
+    {
+        $storedLanguages = $this->getStoredLanguagesForNonAdmin(['default']);
+
+        $this->assertContains('default', $storedLanguages);
+        $this->assertNotContains('de', $storedLanguages);
+    }
+
+    /**
      * @param array<int, string> $allowedLanguages
      *
      * @return array<int, string|null>

--- a/tests/Unit/Security/Service/LanguageServiceTest.php
+++ b/tests/Unit/Security/Service/LanguageServiceTest.php
@@ -52,10 +52,14 @@ final class LanguageServiceTest extends Unit
         );
     }
 
-    public function testTheLanguageIndependentValueAloneIsTreatedAsNoRestriction(): void
+    /**
+     * Unlike for localized fields, the language independent value is a real column of a localized
+     * Classification Store. Granting only that column must therefore not hand out any language.
+     */
+    public function testGrantingOnlyTheLanguageIndependentValueGrantsNoLanguage(): void
     {
         $this->assertSame(
-            ['default', 'de', 'en'],
+            ['default'],
             $this->resolveLanguages(['default'])
         );
     }

--- a/tests/Unit/Security/Service/LanguageServiceTest.php
+++ b/tests/Unit/Security/Service/LanguageServiceTest.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Security\Service;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StaticResolverBundle\Lib\ToolResolverInterface;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\InvalidArgumentException;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\LanguageService;
+use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Translation\Service\AdminLanguageServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementPermissions;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+final class LanguageServiceTest extends Unit
+{
+    public function testLanguageIndependentValueIsAllowedForAdmins(): void
+    {
+        $service = $this->createService(['de']);
+
+        $this->assertTrue(
+            $service->isLanguageIndependentValueAllowed(
+                $this->makeEmpty(DataObject::class),
+                $this->makeEmpty(UserInterface::class, ['isAdmin' => true]),
+                ElementPermissions::LANGUAGE_VIEW_PERMISSIONS
+            )
+        );
+    }
+
+    public function testLanguageIndependentValueIsAllowedWithoutAnyLanguageRestriction(): void
+    {
+        $service = $this->createService([]);
+
+        $this->assertTrue(
+            $service->isLanguageIndependentValueAllowed(
+                $this->makeEmpty(DataObject::class),
+                $this->makeEmpty(UserInterface::class),
+                ElementPermissions::LANGUAGE_VIEW_PERMISSIONS
+            )
+        );
+    }
+
+    public function testLanguageIndependentValueIsAllowedForAnEmptyPermissionString(): void
+    {
+        $service = $this->createService(['']);
+
+        $this->assertTrue(
+            $service->isLanguageIndependentValueAllowed(
+                $this->makeEmpty(DataObject::class),
+                $this->makeEmpty(UserInterface::class),
+                ElementPermissions::LANGUAGE_VIEW_PERMISSIONS
+            )
+        );
+    }
+
+    public function testLanguageIndependentValueIsAllowedWhenItIsTheOnlyGrantedPermission(): void
+    {
+        $service = $this->createService(['default']);
+
+        $this->assertTrue(
+            $service->isLanguageIndependentValueAllowed(
+                $this->makeEmpty(DataObject::class),
+                $this->makeEmpty(UserInterface::class),
+                ElementPermissions::LANGUAGE_VIEW_PERMISSIONS
+            )
+        );
+    }
+
+    public function testLanguageIndependentValueIsAllowedWhenGrantedNextToConcreteLanguages(): void
+    {
+        $service = $this->createService(['default', 'de']);
+
+        $this->assertTrue(
+            $service->isLanguageIndependentValueAllowed(
+                $this->makeEmpty(DataObject::class),
+                $this->makeEmpty(UserInterface::class),
+                ElementPermissions::LANGUAGE_EDIT_PERMISSIONS
+            )
+        );
+    }
+
+    public function testLanguageIndependentValueIsDeniedWhenExcludedFromTheLanguageList(): void
+    {
+        $service = $this->createService(['de', 'en']);
+
+        $this->assertFalse(
+            $service->isLanguageIndependentValueAllowed(
+                $this->makeEmpty(DataObject::class),
+                $this->makeEmpty(UserInterface::class),
+                ElementPermissions::LANGUAGE_EDIT_PERMISSIONS
+            )
+        );
+    }
+
+    public function testLanguageIndependentValueRejectsAnUnknownPermission(): void
+    {
+        $service = $this->createService(['de']);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $service->isLanguageIndependentValueAllowed(
+            $this->makeEmpty(DataObject::class),
+            $this->makeEmpty(UserInterface::class),
+            'view'
+        );
+    }
+
+    /**
+     * @param array<int, string> $languagePermissions
+     */
+    private function createService(array $languagePermissions): LanguageService
+    {
+        return new LanguageService(
+            $this->makeEmpty(AdminLanguageServiceInterface::class),
+            $this->makeEmpty(SecurityServiceInterface::class, [
+                'getSpecialDataObjectPermissions' => $languagePermissions,
+            ]),
+            $this->makeEmpty(ToolResolverInterface::class, [
+                'getValidLanguages' => ['de', 'en'],
+            ]),
+        );
+    }
+}

--- a/tests/Unit/Security/Service/LanguageServiceTest.php
+++ b/tests/Unit/Security/Service/LanguageServiceTest.php
@@ -28,103 +28,72 @@ use Pimcore\Model\UserInterface;
  */
 final class LanguageServiceTest extends Unit
 {
-    public function testLanguageIndependentValueIsAllowedForAdmins(): void
+    public function testAdminsGetTheLanguageIndependentValueAndEveryValidLanguage(): void
     {
-        $service = $this->createService(['de']);
-
-        $this->assertTrue(
-            $service->isLanguageIndependentValueAllowed(
-                $this->makeEmpty(DataObject::class),
-                $this->makeEmpty(UserInterface::class, ['isAdmin' => true]),
-                ElementPermissions::LANGUAGE_VIEW_PERMISSIONS
-            )
+        $this->assertSame(
+            ['default', 'de', 'en'],
+            $this->resolveLanguages(['de'], isAdmin: true)
         );
     }
 
-    public function testLanguageIndependentValueIsAllowedWithoutAnyLanguageRestriction(): void
+    public function testWithoutAnyLanguageRestrictionEveryLanguageIsAllowed(): void
     {
-        $service = $this->createService([]);
-
-        $this->assertTrue(
-            $service->isLanguageIndependentValueAllowed(
-                $this->makeEmpty(DataObject::class),
-                $this->makeEmpty(UserInterface::class),
-                ElementPermissions::LANGUAGE_VIEW_PERMISSIONS
-            )
+        $this->assertSame(
+            ['default', 'de', 'en'],
+            $this->resolveLanguages([])
         );
     }
 
-    public function testLanguageIndependentValueIsAllowedForAnEmptyPermissionString(): void
+    public function testAnEmptyPermissionStringIsTreatedAsNoRestriction(): void
     {
-        $service = $this->createService(['']);
-
-        $this->assertTrue(
-            $service->isLanguageIndependentValueAllowed(
-                $this->makeEmpty(DataObject::class),
-                $this->makeEmpty(UserInterface::class),
-                ElementPermissions::LANGUAGE_VIEW_PERMISSIONS
-            )
+        $this->assertSame(
+            ['default', 'de', 'en'],
+            $this->resolveLanguages([''])
         );
     }
 
-    public function testLanguageIndependentValueIsAllowedWhenItIsTheOnlyGrantedPermission(): void
+    public function testTheLanguageIndependentValueAloneIsTreatedAsNoRestriction(): void
     {
-        $service = $this->createService(['default']);
-
-        $this->assertTrue(
-            $service->isLanguageIndependentValueAllowed(
-                $this->makeEmpty(DataObject::class),
-                $this->makeEmpty(UserInterface::class),
-                ElementPermissions::LANGUAGE_VIEW_PERMISSIONS
-            )
+        $this->assertSame(
+            ['default', 'de', 'en'],
+            $this->resolveLanguages(['default'])
         );
     }
 
-    public function testLanguageIndependentValueIsAllowedWhenGrantedNextToConcreteLanguages(): void
+    public function testTheLanguageIndependentValueIsPrependedWhenGrantedNextToLanguages(): void
     {
-        $service = $this->createService(['default', 'de']);
-
-        $this->assertTrue(
-            $service->isLanguageIndependentValueAllowed(
-                $this->makeEmpty(DataObject::class),
-                $this->makeEmpty(UserInterface::class),
-                ElementPermissions::LANGUAGE_EDIT_PERMISSIONS
-            )
+        $this->assertSame(
+            ['default', 'de'],
+            $this->resolveLanguages(['de', 'default'], ElementPermissions::LANGUAGE_EDIT_PERMISSIONS)
         );
     }
 
-    public function testLanguageIndependentValueIsDeniedWhenExcludedFromTheLanguageList(): void
+    public function testTheLanguageIndependentValueIsDeniedWhenLeftOutOfTheLanguageList(): void
     {
-        $service = $this->createService(['de', 'en']);
-
-        $this->assertFalse(
-            $service->isLanguageIndependentValueAllowed(
-                $this->makeEmpty(DataObject::class),
-                $this->makeEmpty(UserInterface::class),
-                ElementPermissions::LANGUAGE_EDIT_PERMISSIONS
-            )
+        $this->assertSame(
+            ['de', 'en'],
+            $this->resolveLanguages(['de', 'en'], ElementPermissions::LANGUAGE_EDIT_PERMISSIONS)
         );
     }
 
-    public function testLanguageIndependentValueRejectsAnUnknownPermission(): void
+    public function testAnUnknownPermissionIsRejected(): void
     {
-        $service = $this->createService(['de']);
-
         $this->expectException(InvalidArgumentException::class);
 
-        $service->isLanguageIndependentValueAllowed(
-            $this->makeEmpty(DataObject::class),
-            $this->makeEmpty(UserInterface::class),
-            'view'
-        );
+        $this->resolveLanguages(['de'], 'view');
     }
 
     /**
      * @param array<int, string> $languagePermissions
+     *
+     * @return array<int, string>
      */
-    private function createService(array $languagePermissions): LanguageService
-    {
-        return new LanguageService(
+    private function resolveLanguages(
+        array $languagePermissions,
+        string $permission = ElementPermissions::LANGUAGE_VIEW_PERMISSIONS,
+        bool $isAdmin = false
+    ): array {
+        $service = new LanguageService(
             $this->makeEmpty(AdminLanguageServiceInterface::class),
             $this->makeEmpty(SecurityServiceInterface::class, [
                 'getSpecialDataObjectPermissions' => $languagePermissions,
@@ -132,6 +101,12 @@ final class LanguageServiceTest extends Unit
             $this->makeEmpty(ToolResolverInterface::class, [
                 'getValidLanguages' => ['de', 'en'],
             ]),
+        );
+
+        return $service->getUserAllowedLanguagesWithLanguageIndependentValue(
+            $this->makeEmpty(DataObject::class),
+            $this->makeEmpty(UserInterface::class, ['isAdmin' => $isAdmin]),
+            $permission
         );
     }
 }


### PR DESCRIPTION
Fixes https://github.com/pimcore/service-operations/issues/964 (gap A of three).

## Gap addressed

**Runtime behavior** — for a localized Classification Store, the language-independent
"default" column was only ever available to admins. Non-admins never got it, neither for
view nor for edit, no matter how their `lView` / `lEdit` workspace permissions were
configured.

## Root cause

`ClassificationStoreAdapter::getValidLanguages()` seeds the language list with
`MappingProperty::NOT_LOCALIZED_KEY` (`'default'`), returns that seed merged with all valid
languages for admins — and then **discards it for non-admins** by returning
`LanguageService::getUserAllowedLanguages()` verbatim. That method resolves to
`Tool::getValidLanguages()` or to the configured language list, neither of which ever
contains `'default'`.

That single method feeds both directions:

* `handleNormalize()` / `getDetailData()` — values stored under `default` were stripped from
  the response, so the column rendered empty.
* `setStoreValues()` — a submitted `default` language was `continue`d over, so edits were
  silently dropped on save.

`getFieldInheritance()` and `getPreviewFieldData()` were affected the same way.

Note: the prior analysis on the ticket pointed at `DataObject\Service::enrichLayoutPermissions()`
in `pimcore/pimcore`. That turned out to be **wrong** — see "What was verified" below. No core
change is needed.

## What changed

`LanguageServiceInterface` gains `getUserAllowedLanguagesWithLanguageIndependentValue()`, and
`ClassificationStoreAdapter::getValidLanguages()` delegates the non-admin case to it. One
workspace-permission read answers both "which languages" and "is the language-independent
column included", so the hot search-preview path does not pay for a second lookup.

The semantics mirror the classic UI exactly — `enrichLayoutPermissions()` passes the
configured list straight through for a `classificationstore` field (it only strips `default`
for `localizedfields`, where `default` is not a column), and
`public/js/pimcore/object/tags/classificationstore.js` renders `permissionView` as-is when it
is set and `['default', ...websiteLanguages]` when it is not:

| configured `lView` / `lEdit` | resulting language list |
|---|---|
| not set / `NULL` / `''` (no restriction) | `default` + all valid languages |
| `'default'` | `default` only |
| `'default,de'` | `default`, `de` |
| `'de,en'` | `de`, `en` — **no `default`** |

Note the third row of that table is the reason `getUserAllowedLanguages()` could not simply be
reused: its `['default'] means unrestricted` shortcut is correct for localized fields but would
hand a Classification Store user every website language.

So this only restores access that was intended. A user whose language list explicitly leaves
the language-independent column out still does not get it, a user granted only that column gets
only that column, and admins are unchanged.

Also hoisted out of the group/language loops in `setStoreValues()`: the language resolution was
already being repeated per submitted group and language before this PR.

## Tests

* `tests/Unit/Security/Service/LanguageServiceTest.php` (new) — the full permission matrix
  above, plus the admin case and the invalid-permission guard.
* `tests/Unit/DataObject/Data/Adapter/ClassificationStoreAdapterTest.php` — two regression
  tests asserting a non-admin's `default` values are stored when the language list allows the
  language-independent column and skipped when it does not.

Verified red before / green after, including re-checking the final test shape against the
unmodified `src/`.

## What was verified

* Full `Unit` suite green locally (552 tests, 1237 assertions), PHPStan clean, php-cs-fixer
  clean on the touched files. Ran on host PHP 8.4 — the repo's `docker-compose.yml` bind mount
  is not usable in this environment, so the containerised run was **not** exercised; CI is the
  authority there (and is green).
* Classic UI semantics read directly from `admin-ui-classic-bundle` v2.3.x sources
  (`object/tags/classificationstore.js`, `settings/user/workspace/language.js`) and from
  `models/DataObject/Service.php` / `lib/Tool/Admin.php` on `2026.2`.
* Refuted: `DataObject\Service::enrichLayoutPermissions()` in `pimcore/pimcore` is **correct**
  for `classificationstore`. It passes the configured language list through
  `Admin::reorderWebsiteLanguages()`, which already keeps `'default'` and moves it to the front,
  and the classic UI honors that. The ticket's proposed fix (extending the
  `$layout->getFieldtype() === 'localizedfields'` guard to `classificationstore`) would have
  *stripped* `default` from `permissionView` and broken the classic Default tab for users who
  were explicitly granted it. Studio never reads the field definition's
  `permissionView`/`permissionEdit` at all — it drives language gating from
  `dataObject.permissions.localizedView`/`localizedEdit` — so no `pimcore/pimcore` change is
  needed for this issue.
* **Not** verified: no end-to-end run against a live instance (the local install's vendor
  symlinks point at other working copies).

## Sibling PR and merge order

1. **this PR** (`studio-backend-bundle`) — makes the data available.
2. pimcore/studio-ui-bundle#4032 — configuration (gap B) and display (gap C).

The UI PR is independently safe to merge, but the Default column only carries data once this
one is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
