### PR TITLE
[Bug] Fixes pimcore/platform-version#467: Key the element reference cache by type as well as id

### DIFF
--- a/src/Resolver/Element/ReferenceResolver.php
+++ b/src/Resolver/Element/ReferenceResolver.php
@@ -30,7 +30,7 @@ final class ReferenceResolver implements ReferenceResolverInterface
     ];
 
     /**
-     * @var array<int, array>
+     * @var array<string, array>
      */
     private array $cache = [];
 
@@ -40,8 +40,9 @@ final class ReferenceResolver implements ReferenceResolverInterface
 
     public function resolve(ElementInterface $element): array
     {
-        if (isset($this->cache[$element->getId()])) {
-            return $this->cache[$element->getId()];
+        $cacheKey = $element::class . '_' . $element->getId();
+        if (isset($this->cache[$cacheKey])) {
+            return $this->cache[$cacheKey];
         }
 
         /**
@@ -54,7 +55,7 @@ final class ReferenceResolver implements ReferenceResolverInterface
 
         $data['fullPath'] = $element->getFullPath();
 
-        $this->cache[$element->getId()] = $data;
+        $this->cache[$cacheKey] = $data;
 
         return $data;
     }


### PR DESCRIPTION
Fixes pimcore/platform-version#467

ReferenceResolver caches resolved references by id alone. Documents, assets and data objects have independent id sequences, so a document and an asset can share one id; whichever is resolved first fills the cache and every later element with that id gets its payload back, whatever type it is.

On an element carrying both an asset property and a document property whose targets share an id, GET /properties/{elementType}/{id} therefore returns the same reference for both, and the wrong reference is written back when the properties are saved. PropertyHydrator and MetadataHydrator both resolve through this service.

The lookup itself is correct - Property::getData() goes through Element\Service::getElementById() with the type - so only the cache key has to carry the type.

**Expected Behavior**
Each property resolves against its own element type.

*Actual Behavior*
Both properties return the SAME element, the one resolved first.
In the UI the wrong reference is displayed.

The stored data is correct throughout, the Properties table keeps
type=document/data=4 and the frontend resolves it correctly. 
Only Studio's representation in Properties table is wrong, and saving from that state writes the wrong value back.

**Steps to reproduce**
1. Find a numeric id that exists as both a document (in my case a snippet) and an asset (a folder in my case).
On a fresh install this is common - e.g. document 4 and asset 4 both exist.
2. On any element (here: the root document, id 1) add two properties:
propAsset - type Asset -> the asset with id 4
propDoc - type Document -> the document with id 4
Note that "propAsset" sorts before "propDoc".
3. Save.
4. Open the element's Properties tab