### PR TITLE
[Perspectives] Admins are no longer restricted by an assigned perspective

### DIFF
--- a/src/User/Service/UserPerspectiveService.php
+++ b/src/User/Service/UserPerspectiveService.php
@@ -79,10 +79,6 @@ final readonly class UserPerspectiveService implements UserPerspectiveServiceInt
 
     public function getActivePerspective(UserInterface $user): string
     {
-        if ($user->isAdmin()) {
-            return Perspectives::DEFAULT_ID->value;
-        }
-
         $activePerspective = $this->repository->getUserActivePerspective($user->getId());
         $userPerspectives = $this->getAllUserPerspectives($user);
         if (empty($userPerspectives)) {

--- a/src/User/Service/UserPerspectiveService.php
+++ b/src/User/Service/UserPerspectiveService.php
@@ -79,6 +79,10 @@ final readonly class UserPerspectiveService implements UserPerspectiveServiceInt
 
     public function getActivePerspective(UserInterface $user): string
     {
+        if ($user->isAdmin()) {
+            return Perspectives::DEFAULT_ID->value;
+        }
+
         $activePerspective = $this->repository->getUserActivePerspective($user->getId());
         $userPerspectives = $this->getAllUserPerspectives($user);
         if (empty($userPerspectives)) {
@@ -139,6 +143,10 @@ final readonly class UserPerspectiveService implements UserPerspectiveServiceInt
 
     private function getAllUserPerspectives(UserInterface|UserRoleInterface $user): array
     {
+        if ($user instanceof UserInterface && $user->isAdmin()) {
+            return [];
+        }
+
         $userPerspectives = $this->repository->listUserPerspectives($user->getId());
         if (!$user instanceof UserInterface) {
             return $userPerspectives;

--- a/tests/Unit/User/Service/UserPerspectiveServiceTest.php
+++ b/tests/Unit/User/Service/UserPerspectiveServiceTest.php
@@ -63,21 +63,34 @@ final class UserPerspectiveServiceTest extends Unit
         $this->assertCount(1, $result);
     }
 
-    public function testSuperadminGetsDefaultActivePerspectiveDespiteStaleAssignment(): void
+    public function testAdminKeepsExplicitlySelectedActivePerspectiveOutsideStaleAssignment(): void
     {
         $user = $this->makeEmpty(UserInterface::class, [
             'getId' => 1,
             'isAdmin' => true,
         ]);
 
-        // Uses a real, still-configured perspective ID (one of the two in the mocked full set),
-        // not a fake one - otherwise this test would pass even without the isAdmin() bypass in
-        // getActivePerspective(), since a nonexistent stale ID can never match the full set either
-        // way and the bug would go unnoticed.
+        // 'other-perspective' is outside the stale assignment but inside the full set, so it is a
+        // perspective the admin is allowed to select - and their selection must survive the next
+        // application load instead of being reset.
         $service = $this->createService(
-            listUserPerspectives: ['other-perspective'],
+            listUserPerspectives: ['stale-perspective'],
             getUserActivePerspective: 'other-perspective',
         );
+
+        $result = $service->getActivePerspective($user);
+
+        $this->assertSame('other-perspective', $result);
+    }
+
+    public function testAdminWithoutSelectedActivePerspectiveGetsDefaultDespiteStaleAssignment(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+        ]);
+
+        $service = $this->createService(listUserPerspectives: ['stale-perspective']);
 
         $result = $service->getActivePerspective($user);
 
@@ -156,10 +169,7 @@ final class UserPerspectiveServiceTest extends Unit
             'getRoles' => [7],
         ]);
 
-        $service = $this->createService(
-            getUserActivePerspective: 'other-perspective',
-            perspectivesByRoleId: [7 => ['other-perspective']],
-        );
+        $service = $this->createService(perspectivesByRoleId: [7 => ['role-perspective']]);
 
         $result = $service->getActivePerspective($user);
 

--- a/tests/Unit/User/Service/UserPerspectiveServiceTest.php
+++ b/tests/Unit/User/Service/UserPerspectiveServiceTest.php
@@ -1,0 +1,215 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\User\Service;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Repository\PerspectiveConfigRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Service\PerspectiveServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
+use Pimcore\Bundle\StudioBackendBundle\User\Repository\PerspectiveRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveService;
+use Pimcore\Model\UserInterface;
+
+/**
+ * Regression coverage for the admin bypass of perspective restrictions: an admin bypasses every
+ * other permission check, so a perspective assignment that is still stored on the user record or
+ * inherited from one of the user's roles must not restrict them either.
+ *
+ * @internal
+ */
+final class UserPerspectiveServiceTest extends Unit
+{
+    public function testSuperadminGetsFullAllowedPerspectivesDespiteStaleAssignment(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+        ]);
+
+        // Stale data: the repository still reports one restrictive perspective for this user,
+        // as if it had been assigned before the promotion to Superadmin.
+        $service = $this->createService(listUserPerspectives: ['stale-perspective']);
+
+        $result = $service->getAllowedPerspectives($user);
+
+        $this->assertCount(2, $result);
+    }
+
+    public function testNonAdminGetsOnlyAssignedAllowedPerspectives(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => false,
+            'getRoles' => [],
+        ]);
+
+        $service = $this->createService(listUserPerspectives: ['my-perspective']);
+
+        $result = $service->getAllowedPerspectives($user);
+
+        $this->assertCount(1, $result);
+    }
+
+    public function testSuperadminGetsDefaultActivePerspectiveDespiteStaleAssignment(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+        ]);
+
+        // Uses a real, still-configured perspective ID (one of the two in the mocked full set),
+        // not a fake one - otherwise this test would pass even without the isAdmin() bypass in
+        // getActivePerspective(), since a nonexistent stale ID can never match the full set either
+        // way and the bug would go unnoticed.
+        $service = $this->createService(
+            listUserPerspectives: ['other-perspective'],
+            getUserActivePerspective: 'other-perspective',
+        );
+
+        $result = $service->getActivePerspective($user);
+
+        $this->assertSame(Perspectives::DEFAULT_ID->value, $result);
+    }
+
+    public function testValidatePerspectiveAccessAllowsSuperadminForAnyPerspective(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+        ]);
+
+        $service = $this->createService(listUserPerspectives: ['stale-perspective']);
+
+        // 'other-perspective' is one of the two IDs createService() wires up as the full,
+        // unrestricted set - i.e. a perspective outside the stale assignment.
+        $service->validatePerspectiveAccess($user, 'other-perspective');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidatePerspectiveAccessStillThrowsForNonAdminOutsideAssignedList(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => false,
+            'getRoles' => [],
+        ]);
+
+        $service = $this->createService(listUserPerspectives: ['my-perspective']);
+
+        $this->expectException(ForbiddenException::class);
+        $service->validatePerspectiveAccess($user, 'some-other-perspective');
+    }
+
+    public function testAdminGetsFullAllowedPerspectivesWhenRestrictionComesFromAssignedRole(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+            'getRoles' => [7],
+        ]);
+
+        // Nothing is stored on the user record itself - the restriction is inherited from the
+        // assigned role, which is what happens when a user is promoted to admin only afterwards.
+        $service = $this->createService(perspectivesByRoleId: [7 => ['role-perspective']]);
+
+        $result = $service->getAllowedPerspectives($user);
+
+        $this->assertSame(
+            [Perspectives::DEFAULT_ID->value, 'other-perspective'],
+            array_map(static fn (PerspectiveConfig $perspective) => $perspective->getId(), $result)
+        );
+    }
+
+    public function testNonAdminStaysRestrictedByPerspectiveInheritedFromAssignedRole(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => false,
+            'getRoles' => [7],
+        ]);
+
+        $service = $this->createService(perspectivesByRoleId: [7 => ['role-perspective']]);
+
+        $result = $service->getAllowedPerspectives($user);
+
+        $this->assertCount(1, $result);
+    }
+
+    public function testAdminGetsDefaultActivePerspectiveWhenRestrictionComesFromAssignedRole(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+            'getRoles' => [7],
+        ]);
+
+        $service = $this->createService(
+            getUserActivePerspective: 'other-perspective',
+            perspectivesByRoleId: [7 => ['other-perspective']],
+        );
+
+        $result = $service->getActivePerspective($user);
+
+        $this->assertSame(Perspectives::DEFAULT_ID->value, $result);
+    }
+
+    public function testValidatePerspectiveAccessAllowsAdminBeyondRoleInheritedPerspective(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+            'getRoles' => [7],
+        ]);
+
+        $service = $this->createService(perspectivesByRoleId: [7 => ['role-perspective']]);
+
+        $service->validatePerspectiveAccess($user, 'other-perspective');
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @param array<int, string[]> $perspectivesByRoleId
+     */
+    private function createService(
+        array $listUserPerspectives = [],
+        ?string $getUserActivePerspective = null,
+        array $perspectivesByRoleId = [],
+    ): UserPerspectiveService {
+        $repository = $this->makeEmpty(PerspectiveRepositoryInterface::class, [
+            'listUserPerspectives' => static fn (int $userOrRoleId): array => $perspectivesByRoleId[$userOrRoleId]
+                ?? $listUserPerspectives,
+            'getUserActivePerspective' => $getUserActivePerspective,
+        ]);
+
+        $configRepository = $this->makeEmpty(PerspectiveConfigRepositoryInterface::class, [
+            'getConfiguration' => [],
+        ]);
+
+        $defaultPerspective = $this->makeEmpty(PerspectiveConfig::class, [
+            'getId' => Perspectives::DEFAULT_ID->value,
+        ]);
+        $otherPerspective = $this->makeEmpty(PerspectiveConfig::class, [
+            'getId' => 'other-perspective',
+        ]);
+
+        $perspectiveService = $this->makeEmpty(PerspectiveServiceInterface::class, [
+            'hydrateListEntry' => $defaultPerspective,
+            'listConfigurations' => [$otherPerspective],
+        ]);
+
+        return new UserPerspectiveService($repository, $configRepository, $perspectiveService);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/pimcore/studio-ui-bundle/issues/3615

## Why this targets `2025.4` and not `2026.2`

`2026.2` **already carries a fix for this** — it landed there with #1971 (2026-07-29) and is absent
from `2025.4`, the oldest maintained line and the line the issue was reported against. Per the
forward-merge rule a fix belongs on the oldest applicable branch, so this PR lands it on `2025.4`
and it reaches `2026.2` / `2026.x` through the regular forward merge.

One deliberate difference from `2026.2`: this PR does **not** include #1971's second guard, the
unconditional `getActivePerspective()` → default for admins. See "The `getActivePerspective()`
override" below — that guard resets an admin's own perspective selection on every application
load, so `2026.2` should drop it as well (follow-up, not this PR). Because of that, the forward
merge of `src/User/Service/UserPerspectiveService.php` and of the test file will conflict; resolve
both by **taking this side**.

## Root cause

`UserPerspectiveService::getAllUserPerspectives()` resolved the perspective restriction purely from
the stored assignment — the union of the perspectives on the user record and the perspectives of
every role assigned to the user — with no `isAdmin()` short-circuit, even though an admin bypasses
every other permission check. Its three call sites (`getAllowedPerspectives()`,
`getActivePerspective()`, `validatePerspectiveAccess()`) treat an *empty* list as "unrestricted",
so a user promoted to admin after a perspective had been assigned still produced a non-empty list
and stayed restricted to it: the switcher offered only that one perspective, and switching to any
other was rejected with `ForbiddenException`.

That is exactly why the reported symptom is "the menu respects admin, but only the single
role-assigned perspective is offered": the menu is permission-driven and
`Pimcore\Model\User::isAllowed()` short-circuits for admins, while the switcher is fed by
`GET /user/current-information` → `UserInformationHydrator` → `getAllowedPerspectives()`.

The classic admin UI is correct for the same scenario because
`Pimcore\Bundle\AdminBundle\Perspective\Config::getAvailablePerspectives()` opens with
`if ($user->isAdmin()) { $config = self::get(); }` — the full set. This change mirrors that.

## What changed

`src/User/Service/UserPerspectiveService.php` (+4): `getAllUserPerspectives()` returns `[]` for an
admin, so the existing "empty means unrestricted" fallback in all three call sites applies.

No signature, return type or service id changed; it is one guard clause in an `@internal` service,
so there is no BC impact.

### The `getActivePerspective()` override

`2026.2` additionally returns the default perspective unconditionally for admins. That is a
regression and is intentionally left out here: `PUT /user/active-perspective/{perspectiveId}`
persists a switch, and `app-loader.tsx` reads `user.activePerspective` (i.e. `getActivePerspective()`)
on every application load — so an admin's selection would be discarded on every reload.

It is also unnecessary. Once an admin is reported as unrestricted, the validity domain inside
`getActivePerspective()` becomes the full perspective set, which means:

* a perspective the admin explicitly selected is honoured;
* a stale stored value that is no longer configured falls back to the default perspective;
* in the reported scenario nothing was ever selected, so the admin lands on the default
  perspective anyway.

Again the same semantics as classic, where `getRuntimePerspective()` honours the stored active
perspective and only the *available* set is widened for admins.

## Tests

`tests/Unit/User/Service/UserPerspectiveServiceTest.php` — 10 unit tests. Four cover the exact
reproduction path from the issue (restriction inherited from an assigned **role**, user promoted to
admin afterwards):

* `testAdminGetsFullAllowedPerspectivesWhenRestrictionComesFromAssignedRole`
* `testAdminGetsDefaultActivePerspectiveWhenRestrictionComesFromAssignedRole`
* `testValidatePerspectiveAccessAllowsAdminBeyondRoleInheritedPerspective`
* `testNonAdminStaysRestrictedByPerspectiveInheritedFromAssignedRole` (guards the bypass against
  over-reaching)

and `testAdminKeepsExplicitlySelectedActivePerspectiveOutsideStaleAssignment` pins the
active-perspective behaviour described above.

## Verified

Run in the repo's `docker-compose.yml` PHP container:

* **Before the `src/` change** (tests only): `Tests: 10, Assertions: 3, Errors: 2, Failures: 5` —
  every admin case fails, the three non-admin baselines pass.
* **After**: `OK (10 tests, 10 assertions)` for the file, `OK (479 tests, 1062 assertions)` for the
  whole unit suite.
* `vendor/bin/phpstan analyse` → `[OK] No errors`.
* `php-cs-fixer fix --dry-run --diff --allow-risky=yes` on both touched files →
  `Found 0 of 2 files that can be fixed`.

Additionally reproduced the resolution chain against a real installation (real `Pimcore\Model\User`
with `admin` toggled, real `PerspectiveConfigRepository` reading the installed perspectives, a role
carrying one restrictive perspective): non-admin → 1 perspective and `activePerspective` = the
restrictive one; admin → all 7 perspectives and `activePerspective` = `studio_default_perspective`.

**Not verified:** no browser/end-to-end check of the Studio perspective switcher, and the
functional/API suites were not run locally — CI covers those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
