### PR TITLE
[MCP] Accept can_read in a file-defined access grant

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -858,8 +858,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * A list of access grants keyed by unique name — the file-config equivalent
-     * of the settings-store {name, can_access, can_edit} grid. A bare string is
-     * accepted as a view-only grant (name only), matching {@see McpServerAccessEntry::fromMixed()}.
+     * of the settings-store {name, can_read, can_access, can_edit} grid. A bare string is
+     * accepted as a read-only grant (name only), matching {@see McpServerAccessEntry::fromMixed()}.
      */
     private function mcpAccessGrantListNode(string $name, string $info): ArrayNodeDefinition
     {
@@ -873,6 +873,9 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->children()
                     ->scalarNode('name')->isRequired()->cannotBeEmpty()->end()
+                    // Defaults to true, matching McpServerAccessEntry::fromMixed(): a grant
+                    // that names someone without saying more lets them see the server.
+                    ->booleanNode('can_read')->defaultTrue()->end()
                     ->booleanNode('can_access')->defaultFalse()->end()
                     ->booleanNode('can_edit')->defaultFalse()->end()
                 ->end()

--- a/tests/Unit/DependencyInjection/McpServersConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/McpServersConfigurationTest.php
@@ -64,7 +64,7 @@ final class McpServersConfigurationTest extends Unit
                     'owner' => 'john.doe',
                     'share_global' => true,
                     'shared_users' => [
-                        ['name' => 'alice', 'can_access' => true, 'can_edit' => false],
+                        ['name' => 'alice', 'can_read' => true, 'can_access' => true, 'can_edit' => false],
                         'bob',
                     ],
                     'shared_roles' => [
@@ -80,12 +80,14 @@ final class McpServersConfigurationTest extends Unit
         $this->assertTrue($access['share_global']);
         // assertEquals, not assertSame: Symfony appends defaulted keys after the
         // provided ones, so the associative key order is not fixed (list order is).
+        // A grant that only names someone still lets them see the server, which is why
+        // `can_read` defaults to true rather than false like the other two.
         $this->assertEquals([
-            ['name' => 'alice', 'can_access' => true, 'can_edit' => false],
-            ['name' => 'bob', 'can_access' => false, 'can_edit' => false],
+            ['name' => 'alice', 'can_read' => true, 'can_access' => true, 'can_edit' => false],
+            ['name' => 'bob', 'can_read' => true, 'can_access' => false, 'can_edit' => false],
         ], $access['shared_users']);
         $this->assertEquals([
-            ['name' => 'editors', 'can_access' => false, 'can_edit' => true],
+            ['name' => 'editors', 'can_read' => true, 'can_access' => false, 'can_edit' => true],
         ], $access['shared_roles']);
     }
 


### PR DESCRIPTION
A file-defined MCP server cannot express `can_read`, so defining one in YAML fails:

```
Unrecognized option "can_read" under
"pimcore_studio_backend.studio_mcp_servers.foo3.access.shared_users.0".
Available options are "can_access", "can_edit", "name".
```

`0bf234f7` introduced the capability across the DTOs, hydrator, schema and access resolver, but not in the
configuration tree. `McpServerAccessEntry::fromMixed()` reads `can_read` and `toArray()` emits it, so the
settings-store form round-trips a grant the YAML equivalent then rejects. The two config locations disagree
about the same grant shape.

## What this changes

Adds `can_read` to `mcpAccessGrantListNode()`, defaulting to **true** rather than false like the other two.
That matches `McpServerAccessEntry::fromMixed()`, where the flag defaults to true and a bare string name is a
read-only grant: naming someone without saying more lets them see the server. Defaulting it to false would
silently strip visibility from every existing file-defined grant.

The stale docblock describing the grid as `{name, can_access, can_edit}` is corrected too.

## Verified

Unit suite green (889 tests), PHPStan clean. The existing `testSharedUsersAndRolesAcceptTheCapabilityGrid`
encoded the old two-capability shape and is updated to the three-capability one, including the defaulting
behaviour for a grant that names someone and nothing else.

Checked against a running instance: a YAML-defined server with `can_read` on its grants now validates, and
`debug:config` shows all three capabilities normalised per grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
