### PR TITLE
[MCP] Resolve the token audience from the endpoint's owner

### DIFF
--- a/config/oauth.yaml
+++ b/config/oauth.yaml
@@ -51,6 +51,16 @@ services:
         arguments:
             $enabled: false
 
+    # Resolves which registered protected resource a request addresses, so the
+    # audience comes from the endpoint's owner rather than a path hardcoded here.
+    # $issuer is set from config in the extension.
+    Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver\RequestResourceResolver:
+        arguments:
+            $issuer: null
+
+    Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver\RequestResourceResolverInterface:
+        alias: Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver\RequestResourceResolver
+
     # Entry point for the pimcore_mcp firewall (401 + RFC 9728 challenge).
     # $oauthEnabled is set from config in the extension.
     Pimcore\Bundle\StudioBackendBundle\Security\EntryPoint\McpAuthenticationEntryPoint:

--- a/doc/02_Installation_and_Configuration/06_OAuth_Server.md
+++ b/doc/02_Installation_and_Configuration/06_OAuth_Server.md
@@ -58,8 +58,15 @@ pimcore_studio_backend:
 The `issuer` must be the **public** URL clients use — behind a reverse proxy set it to the external
 address (`https://studio.acme.com`), not the internal upstream (`http://php:9000`). Locally it is
 `http://localhost` (or `http://localhost:8080` with a port). Keep it **stable**: changing it re-keys
-every protected resource and invalidates the `iss` on tokens already issued. To vary it per
-environment, drive it from an env var:
+every protected resource and invalidates the `iss` on tokens already issued.
+
+> **Give it a bare origin** — scheme + host, optionally a port, and nothing else. A trailing slash or
+> a path produces malformed protected-resource URIs, and a **query or fragment silently collapses every
+> MCP server onto the same token audience**, defeating the per-server isolation audience binding exists
+> to provide. The value is not shape-validated, so a wrong one fails at first use rather than at
+> container build.
+
+To vary it per environment, drive it from an env var:
 
 ```yaml
 pimcore_studio_backend:

--- a/doc/02_Installation_and_Configuration/06_OAuth_Server.md
+++ b/doc/02_Installation_and_Configuration/06_OAuth_Server.md
@@ -42,8 +42,9 @@ The minimum configuration is the master switch, an issuer, and signing keys:
 pimcore_studio_backend:
     oauth:
         enabled: true
-        # Issuer identifier advertised in metadata and stamped on tokens.
-        # If null, it is derived from the incoming request — set it explicitly in production.
+        # Required when enabled: the public base URL clients reach this instance at.
+        # It is advertised as the issuer (iss), stamped on tokens, and used as the base
+        # for protected-resource URIs. Scheme + host [+ port], no trailing slash, no path.
         issuer: 'https://pimcore.example.com'
         keys:
             private_key: '%env(OAUTH_PRIVATE_KEY)%'
@@ -53,6 +54,19 @@ pimcore_studio_backend:
 ```
 
 > Reference key material via environment variables or Symfony secrets. **Never commit keys.**
+
+The `issuer` must be the **public** URL clients use — behind a reverse proxy set it to the external
+address (`https://studio.acme.com`), not the internal upstream (`http://php:9000`). Locally it is
+`http://localhost` (or `http://localhost:8080` with a port). Keep it **stable**: changing it re-keys
+every protected resource and invalidates the `iss` on tokens already issued. To vary it per
+environment, drive it from an env var:
+
+```yaml
+pimcore_studio_backend:
+    oauth:
+        enabled: true
+        issuer: '%env(PIMCORE_OAUTH_ISSUER)%'   # e.g. https://studio.acme.com
+```
 
 ### Generating keys
 
@@ -196,7 +210,7 @@ All keys live under `pimcore_studio_backend.oauth`.
 | Key | Default | Purpose |
 |-----|---------|---------|
 | `enabled` | `false` | Master switch for the embedded authorization server. |
-| `issuer` | `null` | Issuer (`iss`) advertised in metadata and stamped on tokens. Null derives it from the request. |
+| `issuer` | `null` | Public base URL (`scheme://host[:port]`), advertised as `iss`, stamped on tokens, and the base for protected-resource URIs. **Required when `enabled` is `true`** (config validation fails otherwise). |
 | `access_token_ttl` | `3600` | Access-token lifetime (seconds). |
 | `auth_code_ttl` | `600` | Authorization-code lifetime (seconds). |
 | `refresh_token_ttl` | `2592000` | Refresh-token lifetime (seconds). |

