### PR TITLE
Fix: stale Perspective no longer restricts Superadmin (2025.4)

### DIFF
--- a/src/User/Service/UserPerspectiveService.php
+++ b/src/User/Service/UserPerspectiveService.php
@@ -79,6 +79,10 @@ final readonly class UserPerspectiveService implements UserPerspectiveServiceInt
 
     public function getActivePerspective(UserInterface $user): string
     {
+        if ($user->isAdmin()) {
+            return Perspectives::DEFAULT_ID->value;
+        }
+
         $activePerspective = $this->repository->getUserActivePerspective($user->getId());
         $userPerspectives = $this->getAllUserPerspectives($user);
         if (empty($userPerspectives)) {
@@ -139,6 +143,10 @@ final readonly class UserPerspectiveService implements UserPerspectiveServiceInt
 
     private function getAllUserPerspectives(UserInterface|UserRoleInterface $user): array
     {
+        if ($user instanceof UserInterface && $user->isAdmin()) {
+            return [];
+        }
+
         $userPerspectives = $this->repository->listUserPerspectives($user->getId());
         if (!$user instanceof UserInterface) {
             return $userPerspectives;

--- a/tests/Unit/User/Service/UserPerspectiveServiceTest.php
+++ b/tests/Unit/User/Service/UserPerspectiveServiceTest.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\User\Service;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\Exception\Api\ForbiddenException;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Repository\PerspectiveConfigRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Schema\PerspectiveConfig;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Service\PerspectiveServiceInterface;
+use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\Perspectives;
+use Pimcore\Bundle\StudioBackendBundle\User\Repository\PerspectiveRepositoryInterface;
+use Pimcore\Bundle\StudioBackendBundle\User\Service\UserPerspectiveService;
+use Pimcore\Model\UserInterface;
+
+/**
+ * Regression coverage for PEES-1390 / GitHub pimcore/platform-version#253:
+ * a Superadmin who still has a stale, non-empty perspective assignment stored on their
+ * user record must not be restricted by it, since Superadmins bypass all permission checks.
+ *
+ * @internal
+ */
+final class UserPerspectiveServiceTest extends Unit
+{
+    public function testSuperadminGetsFullAllowedPerspectivesDespiteStaleAssignment(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+        ]);
+
+        // Stale data: the repository still reports one restrictive perspective for this user,
+        // as if it had been assigned before the promotion to Superadmin.
+        $service = $this->createService(listUserPerspectives: ['stale-perspective']);
+
+        $result = $service->getAllowedPerspectives($user);
+
+        $this->assertCount(2, $result);
+    }
+
+    public function testNonAdminGetsOnlyAssignedAllowedPerspectives(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => false,
+            'getRoles' => [],
+        ]);
+
+        $service = $this->createService(listUserPerspectives: ['my-perspective']);
+
+        $result = $service->getAllowedPerspectives($user);
+
+        $this->assertCount(1, $result);
+    }
+
+    public function testSuperadminGetsDefaultActivePerspectiveDespiteStaleAssignment(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+        ]);
+
+        // Uses a real, still-configured perspective ID (one of the two in the mocked full set),
+        // not a fake one - otherwise this test would pass even without the isAdmin() bypass in
+        // getActivePerspective(), since a nonexistent stale ID can never match the full set either
+        // way and the bug would go unnoticed.
+        $service = $this->createService(
+            listUserPerspectives: ['other-perspective'],
+            getUserActivePerspective: 'other-perspective',
+        );
+
+        $result = $service->getActivePerspective($user);
+
+        $this->assertSame(Perspectives::DEFAULT_ID->value, $result);
+    }
+
+    public function testValidatePerspectiveAccessAllowsSuperadminForAnyPerspective(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => true,
+        ]);
+
+        $service = $this->createService(listUserPerspectives: ['stale-perspective']);
+
+        // 'other-perspective' is one of the two IDs createService() wires up as the full,
+        // unrestricted set - i.e. a perspective outside the stale assignment.
+        $service->validatePerspectiveAccess($user, 'other-perspective');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidatePerspectiveAccessStillThrowsForNonAdminOutsideAssignedList(): void
+    {
+        $user = $this->makeEmpty(UserInterface::class, [
+            'getId' => 1,
+            'isAdmin' => false,
+            'getRoles' => [],
+        ]);
+
+        $service = $this->createService(listUserPerspectives: ['my-perspective']);
+
+        $this->expectException(ForbiddenException::class);
+        $service->validatePerspectiveAccess($user, 'some-other-perspective');
+    }
+
+    private function createService(
+        array $listUserPerspectives = [],
+        ?string $getUserActivePerspective = null,
+    ): UserPerspectiveService {
+        $repository = $this->makeEmpty(PerspectiveRepositoryInterface::class, [
+            'listUserPerspectives' => $listUserPerspectives,
+            'getUserActivePerspective' => $getUserActivePerspective,
+        ]);
+
+        $configRepository = $this->makeEmpty(PerspectiveConfigRepositoryInterface::class, [
+            'getConfiguration' => [],
+        ]);
+
+        $defaultPerspective = $this->makeEmpty(PerspectiveConfig::class, [
+            'getId' => Perspectives::DEFAULT_ID->value,
+        ]);
+        $otherPerspective = $this->makeEmpty(PerspectiveConfig::class, [
+            'getId' => 'other-perspective',
+        ]);
+
+        $perspectiveService = $this->makeEmpty(PerspectiveServiceInterface::class, [
+            'hydrateListEntry' => $defaultPerspective,
+            'listConfigurations' => [$otherPerspective],
+        ]);
+
+        return new UserPerspectiveService($repository, $configRepository, $perspectiveService);
+    }
+}


### PR DESCRIPTION
Cherry-pick of #1971 onto `2025.4`.

Related issue: https://github.com/pimcore/studio-ui-bundle/issues/3615 (reported on 2025.4)

## Why

`#1971` fixed this on `2026.2` only. `2025.4` is still affected and is actively maintained, so it never received the fix — and `2025.4` forward-merges into `2026.2`, so landing it here keeps the lines consistent instead of divergent.

## What

Cherry-picked verbatim (`6d00c8fa`), no adaptation needed — the commit applied cleanly and the resulting `UserPerspectiveService.php` is **byte-identical to `2026.2`'s** (blob `b7820485`).

- `getAllUserPerspectives()` short-circuits to an empty list for admins; the existing "empty means unrestricted" fallback in all three call sites handles the rest.
- `getActivePerspective()` returns the default perspective for admins, so a stale stored active value cannot keep them on the old restrictive view.

## Test

Brings across `tests/Unit/User/Service/UserPerspectiveServiceTest.php` (143 lines) from `#1971`. The file did not exist on `2025.4`, so it lands as a clean add.

## Verified / not verified

- Cherry-pick applied with **no conflicts**; diff is +151 lines across 2 files, nothing beyond the upstream commit.
- `php -l` clean on both files.
- **Not** run locally: Codeception and PHPStan — this branch has no `vendor/`. Relying on CI.

## Note for reviewers

`getActivePerspective()`'s unconditional admin short-circuit discards a perspective an admin explicitly selected (it is re-read on every application load), so an admin's own choice does not persist. That behaviour is **already live on `2026.2`** via `#1971`; this PR deliberately does not diverge from it. Worth addressing on both lines together in a follow-up rather than only here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)