### PR TITLE
Allow patching a multiselect to empty

### DIFF
--- a/src/DataObject/Data/Adapter/MultiSelectAdapter.php
+++ b/src/DataObject/Data/Adapter/MultiSelectAdapter.php
@@ -59,7 +59,7 @@ final readonly class MultiSelectAdapter implements SetterDataInterface
         string $key,
         array $newData,
         ?FieldContextData $contextData = null
-    ): array {
+    ): ?array {
         $action = $newData[PatchDataKeys::ACTION->value];
         $fieldData = $newData[PatchDataKeys::DATA->value];
         if ($action === null || $action === PatcherActions::REPLACE->value) {

--- a/tests/Unit/DataObject/Data/Adapter/MultiSelectAdapterTest.php
+++ b/tests/Unit/DataObject/Data/Adapter/MultiSelectAdapterTest.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DataObject\Data\Adapter;
+
+use Codeception\Test\Unit;
+use Exception;
+use Pimcore\Bundle\StudioBackendBundle\DataObject\Data\Adapter\MultiSelectAdapter;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Multiselect;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\UserInterface;
+
+/**
+ * @internal
+ */
+final class MultiSelectAdapterTest extends Unit
+{
+    /**
+     * Regression test: a replace patch with data null clears the field instead of throwing.
+     *
+     * @throws Exception
+     */
+    public function testPatchReplaceWithNullReturnsNull(): void
+    {
+        $this->assertNull($this->callAdapter(['color' => ['action' => 'replace', 'data' => null]]));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testPatchReplaceWithValuesReturnsValues(): void
+    {
+        $result = $this->callAdapter(['color' => ['action' => 'replace', 'data' => ['red', 'green']]]);
+
+        $this->assertSame(['red', 'green'], $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataForSetterReturnsNullWhenValueIsNotAnArray(): void
+    {
+        $this->assertNull($this->callAdapter(['color' => null]));
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function callAdapter(array $data): ?array
+    {
+        $adapter = new MultiSelectAdapter();
+
+        return $adapter->getDataForSetter(
+            $this->makeEmpty(Concrete::class),
+            $this->makeEmpty(Multiselect::class),
+            'color',
+            $data,
+            $this->makeEmpty(UserInterface::class),
+            isPatch: true
+        );
+    }
+}


### PR DESCRIPTION
Because clearing a multiselect through a merge is a legal operation the core adapter's type signature forbade.

**What the merge sent:** object 333's `color` is empty; you chose to pull that side over, so the merger saved `color: { action: 'replace', data: null }` — "replace the target's value with nothing", i.e. clear the field. That's the correct payload for this merge, not a frontend bug.

**Where it exploded:** `MultiSelectAdapter::handlePatch` handles `replace` by returning the payload's `data` verbatim — but its return type was declared `array`, so `data: null` throws a `TypeError` and the whole PATCH 500s (MultiSelectAdapter.php:66).

**Why widening to `?array` is the right fix, not a workaround:** the caller already supports null — `PatchService::patchEditableData` passes the adapter's return straight into `$element->setValue($key, $value)` with no null check, and `setValue(key, null)` is Pimcore's normal "clear this field". The add/remove paths in the same adapter also cope with null existing values. Only the `replace` path's signature was narrower than its own contract. One character (`?`) restores it.

### Verified

- Reproduced via the object merger (embedded in the backend-power-tools compare & merge wizard): merging an object with an empty multiselect over one with values 500ed; with this change the PATCH clears the field.
- Regression test added (`MultiSelectAdapterTest`, following the `NumericRangeAdapterTest` pattern): replace with `data: null` returns null, replace with values returns them, non-array input returns null. 3/3 green locally via `vendor/bin/codecept run Unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
