### PR TITLE
[BUG] Grid export: allow specifying the download file name

### DIFF
--- a/src/ExecutionEngine/Util/StepConfig.php
+++ b/src/ExecutionEngine/Util/StepConfig.php
@@ -37,6 +37,7 @@ enum StepConfig: string
     case CONFIG_COLUMNS = 'columns';
     case CONFIG_FILTERS = 'filters';
     case SETTINGS_DELIMITER = 'delimiter';
+    case SETTINGS_FILE_NAME = 'fileName';
     case SETTINGS_HEADER = 'header';
     case SETTINGS_HEADER_NO_HEADER = 'no_header';
     case SETTINGS_HEADER_TITLE = 'title';

--- a/src/Export/Attribute/Request/ExportDataRequestBody.php
+++ b/src/Export/Attribute/Request/ExportDataRequestBody.php
@@ -45,6 +45,12 @@ final class ExportDataRequestBody extends RequestBody
                 example: ';'
             );
         }
+        $configProperties[] = new Property(
+            property: StepConfig::SETTINGS_FILE_NAME->value,
+            type: 'string',
+            example: 'my-grid-export.csv',
+            nullable: true
+        );
         parent::__construct(
             content: new JsonContent(
                 properties: [

--- a/src/Export/Attribute/Request/ExportDataRequestBody.php
+++ b/src/Export/Attribute/Request/ExportDataRequestBody.php
@@ -34,7 +34,11 @@ final class ExportDataRequestBody extends RequestBody
             new Property(
                 property: StepConfig::SETTINGS_HEADER->value,
                 type: 'string',
-                enum: StepConfig::values(),
+                enum: [
+                    StepConfig::SETTINGS_HEADER_NO_HEADER->value,
+                    StepConfig::SETTINGS_HEADER_TITLE->value,
+                    StepConfig::SETTINGS_HEADER_NAME->value,
+                ],
                 example: StepConfig::SETTINGS_HEADER_TITLE->value
             ),
         ];
@@ -48,7 +52,7 @@ final class ExportDataRequestBody extends RequestBody
         $configProperties[] = new Property(
             property: StepConfig::SETTINGS_FILE_NAME->value,
             type: 'string',
-            example: 'my-grid-export.csv',
+            example: $addDelimiter ? 'my-grid-export.csv' : 'my-grid-export.xlsx',
             nullable: true
         );
         parent::__construct(

--- a/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
+++ b/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
@@ -46,6 +46,12 @@ final class ExportFolderDataRequestBody extends RequestBody
                 example: ';'
             );
         }
+        $configProperties[] = new Property(
+            property: StepConfig::SETTINGS_FILE_NAME->value,
+            type: 'string',
+            example: 'my-grid-export.csv',
+            nullable: true
+        );
 
         parent::__construct(
             content: new JsonContent(

--- a/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
+++ b/src/Export/Attribute/Request/ExportFolderDataRequestBody.php
@@ -35,7 +35,11 @@ final class ExportFolderDataRequestBody extends RequestBody
             new Property(
                 property: StepConfig::SETTINGS_HEADER->value,
                 type: 'string',
-                enum: StepConfig::values(),
+                enum: [
+                    StepConfig::SETTINGS_HEADER_NO_HEADER->value,
+                    StepConfig::SETTINGS_HEADER_TITLE->value,
+                    StepConfig::SETTINGS_HEADER_NAME->value,
+                ],
                 example: StepConfig::SETTINGS_HEADER_TITLE->value
             ),
         ];
@@ -49,7 +53,7 @@ final class ExportFolderDataRequestBody extends RequestBody
         $configProperties[] = new Property(
             property: StepConfig::SETTINGS_FILE_NAME->value,
             type: 'string',
-            example: 'my-grid-export.csv',
+            example: $addDelimiter ? 'my-grid-export.csv' : 'my-grid-export.xlsx',
             nullable: true
         );
 

--- a/src/Export/Service/DownloadService.php
+++ b/src/Export/Service/DownloadService.php
@@ -62,9 +62,9 @@ final readonly class DownloadService implements DownloadServiceInterface
     ): StreamedResponse {
         $this->executionEngineService->validateJobRun($jobRunId);
 
-        if ($downloadName === null) {
-            $downloadName = $this->resolveDownloadName($jobRunId);
-        }
+        $downloadName = $this->resolveDownloadName($jobRunId)
+            ?? $downloadName
+            ?? DownloadDefaults::DEFAULT_ZIP_FILENAME->value;
 
         $fileName = $this->getTempFileName($jobRunId, $tempFileName);
         $folderName = $this->getTempFileName($jobRunId, $tempFolderName);
@@ -157,16 +157,17 @@ final readonly class DownloadService implements DownloadServiceInterface
         return $response;
     }
 
-    private function resolveDownloadName(int $jobRunId): string
+    private function resolveDownloadName(int $jobRunId): ?string
     {
         try {
             $jobRun = $this->jobRunRepository->getJobRunById($jobRunId);
             $environmentData = $jobRun->getJob()?->getEnvironmentData() ?? [];
 
-            return $environmentData[ZipServiceInterface::ZIP_DOWNLOAD_FILENAME] ??
-                DownloadDefaults::DEFAULT_ZIP_FILENAME->value;
+            return $environmentData[DownloadServiceInterface::EXPORT_DOWNLOAD_FILENAME] ??
+                $environmentData[ZipServiceInterface::ZIP_DOWNLOAD_FILENAME] ??
+                null;
         } catch (Exception) {
-            return DownloadDefaults::DEFAULT_ZIP_FILENAME->value;
+            return null;
         }
     }
 

--- a/src/Export/Service/DownloadServiceInterface.php
+++ b/src/Export/Service/DownloadServiceInterface.php
@@ -25,6 +25,8 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 interface DownloadServiceInterface
 {
+    public const EXPORT_DOWNLOAD_FILENAME = 'export_download_filename';
+
     /**
      * @throws EnvironmentException|ForbiddenException|NotFoundException|StreamResourceNotFoundException
      */

--- a/src/Export/Service/ExecutionEngine/ExportService.php
+++ b/src/Export/Service/ExecutionEngine/ExportService.php
@@ -30,11 +30,15 @@ use Pimcore\Bundle\StudioBackendBundle\Export\ExecutionEngine\AutomationAction\M
 use Pimcore\Bundle\StudioBackendBundle\Export\ExecutionEngine\Util\JobSteps;
 use Pimcore\Bundle\StudioBackendBundle\Export\MappedParameter\ExportFolderParameter;
 use Pimcore\Bundle\StudioBackendBundle\Export\MappedParameter\ExportParameter;
+use Pimcore\Bundle\StudioBackendBundle\Export\Service\DownloadServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Export\Util\Constant\ExportFormat;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\SecurityServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Pimcore\Model\Element\ElementDescriptor;
 use Pimcore\Model\UserInterface;
+use function basename;
+use function is_string;
+use function trim;
 
 /**
  * @internal
@@ -91,7 +95,12 @@ final readonly class ExportService implements ExportServiceInterface
             $user = $this->securityService->getCurrentUser();
         }
 
-        return $this->generateExportFileJob($jobSteps, $exportFormat, $user->getId());
+        return $this->generateExportFileJob(
+            $jobSteps,
+            $exportFormat,
+            $user->getId(),
+            downloadFileName: $this->getDownloadFileName($exportParameter->getConfig())
+        );
     }
 
     /**
@@ -127,7 +136,8 @@ final readonly class ExportService implements ExportServiceInterface
             $exportFormat,
             $this->securityService->getCurrentUser()->getId(),
             [new ElementDescriptor($elementType, $folderId)],
-            true
+            true,
+            $this->getDownloadFileName($exportParameter->getConfig())
         );
     }
 
@@ -136,7 +146,8 @@ final readonly class ExportService implements ExportServiceInterface
         string $exportFormat,
         int $ownerId,
         array $selectedElements = [],
-        bool $isFolder = false
+        bool $isFolder = false,
+        ?string $downloadFileName = null
     ): int {
         $name = $this->createJobNameByFormat($exportFormat);
         if ($isFolder) {
@@ -145,13 +156,30 @@ final readonly class ExportService implements ExportServiceInterface
                 : Jobs::COLLECT_CSV_FOLDER_EXPORT_ELEMENTS->value;
         }
 
+        $environmentData = [];
+        if ($downloadFileName !== null) {
+            $environmentData[DownloadServiceInterface::EXPORT_DOWNLOAD_FILENAME] = $downloadFileName;
+        }
+
         $jobRun = $this->jobExecutionAgent->startJobExecution(
-            new Job($name, $jobSteps, $selectedElements),
+            new Job($name, $jobSteps, $selectedElements, $environmentData),
             $ownerId,
             Config::CONTEXT_STOP_ON_ERROR->value
         );
 
         return $jobRun->getId();
+    }
+
+    private function getDownloadFileName(array $config): ?string
+    {
+        $fileName = $config[StepConfig::SETTINGS_FILE_NAME->value] ?? null;
+        if (!is_string($fileName) || trim($fileName) === '') {
+            return null;
+        }
+
+        $fileName = preg_replace('/[^\w\-. ]/', '_', basename(trim($fileName)));
+
+        return $fileName === '' ? null : $fileName;
     }
 
     private function mapJobSteps(

--- a/tests/Unit/Export/Service/DownloadServiceTest.php
+++ b/tests/Unit/Export/Service/DownloadServiceTest.php
@@ -27,6 +27,7 @@ use Pimcore\Bundle\StudioBackendBundle\Element\Service\StorageServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Exception\Api\EnvironmentException;
 use Pimcore\Bundle\StudioBackendBundle\ExecutionEngine\Service\ExecutionEngineServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Export\Service\DownloadService;
+use Pimcore\Bundle\StudioBackendBundle\Export\Service\DownloadServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\Asset\MimeTypes;
 use Pimcore\Bundle\StudioBackendBundle\Util\Constant\HttpResponseHeaders;
 use Psr\Log\LoggerInterface;
@@ -449,6 +450,106 @@ final class DownloadServiceTest extends Unit
 
         $this->assertSame(
             'attachment; filename="my-folder.zip"',
+            $response->headers->get('Content-Disposition'),
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testExportDownloadNameOverridesZipMetadataAndControllerFallback(): void
+    {
+        $stream = fopen('php://memory', 'rb+');
+        fwrite($stream, 'data');
+        rewind($stream);
+
+        $storage = $this->makeEmpty(FilesystemOperator::class, [
+            'readStream' => $stream,
+            'fileSize' => 4,
+        ]);
+
+        $job = new Job(
+            name: 'test-job',
+            steps: [new JobStep('step', 'SomeMessage', '', [])],
+            environmentData: [
+                DownloadServiceInterface::EXPORT_DOWNLOAD_FILENAME => 'Product_2026-09-01_14-32-10.csv',
+                ZipServiceInterface::ZIP_DOWNLOAD_FILENAME => 'my-folder.zip',
+            ],
+        );
+
+        $jobRun = $this->makeEmpty(JobRun::class, [
+            'getJob' => $job,
+        ]);
+
+        $service = $this->createService(
+            storageService: $this->makeEmpty(StorageServiceInterface::class, [
+                'getTempStorage' => $storage,
+                'tempFileExists' => true,
+            ]),
+            jobRunRepository: $this->makeEmpty(JobRunRepositoryInterface::class, [
+                'getJobRunById' => $jobRun,
+            ]),
+        );
+
+        $response = $service->downloadResourceByJobRunId(
+            jobRunId: 1,
+            tempFileName: 'download-csv-{id}.csv',
+            tempFolderName: 'download-csv-{id}',
+            mimeType: 'text/csv',
+            downloadName: 'export.csv',
+        );
+
+        $this->assertSame(
+            'attachment; filename="Product_2026-09-01_14-32-10.csv"',
+            $response->headers->get('Content-Disposition'),
+            'The export file name from the job environment data must override both the ZIP metadata and the controller-provided fallback'
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testControllerFallbackUsedWhenNoExportDownloadName(): void
+    {
+        $stream = fopen('php://memory', 'rb+');
+        fwrite($stream, 'data');
+        rewind($stream);
+
+        $storage = $this->makeEmpty(FilesystemOperator::class, [
+            'readStream' => $stream,
+            'fileSize' => 4,
+        ]);
+
+        $job = new Job(
+            name: 'test-job',
+            steps: [new JobStep('step', 'SomeMessage', '', [])],
+            environmentData: [],
+        );
+
+        $jobRun = $this->makeEmpty(JobRun::class, [
+            'getJob' => $job,
+        ]);
+
+        $service = $this->createService(
+            storageService: $this->makeEmpty(StorageServiceInterface::class, [
+                'getTempStorage' => $storage,
+                'tempFileExists' => true,
+            ]),
+            jobRunRepository: $this->makeEmpty(JobRunRepositoryInterface::class, [
+                'getJobRunById' => $jobRun,
+            ]),
+        );
+
+        $response = $service->downloadResourceByJobRunId(
+            jobRunId: 1,
+            tempFileName: 'download-csv-{id}.csv',
+            tempFolderName: 'download-csv-{id}',
+            mimeType: 'text/csv',
+            downloadName: 'export.csv',
+        );
+
+        $this->assertSame(
+            'attachment; filename="export.csv"',
             $response->headers->get('Content-Disposition'),
         );
     }


### PR DESCRIPTION
### What

Allows grid CSV/XLSX exports to specify the download file name.

- New `StepConfig::SETTINGS_FILE_NAME` (`fileName`) config key, documented in the OpenAPI request schemas for element and folder exports.
- `ExportService` reads `config.fileName`, sanitizes it (basename, restricted character set), and stores it in the job's environment data under a new `DownloadServiceInterface::EXPORT_DOWNLOAD_FILENAME` key — the same mechanism ZIP downloads already use.
- `DownloadService::resolveDownloadName()` now resolves the export file name first, then the ZIP file name, and falls back to the name passed by the controller (`export.csv` / `export.xlsx`), so existing behavior is unchanged when no file name is provided.

### Why

Grid export downloads were always named `export.csv` / `export.xlsx`, making it hard to tell which grid an export came from. With this change the Studio UI sends a grid name + timestamp file name (see the companion studio-ui-bundle PR), e.g. `Product_2026-09-01_14-32-10.csv`.

Closes https://github.com/pimcore/platform-version/issues/437