--- a/doc/04_Development_Details/08_MCP_Server.md
+++ b/doc/04_Development_Details/08_MCP_Server.md
@@ -67,6 +67,16 @@ server](../02_Installation_and_Configuration/06_OAuth_Server.md) (`Authorization
 signature and audience and resolves the Pimcore user. On failure it returns `null`, so `PatAuthenticator` still
 runs — hence it must precede it in the chain.
 
+The audience it validates against is **the protected resource registered for the endpoint being called**, not a
+path this bundle derives. The endpoints behind this firewall belong to different bundles, so the most specific
+registered resource covering the request is what the token is held to, and the URI is built from the configured
+issuer when one is set.
+
+That makes registration the switch: an endpoint whose owner registers no protected resource does not accept
+OAuth, and the authenticator declines so the rest of the chain still runs. Every other credential on such an
+endpoint keeps working unchanged. Servers managed through
+[MCP Server Management](./09_MCP_Server_Management.md) register themselves, so nothing extra is needed for them.
+
 See [OAuth 2.1 Authorization Server](../02_Installation_and_Configuration/06_OAuth_Server.md) for enabling and
 configuring the server.
 

--- a/doc/04_Development_Details/09_MCP_Server_Management.md
+++ b/doc/04_Development_Details/09_MCP_Server_Management.md
@@ -14,6 +14,10 @@ Each server is served at `/pimcore-mcp/studio/{urlSlug}` on the `pimcore_mcp` fi
 a token from the [embedded OAuth 2.1 server](../02_Installation_and_Configuration/06_OAuth_Server.md) (or the
 other authenticators in the chain).
 
+Every enabled server is its own OAuth protected resource, at `<issuer>/pimcore-mcp/studio/{urlSlug}`. That URI is
+what a client names in its RFC 8707 `resource` parameter, what the server's metadata document is published under,
+and what the token's audience is checked against, so a token obtained for one server is refused at another.
+
 > **Experimental.** Configuration keys, API, and UI may change between minor versions.
 
 ## The `mcp_servers` permission

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\DependencyInjection;
 
-use const PHP_URL_HOST;
-use const PHP_URL_SCHEME;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\ConfigurationHelper;
 use Pimcore\Bundle\StudioBackendBundle\Exception\InvalidHostException;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\WidgetTypes;
@@ -28,12 +26,14 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use function in_array;
 use function is_array;
 use function is_int;
 use function is_null;
 use function is_string;
 use function parse_url;
 use function sprintf;
+use function str_contains;
 
 /**
  * This is the class that validates and merges configuration from your app/config files.
@@ -906,6 +906,41 @@ class Configuration implements ConfigurationInterface
                             . 'protected-resource URIs. Required when oauth.enabled is true.'
                         )
                         ->defaultNull()
+                        ->validate()
+                            // The shape check lives here rather than on the parent node so Symfony
+                            // skips it for unresolved env placeholders (`%env(...)%`); absence is
+                            // enforced (only when enabled) by the oauth-node rule below.
+                            ->ifTrue(static function (mixed $issuer): bool {
+                                // A `%...%` placeholder resolves at runtime, so its shape cannot be
+                                // checked here — an http(s) origin never legitimately contains '%'.
+                                if ($issuer === null || (is_string($issuer) && str_contains($issuer, '%'))) {
+                                    return false;
+                                }
+
+                                if (!is_string($issuer)) {
+                                    return true;
+                                }
+
+                                $parts = parse_url($issuer);
+                                if (!is_array($parts)) {
+                                    return true;
+                                }
+
+                                // Must be a bare http(s) origin: scheme + host [+ port], nothing else.
+                                return !in_array($parts['scheme'] ?? null, ['http', 'https'], true)
+                                    || ($parts['host'] ?? '') === ''
+                                    || isset($parts['user'])
+                                    || isset($parts['pass'])
+                                    || ($parts['path'] ?? '') !== ''
+                                    || isset($parts['query'])
+                                    || isset($parts['fragment']);
+                            })
+                            ->thenInvalid(
+                                'pimcore_studio_backend.oauth.issuer must be an absolute http(s) origin '
+                                . '(scheme + host [+ port]) with no userinfo, path, query or fragment, '
+                                . 'e.g. "https://your-host". Got: %s'
+                            )
+                        ->end()
                     ->end()
                     ->integerNode('access_token_ttl')
                         ->info('Access-token lifetime in seconds.')
@@ -1011,25 +1046,13 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->validate()
                     ->ifTrue(
-                        static function (array $oauth): bool {
-                            if (($oauth['enabled'] ?? false) !== true) {
-                                return false;
-                            }
-
-                            // Must be a non-empty absolute origin: an empty or relative value
-                            // yields relative resource URIs and an empty `iss`.
-                            $issuer = $oauth['issuer'] ?? null;
-
-                            return !is_string($issuer)
-                                || $issuer === ''
-                                || parse_url($issuer, PHP_URL_SCHEME) === null
-                                || parse_url($issuer, PHP_URL_HOST) === null;
-                        }
+                        static fn (array $oauth): bool => ($oauth['enabled'] ?? false) === true
+                            && ($oauth['issuer'] ?? null) === null
                     )
                     ->thenInvalid(
-                        'pimcore_studio_backend.oauth.issuer must be set to an absolute public base URL '
-                        . '(e.g. "https://your-host") when oauth.enabled is true: it is stamped on tokens '
-                        . 'and is the base for protected-resource URIs, and cannot be derived per request.'
+                        'pimcore_studio_backend.oauth.issuer must be set (e.g. "https://your-host") when '
+                        . 'oauth.enabled is true: it is stamped on tokens and is the base for '
+                        . 'protected-resource URIs, and cannot be derived per request.'
                     )
                 ->end()
             ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\DependencyInjection;
 
+use const PHP_URL_HOST;
+use const PHP_URL_SCHEME;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\ConfigurationHelper;
 use Pimcore\Bundle\StudioBackendBundle\Exception\InvalidHostException;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Util\Constant\WidgetTypes;
@@ -30,6 +32,7 @@ use function is_array;
 use function is_int;
 use function is_null;
 use function is_string;
+use function parse_url;
 use function sprintf;
 
 /**
@@ -1008,11 +1011,23 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->validate()
                     ->ifTrue(
-                        static fn (array $oauth): bool => ($oauth['enabled'] ?? false) === true
-                            && ($oauth['issuer'] ?? null) === null
+                        static function (array $oauth): bool {
+                            if (($oauth['enabled'] ?? false) !== true) {
+                                return false;
+                            }
+
+                            // Must be a non-empty absolute origin: an empty or relative value
+                            // yields relative resource URIs and an empty `iss`.
+                            $issuer = $oauth['issuer'] ?? null;
+
+                            return !is_string($issuer)
+                                || $issuer === ''
+                                || parse_url($issuer, PHP_URL_SCHEME) === null
+                                || parse_url($issuer, PHP_URL_HOST) === null;
+                        }
                     )
                     ->thenInvalid(
-                        'pimcore_studio_backend.oauth.issuer must be set to the public base URL '
+                        'pimcore_studio_backend.oauth.issuer must be set to an absolute public base URL '
                         . '(e.g. "https://your-host") when oauth.enabled is true: it is stamped on tokens '
                         . 'and is the base for protected-resource URIs, and cannot be derived per request.'
                     )

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -898,8 +898,9 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->scalarNode('issuer')
                         ->info(
-                            'Issuer identifier (iss) advertised in metadata and stamped on tokens, '
-                            . 'e.g. "https://pimcore.example.com". Null derives it from the request.'
+                            'Public base URL of this instance (e.g. "https://pimcore.example.com"), '
+                            . 'advertised as the issuer (iss), stamped on tokens, and used as the base for '
+                            . 'protected-resource URIs. Required when oauth.enabled is true.'
                         )
                         ->defaultNull()
                     ->end()
@@ -1004,6 +1005,17 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                     ->end()
+                ->end()
+                ->validate()
+                    ->ifTrue(
+                        static fn (array $oauth): bool => ($oauth['enabled'] ?? false) === true
+                            && ($oauth['issuer'] ?? null) === null
+                    )
+                    ->thenInvalid(
+                        'pimcore_studio_backend.oauth.issuer must be set to the public base URL '
+                        . '(e.g. "https://your-host") when oauth.enabled is true: it is stamped on tokens '
+                        . 'and is the base for protected-resource URIs, and cannot be derived per request.'
+                    )
                 ->end()
             ->end()
         ->end();

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,14 +26,11 @@ use Pimcore\Bundle\StudioBackendBundle\Util\Constant\ElementTypes;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use function in_array;
 use function is_array;
 use function is_int;
 use function is_null;
 use function is_string;
-use function parse_url;
 use function sprintf;
-use function str_contains;
 
 /**
  * This is the class that validates and merges configuration from your app/config files.
@@ -903,44 +900,11 @@ class Configuration implements ConfigurationInterface
                         ->info(
                             'Public base URL of this instance (e.g. "https://pimcore.example.com"), '
                             . 'advertised as the issuer (iss), stamped on tokens, and used as the base for '
-                            . 'protected-resource URIs. Required when oauth.enabled is true.'
+                            . 'protected-resource URIs. Required when oauth.enabled is true. Must be a bare '
+                            . 'origin: a query or fragment would collapse every MCP server onto the same '
+                            . 'token audience.'
                         )
                         ->defaultNull()
-                        ->validate()
-                            // The shape check lives here rather than on the parent node so Symfony
-                            // skips it for unresolved env placeholders (`%env(...)%`); absence is
-                            // enforced (only when enabled) by the oauth-node rule below.
-                            ->ifTrue(static function (mixed $issuer): bool {
-                                // A `%...%` placeholder resolves at runtime, so its shape cannot be
-                                // checked here — an http(s) origin never legitimately contains '%'.
-                                if ($issuer === null || (is_string($issuer) && str_contains($issuer, '%'))) {
-                                    return false;
-                                }
-
-                                if (!is_string($issuer)) {
-                                    return true;
-                                }
-
-                                $parts = parse_url($issuer);
-                                if (!is_array($parts)) {
-                                    return true;
-                                }
-
-                                // Must be a bare http(s) origin: scheme + host [+ port], nothing else.
-                                return !in_array($parts['scheme'] ?? null, ['http', 'https'], true)
-                                    || ($parts['host'] ?? '') === ''
-                                    || isset($parts['user'])
-                                    || isset($parts['pass'])
-                                    || ($parts['path'] ?? '') !== ''
-                                    || isset($parts['query'])
-                                    || isset($parts['fragment']);
-                            })
-                            ->thenInvalid(
-                                'pimcore_studio_backend.oauth.issuer must be an absolute http(s) origin '
-                                . '(scheme + host [+ port]) with no userinfo, path, query or fragment, '
-                                . 'e.g. "https://your-host". Got: %s'
-                            )
-                        ->end()
                     ->end()
                     ->integerNode('access_token_ttl')
                         ->info('Access-token lifetime in seconds.')

--- a/src/DependencyInjection/PimcoreStudioBackendExtension.php
+++ b/src/DependencyInjection/PimcoreStudioBackendExtension.php
@@ -42,6 +42,7 @@ use Pimcore\Bundle\StudioBackendBundle\OAuth\Controller\AuthorizationApprovalCon
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Controller\AuthorizationServerMetadataController;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Controller\AuthorizeController;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Controller\ClientRegistrationController;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Controller\ProtectedResourceMetadataController;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\EventSubscriber\OAuthCorsSubscriber;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Server\AuthorizationServerFactory;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Server\PendingAuthorizationStore;
@@ -263,7 +264,11 @@ class PimcoreStudioBackendExtension extends Extension implements PrependExtensio
             ->setArgument(self::ARG_ISSUER, $config['oauth']['issuer']);
 
         $container->getDefinition(McpAuthenticationEntryPoint::class)
-            ->setArgument('$oauthEnabled', $config['oauth']['enabled']);
+            ->setArgument('$oauthEnabled', $config['oauth']['enabled'])
+            ->setArgument(self::ARG_ISSUER, $config['oauth']['issuer']);
+
+        $container->getDefinition(ProtectedResourceMetadataController::class)
+            ->setArgument(self::ARG_ISSUER, $config['oauth']['issuer']);
 
         $container->getDefinition(OAuthCorsSubscriber::class)
             ->setArgument(self::ARG_ENABLED, $config['oauth']['enabled'])

--- a/src/DependencyInjection/PimcoreStudioBackendExtension.php
+++ b/src/DependencyInjection/PimcoreStudioBackendExtension.php
@@ -46,6 +46,7 @@ use Pimcore\Bundle\StudioBackendBundle\OAuth\EventSubscriber\OAuthCorsSubscriber
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Server\AuthorizationServerFactory;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Server\PendingAuthorizationStore;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Server\Repository\AccessTokenRepository;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver\RequestResourceResolver;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Server\Repository\ClientRepository;
 use Pimcore\Bundle\StudioBackendBundle\OpenApi\Service\OpenApiServiceInterface;
 use Pimcore\Bundle\StudioBackendBundle\Perspective\Repository\ElementTreeWidgetConfigRepository;
@@ -257,6 +258,9 @@ class PimcoreStudioBackendExtension extends Extension implements PrependExtensio
 
         $container->getDefinition(OAuthAccessTokenAuthenticator::class)
             ->setArgument(self::ARG_ENABLED, $config['oauth']['enabled']);
+
+        $container->getDefinition(RequestResourceResolver::class)
+            ->setArgument(self::ARG_ISSUER, $config['oauth']['issuer']);
 
         $container->getDefinition(McpAuthenticationEntryPoint::class)
             ->setArgument('$oauthEnabled', $config['oauth']['enabled']);

--- a/src/OAuth/Controller/ProtectedResourceMetadataController.php
+++ b/src/OAuth/Controller/ProtectedResourceMetadataController.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\StudioBackendBundle\OAuth\Util\CanonicalUri;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use function rtrim;
 
 /**
  * Serves the RFC 9728 Protected Resource Metadata document.
@@ -33,12 +34,16 @@ final class ProtectedResourceMetadataController
 {
     public function __construct(
         private readonly ResourceRegistryInterface $resourceRegistry,
+        private readonly ?string $issuer = null,
     ) {
     }
 
     public function __invoke(Request $request, string $resourcePath = ''): JsonResponse
     {
-        $resourceUri = CanonicalUri::canonicalize($request->getSchemeAndHttpHost() . $resourcePath);
+        // Resources are registered under the configured issuer, so the lookup has to be
+        // built the same way; using the request host would 404 whenever the two differ.
+        $base = rtrim($this->issuer ?? $request->getSchemeAndHttpHost(), '/');
+        $resourceUri = CanonicalUri::canonicalize($base . $resourcePath);
         $metadata = $this->resourceRegistry->metadataFor($resourceUri);
 
         if ($metadata === null) {

--- a/src/OAuth/Resolver/RequestResourceResolver.php
+++ b/src/OAuth/Resolver/RequestResourceResolver.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver;
+
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Contract\ResourceRegistryInterface;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Dto\ProtectedResource;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Util\CanonicalUri;
+use Symfony\Component\HttpFoundation\Request;
+use function is_array;
+use function parse_url;
+use function rtrim;
+use function str_starts_with;
+use function strlen;
+
+/**
+ * @internal
+ */
+final readonly class RequestResourceResolver implements RequestResourceResolverInterface
+{
+    public function __construct(
+        private ResourceRegistryInterface $resourceRegistry,
+        private ?string $issuer = null,
+    ) {
+    }
+
+    public function resolve(Request $request): ?ProtectedResource
+    {
+        // Resources are registered under the issuer, so the request has to be
+        // expressed the same way. Behind a proxy the request host is not the
+        // issuer, and comparing the two would refuse a correctly issued token.
+        $base = rtrim($this->issuer ?? $request->getSchemeAndHttpHost(), '/');
+        $target = CanonicalUri::canonicalize($base . $request->getPathInfo());
+
+        $match = null;
+        $matchLength = 0;
+        foreach ($this->resourceRegistry->all() as $resource) {
+            if (!self::covers($resource->canonicalUri, $target)) {
+                continue;
+            }
+
+            // Longest match wins, so a resource registered for one server takes
+            // precedence over a broader one registered for its whole prefix.
+            $length = strlen($resource->canonicalUri);
+            if ($length > $matchLength) {
+                $match = $resource;
+                $matchLength = $length;
+            }
+        }
+
+        return $match;
+    }
+
+    /**
+     * The rule a standards-based client applies when deciding whether a resource
+     * covers an endpoint: same origin, and a path prefix that only matches on a
+     * segment boundary, so `/pimcore-mcp/agent` never covers `/pimcore-mcp/agentx`.
+     */
+    private static function covers(string $resourceUri, string $target): bool
+    {
+        $resource = parse_url($resourceUri);
+        $endpoint = parse_url($target);
+
+        if (!is_array($resource) || !is_array($endpoint)) {
+            return false;
+        }
+
+        foreach (['scheme', 'host', 'port'] as $part) {
+            if (($resource[$part] ?? null) !== ($endpoint[$part] ?? null)) {
+                return false;
+            }
+        }
+
+        $resourcePath = rtrim($resource['path'] ?? '/', '/') . '/';
+        $endpointPath = rtrim($endpoint['path'] ?? '/', '/') . '/';
+
+        return str_starts_with($endpointPath, $resourcePath);
+    }
+}

--- a/src/OAuth/Resolver/RequestResourceResolver.php
+++ b/src/OAuth/Resolver/RequestResourceResolver.php
@@ -43,15 +43,14 @@ final readonly class RequestResourceResolver implements RequestResourceResolverI
         $target = CanonicalUri::canonicalize($base . $request->getPathInfo());
 
         $match = null;
-        $matchLength = 0;
+        $matchLength = -1;
         foreach ($this->resourceRegistry->all() as $resource) {
-            if (!self::covers($resource->canonicalUri, $target)) {
-                continue;
-            }
+            $length = self::coveredPathLength($resource->canonicalUri, $target);
 
-            // Longest match wins, so a resource registered for one server takes
-            // precedence over a broader one registered for its whole prefix.
-            $length = strlen($resource->canonicalUri);
+            // Longest matching path wins, so a resource registered for one server takes
+            // precedence over a broader one registered for its whole prefix. Ranking on
+            // the path rather than the whole URI keeps the choice a property of the
+            // request, not of how long the rest of the identifier happens to be.
             if ($length > $matchLength) {
                 $match = $resource;
                 $matchLength = $length;
@@ -62,28 +61,36 @@ final readonly class RequestResourceResolver implements RequestResourceResolverI
     }
 
     /**
-     * The rule a standards-based client applies when deciding whether a resource
-     * covers an endpoint: same origin, and a path prefix that only matches on a
-     * segment boundary, so `/pimcore-mcp/agent` never covers `/pimcore-mcp/agentx`.
+     * How much of the request path a resource covers, or -1 when it does not cover it
+     * at all. The rule a standards-based client applies when deciding whether a resource
+     * covers an endpoint: same origin, and a path prefix that only matches on a segment
+     * boundary, so `/pimcore-mcp/agent` never covers `/pimcore-mcp/agentx`.
      */
-    private static function covers(string $resourceUri, string $target): bool
+    private static function coveredPathLength(string $resourceUri, string $target): int
     {
         $resource = parse_url($resourceUri);
         $endpoint = parse_url($target);
 
         if (!is_array($resource) || !is_array($endpoint)) {
-            return false;
+            return -1;
+        }
+
+        // RFC 8707 resource identifiers carry no query or fragment. One that does can
+        // never be what this endpoint is, and matching it on path alone would let it
+        // shadow the resource that actually is.
+        if (isset($resource['query']) || isset($resource['fragment'])) {
+            return -1;
         }
 
         foreach (['scheme', 'host', 'port'] as $part) {
             if (($resource[$part] ?? null) !== ($endpoint[$part] ?? null)) {
-                return false;
+                return -1;
             }
         }
 
         $resourcePath = rtrim($resource['path'] ?? '/', '/') . '/';
         $endpointPath = rtrim($endpoint['path'] ?? '/', '/') . '/';
 
-        return str_starts_with($endpointPath, $resourcePath);
+        return str_starts_with($endpointPath, $resourcePath) ? strlen($resourcePath) : -1;
     }
 }

--- a/src/OAuth/Resolver/RequestResourceResolverInterface.php
+++ b/src/OAuth/Resolver/RequestResourceResolverInterface.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver;
+
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Dto\ProtectedResource;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Which registered protected resource a request is addressed to.
+ *
+ * The endpoints behind the MCP firewall are owned by other bundles, so the
+ * audience cannot be derived from a path this bundle knows. It is resolved from
+ * the registry instead: whoever owns an endpoint registers it, and that
+ * registration is what names the audience.
+ *
+ * @internal
+ */
+interface RequestResourceResolverInterface
+{
+    /**
+     * The most specific registered resource covering this request, or null when
+     * none does - meaning no audience-bound token can address this endpoint.
+     */
+    public function resolve(Request $request): ?ProtectedResource;
+}

--- a/src/Security/Authenticator/Mcp/OAuthAccessTokenAuthenticator.php
+++ b/src/Security/Authenticator/Mcp/OAuthAccessTokenAuthenticator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp;
 
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Contract\TokenValidatorInterface;
-use Pimcore\Bundle\StudioBackendBundle\OAuth\Util\CanonicalUri;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver\RequestResourceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Security\Service\McpAccessTokenService;
 use Pimcore\Model\User;
 use Pimcore\Security\User\User as SecurityUser;
@@ -52,6 +52,7 @@ final class OAuthAccessTokenAuthenticator extends AbstractAuthenticator
     public function __construct(
         private readonly bool $enabled,
         private readonly TokenValidatorInterface $tokenValidator,
+        private readonly RequestResourceResolverInterface $resourceResolver,
     ) {
     }
 
@@ -79,7 +80,16 @@ final class OAuthAccessTokenAuthenticator extends AbstractAuthenticator
     {
         $token = $this->bearerToken($request) ?? '';
 
-        $resolved = $this->tokenValidator->validate($token, $this->resourceUri($request));
+        // The endpoints behind this firewall belong to other bundles. Whoever owns
+        // one registers it as a protected resource, and that registration names the
+        // audience. Without one there is no audience a token could carry for this
+        // endpoint, so decline and leave the request to the rest of the chain.
+        $resource = $this->resourceResolver->resolve($request);
+        if ($resource === null) {
+            throw new AuthenticationException('This endpoint is not a registered OAuth protected resource.');
+        }
+
+        $resolved = $this->tokenValidator->validate($token, $resource->canonicalUri);
         if ($resolved === null) {
             throw new AuthenticationException('Invalid or expired OAuth access token.');
         }
@@ -120,10 +130,5 @@ final class OAuthAccessTokenAuthenticator extends AbstractAuthenticator
         $token = substr($header, strlen(self::BEARER_PREFIX));
 
         return $token === '' ? null : $token;
-    }
-
-    private function resourceUri(Request $request): string
-    {
-        return CanonicalUri::canonicalize($request->getSchemeAndHttpHost() . '/pimcore-mcp');
     }
 }

--- a/src/Security/EntryPoint/McpAuthenticationEntryPoint.php
+++ b/src/Security/EntryPoint/McpAuthenticationEntryPoint.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\StudioBackendBundle\Security\EntryPoint;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use function rtrim;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use function sprintf;
@@ -37,6 +38,7 @@ final class McpAuthenticationEntryPoint implements AuthenticationEntryPointInter
 
     public function __construct(
         private readonly bool $oauthEnabled,
+        private readonly ?string $issuer = null,
     ) {
     }
 
@@ -49,12 +51,24 @@ final class McpAuthenticationEntryPoint implements AuthenticationEntryPointInter
                 'WWW-Authenticate',
                 sprintf(
                     'Bearer resource_metadata="%s", scope="%s"',
-                    $request->getSchemeAndHttpHost() . self::METADATA_PREFIX . $request->getPathInfo(),
+                    $this->metadataUrl($request),
                     self::DEFAULT_SCOPE,
                 )
             );
         }
 
         return $response;
+    }
+
+    /**
+     * Built from the configured issuer, because that is what the resource is registered
+     * under: pointing the client at the request host instead would send it to a metadata
+     * document that resolves to nothing whenever the two differ, as they do behind a proxy.
+     */
+    private function metadataUrl(Request $request): string
+    {
+        $base = rtrim($this->issuer ?? $request->getSchemeAndHttpHost(), '/');
+
+        return $base . self::METADATA_PREFIX . $request->getPathInfo();
     }
 }

--- a/src/Security/EntryPoint/McpAuthenticationEntryPoint.php
+++ b/src/Security/EntryPoint/McpAuthenticationEntryPoint.php
@@ -80,9 +80,16 @@ final class McpAuthenticationEntryPoint implements AuthenticationEntryPointInter
         $base = rtrim($this->issuer ?? $request->getSchemeAndHttpHost(), '/');
 
         $resource = $this->resourceResolver->resolve($request);
-        $resourcePath = $resource !== null ? parse_url($resource->canonicalUri, PHP_URL_PATH) : null;
-        $path = is_string($resourcePath) && $resourcePath !== '' ? $resourcePath : $request->getPathInfo();
+        if ($resource === null) {
+            // Nothing registered covers the endpoint: best-effort challenge at the request path.
+            return $base . self::METADATA_PREFIX . $request->getPathInfo();
+        }
 
-        return $base . self::METADATA_PREFIX . $path;
+        // A matched resource: use its path. An origin-only (root) resource has none, which
+        // points the client at the resource's own metadata document (an empty suffix), not
+        // at the endpoint-specific path the controller's exact lookup could not resolve.
+        $path = parse_url($resource->canonicalUri, PHP_URL_PATH);
+
+        return $base . self::METADATA_PREFIX . (is_string($path) ? $path : '');
     }
 }

--- a/src/Security/EntryPoint/McpAuthenticationEntryPoint.php
+++ b/src/Security/EntryPoint/McpAuthenticationEntryPoint.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StudioBackendBundle\Security\EntryPoint;
 
+use const PHP_URL_PATH;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver\RequestResourceResolverInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use function rtrim;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use function is_string;
+use function parse_url;
+use function rtrim;
 use function sprintf;
 
 /**
@@ -38,6 +42,7 @@ final class McpAuthenticationEntryPoint implements AuthenticationEntryPointInter
 
     public function __construct(
         private readonly bool $oauthEnabled,
+        private readonly RequestResourceResolverInterface $resourceResolver,
         private readonly ?string $issuer = null,
     ) {
     }
@@ -61,14 +66,23 @@ final class McpAuthenticationEntryPoint implements AuthenticationEntryPointInter
     }
 
     /**
-     * Built from the configured issuer, because that is what the resource is registered
-     * under: pointing the client at the request host instead would send it to a metadata
-     * document that resolves to nothing whenever the two differ, as they do behind a proxy.
+     * Points at the resource the authenticator would actually validate the token against,
+     * not the raw request path. The resolver matches by longest prefix, so when a broader
+     * resource covers this endpoint the two differ, and advertising the request path would
+     * send the client to a metadata document the controller's exact lookup answers with a
+     * 404. Falls back to the request path when nothing is registered for the endpoint.
+     *
+     * The base is the configured issuer, which is what the resource is registered under;
+     * the request host would resolve to nothing whenever the two differ, as behind a proxy.
      */
     private function metadataUrl(Request $request): string
     {
         $base = rtrim($this->issuer ?? $request->getSchemeAndHttpHost(), '/');
 
-        return $base . self::METADATA_PREFIX . $request->getPathInfo();
+        $resource = $this->resourceResolver->resolve($request);
+        $resourcePath = $resource !== null ? parse_url($resource->canonicalUri, PHP_URL_PATH) : null;
+        $path = is_string($resourcePath) && $resourcePath !== '' ? $resourcePath : $request->getPathInfo();
+
+        return $base . self::METADATA_PREFIX . $path;
     }
 }

--- a/tests/Unit/DependencyInjection/OAuthConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/OAuthConfigurationTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\DependencyInjection;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\DependencyInjection\Configuration;
+use ReflectionMethod;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+/**
+ * The embedded OAuth server has no meaningful identity without an issuer: it is
+ * stamped on tokens (`iss`) and is the base for protected-resource URIs, and it
+ * cannot be derived per request. So enabling OAuth without one is rejected at
+ * container-compile time rather than failing silently at runtime.
+ *
+ * @internal
+ */
+final class OAuthConfigurationTest extends Unit
+{
+    public function testEnablingOAuthWithoutAnIssuerIsRejected(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches('/issuer/');
+
+        $this->process(['enabled' => true]);
+    }
+
+    public function testEnablingOAuthWithAnIssuerIsAccepted(): void
+    {
+        $processed = $this->process(['enabled' => true, 'issuer' => 'https://studio.example.com']);
+
+        $this->assertSame('https://studio.example.com', $processed['oauth']['issuer']);
+    }
+
+    public function testDisabledOAuthDoesNotRequireAnIssuer(): void
+    {
+        $processed = $this->process(['enabled' => false]);
+
+        $this->assertNull($processed['oauth']['issuer']);
+    }
+
+    /**
+     * @param array<string, mixed> $oauth
+     *
+     * @return array<string, mixed>
+     */
+    private function process(array $oauth): array
+    {
+        $root = (new TreeBuilder('pimcore_studio_backend'))->getRootNode();
+        (new ReflectionMethod(Configuration::class, 'addOAuthNode'))
+            ->invoke(new Configuration(), $root);
+
+        return (new Processor())->process(
+            $root->getNode(true),
+            [['oauth' => $oauth]]
+        );
+    }
+}

--- a/tests/Unit/DependencyInjection/OAuthConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/OAuthConfigurationTest.php
@@ -23,8 +23,9 @@ use Symfony\Component\Config\Definition\Processor;
 /**
  * The embedded OAuth server has no meaningful identity without an issuer: it is
  * stamped on tokens (`iss`) and is the base for protected-resource URIs, and it
- * cannot be derived per request. So enabling OAuth without one is rejected at
- * container-compile time rather than failing silently at runtime.
+ * cannot be derived per request. So enabling OAuth without one — or with anything
+ * other than a bare http(s) origin — is rejected at container-compile time rather
+ * than failing silently at runtime.
  *
  * @internal
  */
@@ -38,27 +39,51 @@ final class OAuthConfigurationTest extends Unit
         $this->process(['enabled' => true]);
     }
 
-    public function testEnablingOAuthWithAnEmptyIssuerIsRejected(): void
+    /**
+     * @dataProvider malformedIssuers
+     */
+    public function testAMalformedIssuerIsRejected(string $issuer): void
     {
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessageMatches('/issuer/');
 
-        $this->process(['enabled' => true, 'issuer' => '']);
+        $this->process(['enabled' => true, 'issuer' => $issuer]);
     }
 
-    public function testEnablingOAuthWithANonAbsoluteIssuerIsRejected(): void
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function malformedIssuers(): array
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageMatches('/issuer/');
-
-        $this->process(['enabled' => true, 'issuer' => 'not-an-absolute-url']);
+        return [
+            'empty' => [''],
+            'no scheme or host' => ['not-an-absolute-url'],
+            'non-http(s) scheme' => ['ftp://pimcore.example.com'],
+            'with a path' => ['https://pimcore.example.com/base'],
+            'with a trailing slash' => ['https://pimcore.example.com/'],
+            'with a query' => ['https://pimcore.example.com?tenant=a'],
+            'with a fragment' => ['https://pimcore.example.com#frag'],
+            'with userinfo' => ['https://user:pass@pimcore.example.com'],
+        ];
     }
 
-    public function testEnablingOAuthWithAnIssuerIsAccepted(): void
+    /**
+     * An `%env(...)%` placeholder resolves at container runtime, so the shape cannot
+     * (and must not) be validated at config-compile time — the documented env-driven
+     * form must be accepted.
+     */
+    public function testAnEnvPlaceholderIssuerIsAccepted(): void
     {
-        $processed = $this->process(['enabled' => true, 'issuer' => 'https://studio.example.com']);
+        $processed = $this->process(['enabled' => true, 'issuer' => '%env(PIMCORE_OAUTH_ISSUER)%']);
 
-        $this->assertSame('https://studio.example.com', $processed['oauth']['issuer']);
+        $this->assertSame('%env(PIMCORE_OAUTH_ISSUER)%', $processed['oauth']['issuer']);
+    }
+
+    public function testAnAbsoluteHttpsOriginIsAccepted(): void
+    {
+        $processed = $this->process(['enabled' => true, 'issuer' => 'https://studio.example.com:8443']);
+
+        $this->assertSame('https://studio.example.com:8443', $processed['oauth']['issuer']);
     }
 
     public function testDisabledOAuthDoesNotRequireAnIssuer(): void

--- a/tests/Unit/DependencyInjection/OAuthConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/OAuthConfigurationTest.php
@@ -38,6 +38,22 @@ final class OAuthConfigurationTest extends Unit
         $this->process(['enabled' => true]);
     }
 
+    public function testEnablingOAuthWithAnEmptyIssuerIsRejected(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches('/issuer/');
+
+        $this->process(['enabled' => true, 'issuer' => '']);
+    }
+
+    public function testEnablingOAuthWithANonAbsoluteIssuerIsRejected(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches('/issuer/');
+
+        $this->process(['enabled' => true, 'issuer' => 'not-an-absolute-url']);
+    }
+
     public function testEnablingOAuthWithAnIssuerIsAccepted(): void
     {
         $processed = $this->process(['enabled' => true, 'issuer' => 'https://studio.example.com']);

--- a/tests/Unit/DependencyInjection/OAuthConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/OAuthConfigurationTest.php
@@ -23,9 +23,12 @@ use Symfony\Component\Config\Definition\Processor;
 /**
  * The embedded OAuth server has no meaningful identity without an issuer: it is
  * stamped on tokens (`iss`) and is the base for protected-resource URIs, and it
- * cannot be derived per request. So enabling OAuth without one — or with anything
- * other than a bare http(s) origin — is rejected at container-compile time rather
- * than failing silently at runtime.
+ * cannot be derived per request. Leaving it unset while enabling OAuth registers
+ * no protected resource at all, so every OAuth request would 401 with nothing
+ * pointing at the cause — hence it is rejected at container-compile time.
+ *
+ * The URL *shape* is documented rather than validated, matching how the rest of
+ * this configuration treats operator-supplied URLs (e.g. client redirect_uris).
  *
  * @internal
  */
@@ -39,51 +42,22 @@ final class OAuthConfigurationTest extends Unit
         $this->process(['enabled' => true]);
     }
 
-    /**
-     * @dataProvider malformedIssuers
-     */
-    public function testAMalformedIssuerIsRejected(string $issuer): void
+    public function testEnablingOAuthWithAnIssuerIsAccepted(): void
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageMatches('/issuer/');
+        $processed = $this->process(['enabled' => true, 'issuer' => 'https://studio.example.com']);
 
-        $this->process(['enabled' => true, 'issuer' => $issuer]);
+        $this->assertSame('https://studio.example.com', $processed['oauth']['issuer']);
     }
 
     /**
-     * @return array<string, array{string}>
-     */
-    public static function malformedIssuers(): array
-    {
-        return [
-            'empty' => [''],
-            'no scheme or host' => ['not-an-absolute-url'],
-            'non-http(s) scheme' => ['ftp://pimcore.example.com'],
-            'with a path' => ['https://pimcore.example.com/base'],
-            'with a trailing slash' => ['https://pimcore.example.com/'],
-            'with a query' => ['https://pimcore.example.com?tenant=a'],
-            'with a fragment' => ['https://pimcore.example.com#frag'],
-            'with userinfo' => ['https://user:pass@pimcore.example.com'],
-        ];
-    }
-
-    /**
-     * An `%env(...)%` placeholder resolves at container runtime, so the shape cannot
-     * (and must not) be validated at config-compile time — the documented env-driven
-     * form must be accepted.
+     * An `%env(...)%` placeholder resolves at container runtime, so the documented
+     * env-driven form must pass configuration processing untouched.
      */
     public function testAnEnvPlaceholderIssuerIsAccepted(): void
     {
         $processed = $this->process(['enabled' => true, 'issuer' => '%env(PIMCORE_OAUTH_ISSUER)%']);
 
         $this->assertSame('%env(PIMCORE_OAUTH_ISSUER)%', $processed['oauth']['issuer']);
-    }
-
-    public function testAnAbsoluteHttpsOriginIsAccepted(): void
-    {
-        $processed = $this->process(['enabled' => true, 'issuer' => 'https://studio.example.com:8443']);
-
-        $this->assertSame('https://studio.example.com:8443', $processed['oauth']['issuer']);
     }
 
     public function testDisabledOAuthDoesNotRequireAnIssuer(): void

--- a/tests/Unit/OAuth/Controller/ProtectedResourceMetadataControllerTest.php
+++ b/tests/Unit/OAuth/Controller/ProtectedResourceMetadataControllerTest.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\StudioBackendBundle\OAuth\Controller\ProtectedResourceMetadat
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Dto\ProtectedResource;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Registry\ConfigProtectedResourceRegistry;
 use Symfony\Component\HttpFoundation\Request;
+use function json_decode;
 use Symfony\Component\HttpFoundation\Response;
 
 final class ProtectedResourceMetadataControllerTest extends Unit
@@ -56,6 +57,34 @@ final class ProtectedResourceMetadataControllerTest extends Unit
         );
 
         $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    /**
+     * The other half of the same problem as the 401 challenge: the document has to be
+     * findable on whatever host the client reaches it by, because the resource it
+     * describes is registered under the issuer.
+     */
+    public function testResolvesByIssuerWhenTheRequestArrivesOnAnotherHost(): void
+    {
+        $registry = new ConfigProtectedResourceRegistry([
+            [
+                'uri' => 'https://pimcore.example.com/pimcore-mcp',
+                'scopes_supported' => ['mcp:read'],
+                'authorization_servers' => ['https://pimcore.example.com'],
+            ],
+        ]);
+
+        $response = (new ProtectedResourceMetadataController($registry, 'https://pimcore.example.com'))(
+            Request::create('http://internal.local/.well-known/oauth-protected-resource/pimcore-mcp'),
+            '/pimcore-mcp',
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $payload = json_decode((string) $response->getContent(), true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('https://pimcore.example.com/pimcore-mcp', $payload['resource'] ?? null);
     }
 
     private function requestFor(string $schemeAndHost): Request

--- a/tests/Unit/OAuth/Resolver/RequestResourceResolverTest.php
+++ b/tests/Unit/OAuth/Resolver/RequestResourceResolverTest.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\OAuth\Resolver;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Dto\ProtectedResource;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Registry\ConfigProtectedResourceRegistry;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver\RequestResourceResolver;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+final class RequestResourceResolverTest extends Unit
+{
+    private const string ISSUER = 'https://pimcore.example.com';
+
+    private const string STUDIO_SERVER = self::ISSUER . '/pimcore-mcp/studio/product-read';
+
+    private const string AGENT_GROUP = self::ISSUER . '/pimcore-mcp/agent/content';
+
+    public function testResolvesTheStudioServerItsRequestAddresses(): void
+    {
+        $resource = $this->resolve('/pimcore-mcp/studio/product-read', self::STUDIO_SERVER);
+
+        $this->assertNotNull($resource);
+        $this->assertSame(self::STUDIO_SERVER, $resource->canonicalUri);
+    }
+
+    public function testResolvesAnEndpointOwnedByAnotherBundle(): void
+    {
+        // The regression this replaces: deriving the audience from a path this
+        // bundle knows only worked for its own servers, so an endpoint registered
+        // by another bundle could never be reached with an audience-bound token.
+        $resource = $this->resolve('/pimcore-mcp/agent/content', self::STUDIO_SERVER, self::AGENT_GROUP);
+
+        $this->assertNotNull($resource);
+        $this->assertSame(self::AGENT_GROUP, $resource->canonicalUri);
+    }
+
+    public function testUnregisteredEndpointResolvesToNothing(): void
+    {
+        // No registration means no audience a token could carry for this endpoint.
+        $this->assertNull($this->resolve('/pimcore-mcp/agent/content', self::STUDIO_SERVER));
+    }
+
+    public function testPrefixOnlyMatchesOnASegmentBoundary(): void
+    {
+        $this->assertNull($this->resolve('/pimcore-mcp/agent/contentx', self::AGENT_GROUP));
+    }
+
+    public function testMostSpecificRegistrationWins(): void
+    {
+        $resource = $this->resolve(
+            '/pimcore-mcp/agent/content',
+            self::ISSUER . '/pimcore-mcp',
+            self::AGENT_GROUP,
+        );
+
+        $this->assertNotNull($resource);
+        $this->assertSame(self::AGENT_GROUP, $resource->canonicalUri);
+    }
+
+    public function testIssuerIsPreferredOverTheRequestHost(): void
+    {
+        // Behind a proxy the request host is not the issuer; comparing the two
+        // would refuse a token issued for the resource as registered.
+        $resource = $this->resolve('/pimcore-mcp/studio/product-read', self::STUDIO_SERVER);
+
+        $this->assertNotNull($resource);
+        $this->assertSame(self::STUDIO_SERVER, $resource->canonicalUri);
+    }
+
+    public function testWithoutAnIssuerTheRequestHostIsUsed(): void
+    {
+        $registry = new ConfigProtectedResourceRegistry();
+        $registry->register(new ProtectedResource('http://localhost/pimcore-mcp/agent/content', [], []));
+
+        $resource = (new RequestResourceResolver($registry))->resolve(
+            Request::create('http://localhost/pimcore-mcp/agent/content'),
+        );
+
+        $this->assertNotNull($resource);
+        $this->assertSame('http://localhost/pimcore-mcp/agent/content', $resource->canonicalUri);
+    }
+
+    private function resolve(string $path, string ...$registered): ?ProtectedResource
+    {
+        $registry = new ConfigProtectedResourceRegistry();
+        foreach ($registered as $uri) {
+            $registry->register(new ProtectedResource($uri, [], []));
+        }
+
+        // A request arriving on a host that is not the issuer, which is the shape
+        // every proxied deployment has.
+        return (new RequestResourceResolver($registry, self::ISSUER))
+            ->resolve(Request::create('http://internal.local' . $path));
+    }
+}

--- a/tests/Unit/OAuth/Resolver/RequestResourceResolverTest.php
+++ b/tests/Unit/OAuth/Resolver/RequestResourceResolverTest.php
@@ -95,6 +95,30 @@ final class RequestResourceResolverTest extends Unit
         $this->assertSame('http://localhost/pimcore-mcp/agent/content', $resource->canonicalUri);
     }
 
+    /**
+     * A resource carrying a query cannot be what an endpoint is, and ranking on the whole
+     * identifier would let a long query outrank the resource that actually matches.
+     */
+    public function testAQueryBearingResourceNeverShadowsTheRealOne(): void
+    {
+        $resource = $this->resolve(
+            '/pimcore-mcp/studio/product-read',
+            self::STUDIO_SERVER . '?tenant=a-very-long-tenant-identifier',
+            self::STUDIO_SERVER,
+        );
+
+        $this->assertNotNull($resource);
+        $this->assertSame(self::STUDIO_SERVER, $resource->canonicalUri);
+    }
+
+    public function testAQueryBearingResourceAloneResolvesToNothing(): void
+    {
+        $this->assertNull($this->resolve(
+            '/pimcore-mcp/studio/product-read',
+            self::STUDIO_SERVER . '?tenant=a',
+        ));
+    }
+
     private function resolve(string $path, string ...$registered): ?ProtectedResource
     {
         $registry = new ConfigProtectedResourceRegistry();

--- a/tests/Unit/Security/Authenticator/Mcp/OAuthAccessTokenAuthenticatorTest.php
+++ b/tests/Unit/Security/Authenticator/Mcp/OAuthAccessTokenAuthenticatorTest.php
@@ -15,7 +15,9 @@ namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Security\Authenticator\M
 
 use Codeception\Test\Unit;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Contract\TokenValidatorInterface;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Dto\ProtectedResource;
 use Pimcore\Bundle\StudioBackendBundle\OAuth\Dto\ResolvedAccess;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver\RequestResourceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Security\Authenticator\Mcp\OAuthAccessTokenAuthenticator;
 use Pimcore\Model\User;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,6 +27,8 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 final class OAuthAccessTokenAuthenticatorTest extends Unit
 {
     private const string JWT = 'Bearer aaa.bbb.ccc';
+
+    private const string RESOURCE = 'https://localhost/pimcore-mcp/studio/product-read';
 
     public function testDisabledNeverSupports(): void
     {
@@ -46,7 +50,7 @@ final class OAuthAccessTokenAuthenticatorTest extends Unit
     {
         $user = new User();
         $user->setUsername('agent-user');
-        $resolved = new ResolvedAccess($user, ['mcp:read'], ['https://localhost/pimcore-mcp'], 'studio-mcp');
+        $resolved = new ResolvedAccess($user, ['mcp:read'], [self::RESOURCE], 'studio-mcp');
 
         $passport = $this->makeAuthenticator(true, $resolved)->authenticate($this->requestWith(self::JWT));
 
@@ -68,11 +72,59 @@ final class OAuthAccessTokenAuthenticatorTest extends Unit
         );
     }
 
-    private function makeAuthenticator(bool $enabled, ?ResolvedAccess $resolved): OAuthAccessTokenAuthenticator
+    public function testAuthenticateThrowsWhenTheEndpointIsNotARegisteredResource(): void
     {
+        $user = new User();
+        $user->setUsername('agent-user');
+        $resolved = new ResolvedAccess($user, ['mcp:read'], [self::RESOURCE], 'studio-mcp');
+
+        // An endpoint whose owner registered no protected resource has no audience a
+        // token could carry, so the token is never even validated against one.
+        $auth = $this->makeAuthenticator(true, $resolved, resource: null);
+
+        $this->expectException(AuthenticationException::class);
+        $auth->authenticate($this->requestWith(self::JWT));
+    }
+
+    public function testValidatesAgainstTheResourceTheRequestResolvesTo(): void
+    {
+        $user = new User();
+        $user->setUsername('agent-user');
+        $resolved = new ResolvedAccess($user, ['mcp:read'], [self::RESOURCE], 'studio-mcp');
+
+        $seen = [];
+        $auth = new OAuthAccessTokenAuthenticator(
+            true,
+            $this->makeEmpty(TokenValidatorInterface::class, [
+                'validate' => function (string $token, string $resourceUri) use (&$seen, $resolved) {
+                    $seen[] = $resourceUri;
+
+                    return $resolved;
+                },
+            ]),
+            $this->makeEmpty(RequestResourceResolverInterface::class, [
+                'resolve' => new ProtectedResource(self::RESOURCE, [], []),
+            ]),
+        );
+
+        $auth->authenticate($this->requestWith(self::JWT));
+
+        // The audience checked is the one the endpoint's owner registered, not a
+        // path this bundle derived for itself.
+        $this->assertSame([self::RESOURCE], $seen);
+    }
+
+    private function makeAuthenticator(
+        bool $enabled,
+        ?ResolvedAccess $resolved,
+        ?string $resource = self::RESOURCE,
+    ): OAuthAccessTokenAuthenticator {
         return new OAuthAccessTokenAuthenticator(
             $enabled,
             $this->makeEmpty(TokenValidatorInterface::class, ['validate' => $resolved]),
+            $this->makeEmpty(RequestResourceResolverInterface::class, [
+                'resolve' => $resource === null ? null : new ProtectedResource($resource, [], []),
+            ]),
         );
     }
 

--- a/tests/Unit/Security/EntryPoint/McpAuthenticationEntryPointTest.php
+++ b/tests/Unit/Security/EntryPoint/McpAuthenticationEntryPointTest.php
@@ -43,6 +43,25 @@ final class McpAuthenticationEntryPointTest extends Unit
         $this->assertFalse($response->headers->has('WWW-Authenticate'));
     }
 
+    /**
+     * Behind a proxy the request host is not the issuer, and the resource is registered
+     * under the issuer. Pointing the client at the request host would send it to a
+     * metadata document that resolves to nothing, so discovery would never start.
+     */
+    public function testChallengeUsesTheIssuerRatherThanTheRequestHost(): void
+    {
+        $entryPoint = new McpAuthenticationEntryPoint(true, 'https://pimcore.example.com');
+
+        $response = $entryPoint->start(Request::create('http://internal.local/pimcore-mcp/message'));
+
+        $this->assertSame(
+            'Bearer resource_metadata='
+            . '"https://pimcore.example.com/.well-known/oauth-protected-resource/pimcore-mcp/message",'
+            . ' scope="mcp:read"',
+            $response->headers->get('WWW-Authenticate'),
+        );
+    }
+
     private function mcpRequest(): Request
     {
         return Request::create('https://pimcore.example.com/pimcore-mcp/message');

--- a/tests/Unit/Security/EntryPoint/McpAuthenticationEntryPointTest.php
+++ b/tests/Unit/Security/EntryPoint/McpAuthenticationEntryPointTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StudioBackendBundle\Tests\Unit\Security\EntryPoint;
 
 use Codeception\Test\Unit;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Dto\ProtectedResource;
+use Pimcore\Bundle\StudioBackendBundle\OAuth\Resolver\RequestResourceResolverInterface;
 use Pimcore\Bundle\StudioBackendBundle\Security\EntryPoint\McpAuthenticationEntryPoint;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,11 +24,11 @@ final class McpAuthenticationEntryPointTest extends Unit
 {
     public function testEnabledEmitsChallengeWithResourceMetadata(): void
     {
-        $response = (new McpAuthenticationEntryPoint(true))->start($this->mcpRequest());
+        // Nothing registered covers the endpoint, so the challenge falls back to the
+        // request path (the resource for the endpoint that was actually requested).
+        $response = $this->entryPoint(true)->start($this->mcpRequest());
 
         $this->assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
-        // The metadata URL is derived from the request path, so it points at the
-        // protected resource for the endpoint that was actually requested.
         $this->assertSame(
             'Bearer resource_metadata='
             . '"https://pimcore.example.com/.well-known/oauth-protected-resource/pimcore-mcp/message",'
@@ -37,7 +39,7 @@ final class McpAuthenticationEntryPointTest extends Unit
 
     public function testDisabledReturnsPlain401WithoutChallenge(): void
     {
-        $response = (new McpAuthenticationEntryPoint(false))->start($this->mcpRequest());
+        $response = $this->entryPoint(false)->start($this->mcpRequest());
 
         $this->assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
         $this->assertFalse($response->headers->has('WWW-Authenticate'));
@@ -50,7 +52,7 @@ final class McpAuthenticationEntryPointTest extends Unit
      */
     public function testChallengeUsesTheIssuerRatherThanTheRequestHost(): void
     {
-        $entryPoint = new McpAuthenticationEntryPoint(true, 'https://pimcore.example.com');
+        $entryPoint = $this->entryPoint(true, null, 'https://pimcore.example.com');
 
         $response = $entryPoint->start(Request::create('http://internal.local/pimcore-mcp/message'));
 
@@ -60,6 +62,34 @@ final class McpAuthenticationEntryPointTest extends Unit
             . ' scope="mcp:read"',
             $response->headers->get('WWW-Authenticate'),
         );
+    }
+
+    /**
+     * When a broader resource covers the endpoint, the authenticator validates the token
+     * against that resource, so the challenge must advertise the matched resource's
+     * metadata — not the request path, which the metadata controller's exact lookup would
+     * answer with a 404.
+     */
+    public function testChallengePointsAtTheMatchedResourceNotTheRequestPath(): void
+    {
+        $matched = new ProtectedResource('https://pimcore.example.com/pimcore-mcp', [], []);
+
+        $response = $this->entryPoint(true, $matched, 'https://pimcore.example.com')
+            ->start(Request::create('https://pimcore.example.com/pimcore-mcp/agent/content'));
+
+        $this->assertSame(
+            'Bearer resource_metadata='
+            . '"https://pimcore.example.com/.well-known/oauth-protected-resource/pimcore-mcp",'
+            . ' scope="mcp:read"',
+            $response->headers->get('WWW-Authenticate'),
+        );
+    }
+
+    private function entryPoint(bool $enabled, ?ProtectedResource $match = null, ?string $issuer = null): McpAuthenticationEntryPoint
+    {
+        $resolver = $this->makeEmpty(RequestResourceResolverInterface::class, ['resolve' => $match]);
+
+        return new McpAuthenticationEntryPoint($enabled, $resolver, $issuer);
     }
 
     private function mcpRequest(): Request

--- a/tests/Unit/Security/EntryPoint/McpAuthenticationEntryPointTest.php
+++ b/tests/Unit/Security/EntryPoint/McpAuthenticationEntryPointTest.php
@@ -85,6 +85,26 @@ final class McpAuthenticationEntryPointTest extends Unit
         );
     }
 
+    /**
+     * An origin-only resource covers the request but has no path, so the challenge must
+     * point at the resource's own metadata document (empty suffix) rather than falling
+     * back to the request path, which the controller's exact lookup could not resolve.
+     */
+    public function testChallengePointsAtAMatchedRootResource(): void
+    {
+        $matched = new ProtectedResource('https://pimcore.example.com', [], []);
+
+        $response = $this->entryPoint(true, $matched, 'https://pimcore.example.com')
+            ->start(Request::create('https://pimcore.example.com/pimcore-mcp/message'));
+
+        $this->assertSame(
+            'Bearer resource_metadata='
+            . '"https://pimcore.example.com/.well-known/oauth-protected-resource",'
+            . ' scope="mcp:read"',
+            $response->headers->get('WWW-Authenticate'),
+        );
+    }
+
     private function entryPoint(bool $enabled, ?ProtectedResource $match = null, ?string $issuer = null): McpAuthenticationEntryPoint
     {
         $resolver = $this->makeEmpty(RequestResourceResolverInterface::class, ['resolve' => $match]);


### PR DESCRIPTION
Second half of the split out of #2022, which is closed in favour of this and #2028. This one carries the MCP
side: how an endpoint behind the `pimcore_mcp` firewall gets the audience its token is checked against.

## The problem

`OAuthAccessTokenAuthenticator` derived the resource URI from a path hardcoded in this bundle
(`<host>/pimcore-mcp`). That is wrong in three ways:

- **It is a prefix, not an endpoint.** Nothing serves `/pimcore-mcp` itself, and no protected resource is
  registered for it, so with the audience enforced (#2028) an audience-bound token could never match.
- **It uses the request host rather than the issuer.** Resources are registered under the issuer, so behind any
  proxy the two differ and a correctly issued token is refused at the endpoint it was issued for.
- **It only ever describes this bundle's own servers.** The endpoints behind that firewall belong to other
  bundles too, and `/pimcore-mcp/agent/{group}` from the Agent bundle could never match a hardcoded Studio path.

The earlier attempt in #2022 fixed the first two by hardcoding `/pimcore-mcp/studio/<slug>` instead, which
still leaves any other bundle's endpoint unreachable.

## What this does

Resolves the audience from **whoever owns the endpoint**. A new `RequestResourceResolver` finds the most
specific registered protected resource covering the request, and the authenticator validates against that.
This bundle needs no per-consumer path knowledge: a bundle that registers its endpoint as a protected resource
works, which is the same contract Data Hub Simple REST already follows.

Matching is origin equality plus a path prefix that only matches on a segment boundary, the same rule a
standards-based client applies when deciding whether a resource covers an endpoint, so the server's check
agrees with what the client was told is allowed. Longest match wins, so a resource registered for one server
takes precedence over a broader one. The URI is built from the configured issuer when set.

When no registered resource covers the request the authenticator declines rather than guessing. Declining
leaves the rest of the chain intact, so PAT and session authentication are unaffected on endpoints that have
not opted in.

## Compatibility

Nothing changes for a credential that is not a JWT-shaped bearer: `supports()` still declines the `pmcp_`
prefix, opaque PATs and session-bridge requests, so they never reach this code. An endpoint whose owner
registers no protected resource keeps working exactly as before on its other credentials, and simply does not
accept OAuth until it registers one. Registration is the switch.

## Verified

Unit suite green (898 tests), PHPStan clean. `RequestResourceResolverTest` covers the Studio server case, an
endpoint owned by another bundle, an unregistered endpoint, segment-boundary matching, longest-match
precedence, and issuer-versus-host derivation.

## Follow-up

The Agent bundle registers no protected resource, so OAuth on `/pimcore-mcp/agent/*` stays unavailable until
it does. That is a separate change in that repository, and this PR does not regress it: OAuth was never usable
there.

Once #2028 merges, the remaining MCP residue from #2022 lands on top of this: swapping the scope provider's
literals for `McpScopes::READ`/`WRITE`, and the `09_MCP_Server_Management.md` documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
